### PR TITLE
perf: refactor database access to use cached values for improved performance

### DIFF
--- a/hms_tz/hms_tz/doctype/clinical_procedure_template/clinical_procedure_template.py
+++ b/hms_tz/hms_tz/doctype/clinical_procedure_template/clinical_procedure_template.py
@@ -107,7 +107,7 @@ def create_item_from_template(doc):
 
 
 def make_item_price(item, item_price):
-    price_list_name = frappe.db.get_value("Price List", {"selling": 1})
+    price_list_name = frappe.get_cached_value("Price List", {"selling": 1})
     frappe.get_doc(
         {
             "doctype": "Item Price",

--- a/hms_tz/hms_tz/doctype/healthcare_insurance_company/healthcare_insurance_company.py
+++ b/hms_tz/hms_tz/doctype/healthcare_insurance_company/healthcare_insurance_company.py
@@ -34,7 +34,7 @@ def create_customer(doc):
             .insert()
             .name
         )
-    territory = frappe.get_value("Selling Settings", None, "territory")
+    territory = frappe.get_cached_value("Selling Settings", None, "territory")
     if not (territory):
         territory = "Rest Of The World"
         frappe.msgprint(

--- a/hms_tz/hms_tz/doctype/healthcare_practitioner/healthcare_practitioner.py
+++ b/hms_tz/hms_tz/doctype/healthcare_practitioner/healthcare_practitioner.py
@@ -43,7 +43,7 @@ class HealthcarePractitioner(Document):
         if self.user_id:
             self.validate_user_id()
         else:
-            existing_user_id = frappe.db.get_value(
+            existing_user_id = frappe.get_cached_value(
                 "Healthcare Practitioner", self.name, "user_id"
             )
             if existing_user_id:
@@ -84,7 +84,7 @@ class HealthcarePractitioner(Document):
 
 
 def validate_service_item(item, msg):
-    if frappe.db.get_value("Item", item, "is_stock_item"):
+    if frappe.get_cached_value("Item", item, "is_stock_item"):
         frappe.throw(_(msg))
 
 

--- a/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.py
+++ b/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.py
@@ -56,7 +56,7 @@ class HealthcareReferral(Document):
 		if not self.encounter:
 			return
 		
-		clinical_notes = frappe.db.get_value("Patient Encounter", self.encounter, "examination_detail")
+		clinical_notes = frappe.get_cached_value("Patient Encounter", self.encounter, "examination_detail")
 		self.reason_for_referral = clinical_notes.replace('"', " ")
 
 

--- a/hms_tz/hms_tz/doctype/healthcare_service_unit_type/healthcare_service_unit_type.py
+++ b/hms_tz/hms_tz/doctype/healthcare_service_unit_type/healthcare_service_unit_type.py
@@ -55,7 +55,7 @@ class HealthcareServiceUnitType(Document):
             item_price = item_price_exists(self)
 
             if not item_price:
-                price_list_name = frappe.db.get_value("Price List", {"selling": 1})
+                price_list_name = frappe.get_cached_value("Price List", {"selling": 1})
                 if self.rate:
                     make_item_price(self.item_code, price_list_name, self.rate)
                 else:
@@ -100,7 +100,7 @@ def create_item(doc):
 
     # insert item price
     # get item price list to insert item price
-    price_list_name = frappe.db.get_value("Price List", {"selling": 1})
+    price_list_name = frappe.get_cached_value("Price List", {"selling": 1})
     if doc.rate:
         make_item_price(item.name, price_list_name, doc.rate)
         item.standard_rate = doc.rate

--- a/hms_tz/hms_tz/doctype/healthcare_service_unit_type/test_healthcare_service_unit_type.py
+++ b/hms_tz/hms_tz/doctype/healthcare_service_unit_type/test_healthcare_service_unit_type.py
@@ -14,7 +14,7 @@ class TestHealthcareServiceUnitType(unittest.TestCase):
         # check item disabled
         unit_type.disabled = 1
         unit_type.save()
-        self.assertEqual(frappe.db.get_value("Item", unit_type.item, "disabled"), 1)
+        self.assertEqual(frappe.get_cached_value("Item", unit_type.item, "disabled"), 1)
 
 
 def get_unit_type():

--- a/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.py
+++ b/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.py
@@ -187,7 +187,7 @@ def schedule_inpatient(args):
 @frappe.whitelist()
 def schedule_discharge(args):
     discharge_order = json.loads(args)
-    inpatient_record_id = frappe.db.get_value(
+    inpatient_record_id = frappe.get_cached_value(
         "Patient", discharge_order["patient"], "inpatient_record"
     )
     if inpatient_record_id:
@@ -249,7 +249,7 @@ def validate_invoiced_inpatient(inpatient_record):
     if inpatient_record.insurance_subscription:
         return
     if (
-        frappe.db.get_value(
+        frappe.get_cached_value(
             "Company",
             inpatient_record.company,
             "allow_discharge_patient_with_pending_unbilled_invoices",

--- a/hms_tz/hms_tz/doctype/inpatient_record/test_inpatient_record.py
+++ b/hms_tz/hms_tz/doctype/inpatient_record/test_inpatient_record.py
@@ -23,22 +23,22 @@ class TestInpatientRecord(unittest.TestCase):
         ip_record.expected_length_of_stay = 0
         ip_record.save(ignore_permissions=True)
         self.assertEqual(
-            ip_record.name, frappe.db.get_value("Patient", patient, "inpatient_record")
+            ip_record.name, frappe.get_cached_value("Patient", patient, "inpatient_record")
         )
         self.assertEqual(
             ip_record.status,
-            frappe.db.get_value("Patient", patient, "inpatient_status"),
+            frappe.get_cached_value("Patient", patient, "inpatient_status"),
         )
 
         # Admit
         service_unit = get_healthcare_service_unit()
         admit_patient(ip_record, service_unit, now_datetime())
         self.assertEqual(
-            "Admitted", frappe.db.get_value("Patient", patient, "inpatient_status")
+            "Admitted", frappe.get_cached_value("Patient", patient, "inpatient_status")
         )
         self.assertEqual(
             "Occupied",
-            frappe.db.get_value(
+            frappe.get_cached_value(
                 "Healthcare Service Unit", service_unit, "occupancy_status"
             ),
         )
@@ -47,7 +47,7 @@ class TestInpatientRecord(unittest.TestCase):
         schedule_discharge(frappe.as_json({"patient": patient}))
         self.assertEqual(
             "Vacant",
-            frappe.db.get_value(
+            frappe.get_cached_value(
                 "Healthcare Service Unit", service_unit, "occupancy_status"
             ),
         )
@@ -60,10 +60,10 @@ class TestInpatientRecord(unittest.TestCase):
         discharge_patient(ip_record1)
 
         self.assertEqual(
-            None, frappe.db.get_value("Patient", patient, "inpatient_record")
+            None, frappe.get_cached_value("Patient", patient, "inpatient_record")
         )
         self.assertEqual(
-            None, frappe.db.get_value("Patient", patient, "inpatient_status")
+            None, frappe.get_cached_value("Patient", patient, "inpatient_status")
         )
 
     def test_validate_overlap_admission(self):

--- a/hms_tz/hms_tz/doctype/lab_test/lab_test.py
+++ b/hms_tz/hms_tz/doctype/lab_test/lab_test.py
@@ -43,7 +43,7 @@ class LabTest(Document):
             frappe.db.set_value(
                 "Lab Prescription", self.prescription, "lab_test", self.name
             )
-            if frappe.db.get_value("Lab Prescription", self.prescription, "invoiced"):
+            if frappe.get_cached_value("Lab Prescription", self.prescription, "invoiced"):
                 self.invoiced = True
         if not self.lab_test_name and self.template:
             self.load_test_from_template()
@@ -177,7 +177,7 @@ def create_lab_test_from_invoice(sales_invoice):
         for item in invoice.items:
             lab_test_created = 0
             if item.reference_dt == "Lab Prescription":
-                lab_test_created = frappe.db.get_value(
+                lab_test_created = frappe.get_cached_value(
                     "Lab Prescription", item.reference_dn, "lab_test_created"
                 )
             elif item.reference_dt == "Lab Test":

--- a/hms_tz/hms_tz/doctype/lab_test/test_lab_test.py
+++ b/hms_tz/hms_tz/doctype/lab_test/test_lab_test.py
@@ -23,7 +23,7 @@ class TestLabTest(unittest.TestCase):
         lab_template = create_lab_test_template()
         self.assertTrue(frappe.db.exists("Item", lab_template.item))
         self.assertEqual(
-            frappe.db.get_value(
+            frappe.get_cached_value(
                 "Item Price", {"item_code": lab_template.item}, "price_list_rate"
             ),
             lab_template.lab_test_rate,
@@ -31,7 +31,7 @@ class TestLabTest(unittest.TestCase):
 
         lab_template.disabled = 1
         lab_template.save()
-        self.assertEquals(frappe.db.get_value("Item", lab_template.item, "disabled"), 1)
+        self.assertEquals(frappe.get_cached_value("Item", lab_template.item, "disabled"), 1)
 
         lab_template.reload()
 
@@ -175,7 +175,7 @@ def create_sales_invoice():
 
     sales_invoice = frappe.new_doc("Sales Invoice")
     sales_invoice.patient = patient
-    sales_invoice.customer = frappe.db.get_value("Patient", patient, "customer")
+    sales_invoice.customer = frappe.get_cached_value("Patient", patient, "customer")
     sales_invoice.due_date = getdate()
     sales_invoice.company = "_Test Company"
     sales_invoice.debit_to = get_receivable_account("_Test Company")

--- a/hms_tz/hms_tz/doctype/lab_test_template/lab_test_template.py
+++ b/hms_tz/hms_tz/doctype/lab_test_template/lab_test_template.py
@@ -33,7 +33,7 @@ class LabTestTemplate(Document):
             item_price = self.item_price_exists()
             if not item_price:
                 if self.lab_test_rate and self.lab_test_rate > 0.0:
-                    price_list_name = frappe.db.get_value("Price List", {"selling": 1})
+                    price_list_name = frappe.get_cached_value("Price List", {"selling": 1})
                     make_item_price(
                         self.lab_test_code, price_list_name, self.lab_test_rate
                     )
@@ -140,7 +140,7 @@ def create_item_from_template(doc):
 
     # Insert item price
     if doc.is_billable and doc.lab_test_rate != 0.0:
-        price_list_name = frappe.db.get_value("Price List", {"selling": 1})
+        price_list_name = frappe.get_cached_value("Price List", {"selling": 1})
         if doc.lab_test_rate:
             make_item_price(item.name, price_list_name, doc.lab_test_rate)
         else:

--- a/hms_tz/hms_tz/doctype/limit_change_request/limit_change_request.py
+++ b/hms_tz/hms_tz/doctype/limit_change_request/limit_change_request.py
@@ -34,7 +34,7 @@ class LimitChangeRequest(Document):
 
     def validate_appointment_info(self):
         if self.appointment_no:
-            if "NHIF" in frappe.get_value(
+            if "NHIF" in frappe.get_cached_value(
                 "Patient Appointment", self.appointment_no, "insurance_company"
             ):
                 url = get_url_to_form("Patient Appointment", self.appointment_no)
@@ -43,7 +43,7 @@ class LimitChangeRequest(Document):
                 )
 
     def validate_draft_duplicate(self):
-        exists_lcr = frappe.get_value(
+        exists_lcr = frappe.get_cached_value(
             "Limit Change Request",
             {
                 "name": ["!=", self.name],
@@ -126,7 +126,7 @@ class LimitChangeRequest(Document):
 
     def on_cancel(self):
         if self.is_cash_inpatient and self.inpatient_record:
-            old_cash_limit = frappe.get_value(
+            old_cash_limit = frappe.get_cached_value(
                 "Patient", {"name": self.patient}, "cash_limit"
             )
             frappe.db.set_value(
@@ -134,17 +134,17 @@ class LimitChangeRequest(Document):
             )
 
         if self.is_non_nhif_patient and self.appointment_no:
-            insurance_subscription = frappe.get_value(
+            insurance_subscription = frappe.get_cached_value(
                 "Patient Appointment",
                 {"name": self.appointment_no},
                 "insurance_subscription",
             )
-            coverage_plan = frappe.get_value(
+            coverage_plan = frappe.get_cached_value(
                 "Healthcare Insurance Subscription",
                 insurance_subscription,
                 "healthcare_insurance_coverage_plan",
             )
-            old_daily_limit = frappe.get_value(
+            old_daily_limit = frappe.get_cached_value(
                 "Healthcare Insurance Coverage Plan", coverage_plan, "daily_limit"
             )
             frappe.db.set_value(
@@ -176,7 +176,7 @@ class LimitChangeRequest(Document):
             if encounters[0]["mode_of_payment"] and encounters[0]["inpatient_record"]:
                 self.inpatient_record = encounters[0]["inpatient_record"]
                 self.is_cash_inpatient = 1
-                self.previous_cash_limit = frappe.get_value(
+                self.previous_cash_limit = frappe.get_cached_value(
                     "Inpatient Record", self.inpatient_record, "cash_limit"
                 )
                 self.current_total_deposit = -1 * (

--- a/hms_tz/hms_tz/doctype/lrpmt_returns/lrpmt_returns.py
+++ b/hms_tz/hms_tz/doctype/lrpmt_returns/lrpmt_returns.py
@@ -764,7 +764,7 @@ def get_refdoc(doctype, childname, template, encounter):
 
     for refd in ref_docs:
         if refd.get("table") == doctype:
-            docname = frappe.get_value(
+            docname = frappe.get_cached_value(
                 refd.get("ref_d"),
                 {
                     "ref_doctype": "Patient Encounter",
@@ -1090,13 +1090,13 @@ def get_therapies(patient, appointment, company):
 
     for item in therapy_items:
         if item.therapy_type:
-            therapy_plan = frappe.get_value(
+            therapy_plan = frappe.get_cached_value(
                 "Therapy Plan",
                 {"ref_doctype": "Patient Encounter", "ref_docname": item.parent},
                 "name",
             )
 
-            plan_child_table_id = frappe.db.get_value(
+            plan_child_table_id = frappe.get_cached_value(
                 "Therapy Plan Detail",
                 {
                     "parent": therapy_plan,

--- a/hms_tz/hms_tz/doctype/medication/medication.py
+++ b/hms_tz/hms_tz/doctype/medication/medication.py
@@ -81,7 +81,7 @@ def create_item_from_medication(doc):
 
 
 def make_item_price(item, item_price):
-    price_list_name = frappe.db.get_value("Price List", {"selling": 1})
+    price_list_name = frappe.get_cached_value("Price List", {"selling": 1})
     frappe.get_doc(
         {
             "doctype": "Item Price",

--- a/hms_tz/hms_tz/doctype/patient/patient.py
+++ b/hms_tz/hms_tz/doctype/patient/patient.py
@@ -132,7 +132,7 @@ class Patient(Document):
     def get_patient_name(self):
         self.set_full_name()
         name = self.patient_name
-        if frappe.db.get_value("Patient", name):
+        if frappe.get_cached_value("Patient", name):
             count = frappe.db.sql(
                 f"""select ifnull(MAX(CAST(SUBSTRING_INDEX(name, ' ', -1) AS UNSIGNED)), 0) from tabPatient
 				 where name like %s""",
@@ -223,7 +223,7 @@ def make_invoice(patient, company):
         "Stock Settings", "stock_uom"
     )
     sales_invoice = frappe.new_doc("Sales Invoice")
-    sales_invoice.customer = frappe.db.get_value("Patient", patient, "customer")
+    sales_invoice.customer = frappe.get_cached_value("Patient", patient, "customer")
     sales_invoice.due_date = getdate()
     sales_invoice.company = company
     sales_invoice.is_pos = 0
@@ -272,7 +272,7 @@ def get_patient_billing_info(patient, ip_billing_info=False):
     company = False
     if ip_billing_info and patient.inpatient_record:
         filters["inpatient_record"] = patient.inpatient_record
-        company = frappe.db.get_value(
+        company = frappe.get_cached_value(
             "Inpatient Record", patient.inpatient_record, "company"
         )
 
@@ -296,7 +296,7 @@ def get_patient_billing_info(patient, ip_billing_info=False):
     if not company:
         company = frappe.db.get_single_value("Global Defaults", "default_company")
 
-    company_default_currency = frappe.db.get_value(
+    company_default_currency = frappe.get_cached_value(
         "Company", company, "default_currency"
     )
     from erpnext.accounts.party import get_party_account_currency
@@ -384,7 +384,7 @@ def make_contact(doc):
 
     except frappe.exceptions.DuplicateEntryError:
         if doc.doctype == "Patient":
-            contact_name = frappe.db.get_value("Contact", {"first_name": doc.name})
+            contact_name = frappe.get_cached_value("Contact", {"first_name": doc.name})
             if not contact_name:
                 return
 

--- a/hms_tz/hms_tz/doctype/patient/test_patient.py
+++ b/hms_tz/hms_tz/doctype/patient/test_patient.py
@@ -15,7 +15,7 @@ class TestPatient(unittest.TestCase):
         frappe.db.sql("""delete from `tabPatient`""")
         frappe.db.set_value("Healthcare Settings", None, "link_customer_to_patient", 1)
         patient = create_patient()
-        self.assertTrue(frappe.db.get_value("Patient", patient, "customer"))
+        self.assertTrue(frappe.get_cached_value("Patient", patient, "customer"))
 
     def test_patient_registration(self):
         frappe.db.sql("""delete from `tabPatient`""")

--- a/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.py
+++ b/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.py
@@ -99,18 +99,18 @@ class PatientAppointment(Document):
                     "service_unit": self.service_unit,
                 },
             )
-            allow_overlap = frappe.get_value(
+            allow_overlap = frappe.get_cached_value(
                 "Healthcare Service Unit", self.service_unit, "overlap_appointments"
             )
             if allow_overlap:
                 if self.practitioner_availability:
-                    service_unit_capacity = frappe.get_value(
+                    service_unit_capacity = frappe.get_cached_value(
                         "Practitioner Availability",
                         self.practitioner_availability,
                         "total_service_unit_capacity",
                     )
                 else:
-                    service_unit_capacity = frappe.get_value(
+                    service_unit_capacity = frappe.get_cached_value(
                         "Healthcare Service Unit",
                         self.service_unit,
                         "total_service_unit_capacity",
@@ -150,7 +150,7 @@ class PatientAppointment(Document):
             )
 
         if self.service_unit:
-            service_unit_company = frappe.db.get_value(
+            service_unit_company = frappe.get_cached_value(
                 "Healthcare Service Unit", self.service_unit, "company"
             )
             if service_unit_company and service_unit_company != self.company:
@@ -166,7 +166,7 @@ class PatientAppointment(Document):
         if frappe.db.get_single_value(
             "Healthcare Settings", "automate_appointment_invoicing"
         ):
-            if not frappe.db.get_value("Patient", self.patient, "customer"):
+            if not frappe.get_cached_value("Patient", self.patient, "customer"):
                 msg = _("Please set a Customer linked to the Patient")
                 msg += f" <b><a href='#Form/Patient/{self.patient}'>{self.patient}</a></b>"
                 frappe.throw(msg, title=_("Customer Not Found"))
@@ -180,7 +180,7 @@ class PatientAppointment(Document):
                 1,
             )
             if self.procedure_template:
-                comments = frappe.db.get_value(
+                comments = frappe.get_cached_value(
                     "Procedure Prescription", self.procedure_prescription, "comments"
                 )
                 if comments:
@@ -228,7 +228,7 @@ def invoice_appointment(appointment_doc):
     automate_invoicing = frappe.db.get_single_value(
         "Healthcare Settings", "automate_appointment_invoicing"
     )
-    appointment_invoiced = frappe.db.get_value(
+    appointment_invoiced = frappe.get_cached_value(
         "Patient Appointment", appointment_doc.name, "invoiced"
     )
     enable_free_follow_ups = frappe.db.get_single_value(
@@ -251,7 +251,7 @@ def invoice_appointment(appointment_doc):
     if automate_invoicing and not appointment_invoiced and not fee_validity:
         sales_invoice = frappe.new_doc("Sales Invoice")
         sales_invoice.patient = appointment_doc.patient
-        sales_invoice.customer = frappe.get_value(
+        sales_invoice.customer = frappe.get_cached_value(
             "Patient", appointment_doc.patient, "customer"
         )
         sales_invoice.appointment = appointment_doc.name
@@ -348,7 +348,7 @@ def cancel_sales_invoice(sales_invoice):
 
 
 def check_sales_invoice_exists(appointment):
-    sales_invoice = frappe.db.get_value(
+    sales_invoice = frappe.db.get_cached_value(
         "Sales Invoice Item",
         {"reference_dt": "Patient Appointment", "reference_dn": appointment.name},
         "parent",
@@ -403,7 +403,7 @@ def check_employee_wise_availability(date, practitioner_doc):
     if practitioner_doc.employee:
         employee = practitioner_doc.employee
     elif practitioner_doc.user_id:
-        employee = frappe.db.get_value(
+        employee = frappe.get_cached_value(
             "Employee", {"user_id": practitioner_doc.user_id}, "name"
         )
 
@@ -527,7 +527,7 @@ def get_available_slots(practitioner_doc, date):
                     slot_name = (
                         schedule_entry.schedule + " - " + schedule_entry.service_unit
                     )
-                    allow_overlap, service_unit_capacity = frappe.get_value(
+                    allow_overlap, service_unit_capacity = frappe.get_cached_value(
                         "Healthcare Service Unit",
                         schedule_entry.service_unit,
                         ["overlap_appointments", "total_service_unit_capacity"],
@@ -603,7 +603,7 @@ def get_present_event_slots(present_events, date, practitioner):
 
                 if present_event.service_unit:
                     slot_name = slot_name + " - " + present_event.service_unit
-                    allow_overlap, service_unit_capacity = frappe.get_value(
+                    allow_overlap, service_unit_capacity = frappe.get_cached_value(
                         "Healthcare Service Unit",
                         present_event.service_unit,
                         ["overlap_appointments", "total_service_unit_capacity"],
@@ -689,7 +689,7 @@ def update_status(appointment_id, status):
         appointment_booked = False
         cancel_appointment(appointment_id)
 
-    procedure_prescription = frappe.db.get_value(
+    procedure_prescription = frappe.get_cached_value(
         "Patient Appointment", appointment_id, "procedure_prescription"
     )
     if procedure_prescription:
@@ -777,7 +777,7 @@ def send_appointment_reminder():
 
 
 def send_message(doc, message):
-    patient_mobile = frappe.db.get_value("Patient", doc.patient, "mobile")
+    patient_mobile = frappe.get_cached_value("Patient", doc.patient, "mobile")
     if patient_mobile:
         context = {"doc": doc, "alert": doc, "comments": None}
         if doc.get("_comments"):
@@ -836,7 +836,7 @@ def get_events(start, end, filters=None):
             item.title = item.title + " - " + item.patient_age
         item.title = item.title + ")"
         if item.triage:
-            color = frappe.db.get_value("Triage", item.triage, "color")
+            color = frappe.get_cached_value("Triage", item.triage, "color")
             if color:
                 item.color = color
     return data

--- a/hms_tz/hms_tz/doctype/patient_appointment/test_patient_appointment.py
+++ b/hms_tz/hms_tz/doctype/patient_appointment/test_patient_appointment.py
@@ -32,7 +32,7 @@ class TestPatientAppointment(unittest.TestCase):
         self.assertEquals(appointment.status, "Scheduled")
         create_encounter(appointment)
         self.assertEquals(
-            frappe.db.get_value("Patient Appointment", appointment.name, "status"),
+            frappe.get_cached_value("Patient Appointment", appointment.name, "status"),
             "Closed",
         )
 
@@ -45,7 +45,7 @@ class TestPatientAppointment(unittest.TestCase):
             patient, practitioner, add_days(nowdate(), 4), invoice=1
         )
         self.assertEqual(
-            frappe.db.get_value("Patient Appointment", appointment.name, "invoiced"), 1
+            frappe.get_cached_value("Patient Appointment", appointment.name, "invoiced"), 1
         )
         encounter = make_encounter(appointment.name)
         self.assertTrue(encounter)
@@ -55,7 +55,7 @@ class TestPatientAppointment(unittest.TestCase):
         # invoiced flag mapped from appointment
         self.assertEqual(
             encounter.invoiced,
-            frappe.db.get_value("Patient Appointment", appointment.name, "invoiced"),
+            frappe.get_cached_value("Patient Appointment", appointment.name, "invoiced"),
         )
 
     def test_invoicing(self):
@@ -66,7 +66,7 @@ class TestPatientAppointment(unittest.TestCase):
         )
         appointment = create_appointment(patient, practitioner, nowdate())
         self.assertEqual(
-            frappe.db.get_value("Patient Appointment", appointment.name, "invoiced"), 0
+            frappe.get_cached_value("Patient Appointment", appointment.name, "invoiced"), 0
         )
 
         frappe.db.set_value(
@@ -76,22 +76,22 @@ class TestPatientAppointment(unittest.TestCase):
             patient, practitioner, add_days(nowdate(), 2), invoice=1
         )
         self.assertEqual(
-            frappe.db.get_value("Patient Appointment", appointment.name, "invoiced"), 1
+            frappe.get_cached_value("Patient Appointment", appointment.name, "invoiced"), 1
         )
-        sales_invoice_name = frappe.db.get_value(
+        sales_invoice_name = frappe.get_cached_value(
             "Sales Invoice Item", {"reference_dn": appointment.name}, "parent"
         )
         self.assertTrue(sales_invoice_name)
         self.assertEqual(
-            frappe.db.get_value("Sales Invoice", sales_invoice_name, "company"),
+            frappe.get_cached_value("Sales Invoice", sales_invoice_name, "company"),
             appointment.company,
         )
         self.assertEqual(
-            frappe.db.get_value("Sales Invoice", sales_invoice_name, "patient"),
+            frappe.get_cached_value("Sales Invoice", sales_invoice_name, "patient"),
             appointment.patient,
         )
         self.assertEqual(
-            frappe.db.get_value("Sales Invoice", sales_invoice_name, "paid_amount"),
+            frappe.get_cached_value("Sales Invoice", sales_invoice_name, "paid_amount"),
             appointment.paid_amount,
         )
 
@@ -99,17 +99,17 @@ class TestPatientAppointment(unittest.TestCase):
         patient, medical_department, practitioner = create_healthcare_docs()
         frappe.db.set_value("Healthcare Settings", None, "enable_free_follow_ups", 1)
         appointment = create_appointment(patient, practitioner, nowdate())
-        fee_validity = frappe.db.get_value(
+        fee_validity = frappe.get_cached_value(
             "Fee Validity Reference", {"appointment": appointment.name}, "parent"
         )
         # fee validity created
         self.assertTrue(fee_validity)
 
-        visited = frappe.db.get_value("Fee Validity", fee_validity, "visited")
+        visited = frappe.get_cached_value("Fee Validity", fee_validity, "visited")
         update_status(appointment.name, "Cancelled")
         # check fee validity updated
         self.assertEqual(
-            frappe.db.get_value("Fee Validity", fee_validity, "visited"), visited - 1
+            frappe.get_cached_value("Fee Validity", fee_validity, "visited"), visited - 1
         )
 
         frappe.db.set_value("Healthcare Settings", None, "enable_free_follow_ups", 0)
@@ -119,11 +119,11 @@ class TestPatientAppointment(unittest.TestCase):
         appointment = create_appointment(patient, practitioner, nowdate(), invoice=1)
         update_status(appointment.name, "Cancelled")
         # check invoice cancelled
-        sales_invoice_name = frappe.db.get_value(
+        sales_invoice_name = frappe.get_cached_value(
             "Sales Invoice Item", {"reference_dn": appointment.name}, "parent"
         )
         self.assertEqual(
-            frappe.db.get_value("Sales Invoice", sales_invoice_name, "status"),
+            frappe.get_cached_value("Sales Invoice", sales_invoice_name, "status"),
             "Cancelled",
         )
 

--- a/hms_tz/hms_tz/doctype/practitioner_availability/practitioner_availability.py
+++ b/hms_tz/hms_tz/doctype/practitioner_availability/practitioner_availability.py
@@ -98,7 +98,7 @@ def validate_overlap(doc):
 
 def validate_service_unit_capacity(doc):
     if doc.service_unit:
-        service_unit_capacity = frappe.get_value(
+        service_unit_capacity = frappe.get_cached_value(
             "Healthcare Service Unit", doc.service_unit, "total_service_unit_capacity"
         )
         if (

--- a/hms_tz/hms_tz/doctype/radiology_examination/radiology_examination.py
+++ b/hms_tz/hms_tz/doctype/radiology_examination/radiology_examination.py
@@ -33,11 +33,11 @@ class RadiologyExamination(Document):
         set_title_field(self)
         ref_company = False
         if self.inpatient_record:
-            ref_company = frappe.db.get_value(
+            ref_company = frappe.get_cached_value(
                 "Inpatient Record", self.inpatient_record, "company"
             )
         elif self.service_unit:
-            ref_company = frappe.db.get_value(
+            ref_company = frappe.get_cached_value(
                 "Healthcare Service Unit", self.service_unit, "company"
             )
         if ref_company:

--- a/hms_tz/hms_tz/doctype/therapy_session/therapy_session.py
+++ b/hms_tz/hms_tz/doctype/therapy_session/therapy_session.py
@@ -136,7 +136,7 @@ def create_therapy_session(source_name, target_doc=None):
 @frappe.whitelist()
 def invoice_therapy_session(source_name, target_doc=None):
     def set_missing_values(source, target):
-        target.customer = frappe.db.get_value("Patient", source.patient, "customer")
+        target.customer = frappe.get_cached_value("Patient", source.patient, "customer")
         target.due_date = getdate()
         target.debit_to = get_receivable_account(source.company)
         item = target.append("items", {})
@@ -165,7 +165,7 @@ def invoice_therapy_session(source_name, target_doc=None):
 
 
 def get_therapy_item(therapy, item):
-    item.item_code = frappe.db.get_value("Therapy Type", therapy.therapy_type, "item")
+    item.item_code = frappe.get_cached_value("Therapy Type", therapy.therapy_type, "item")
     item.description = _(f"Therapy Session Charges: {therapy.practitioner}")
     item.income_account = get_income_account(therapy.practitioner, therapy.company)
     item.cost_center = frappe.get_cached_value(

--- a/hms_tz/hms_tz/doctype/therapy_type/test_therapy_type.py
+++ b/hms_tz/hms_tz/doctype/therapy_type/test_therapy_type.py
@@ -14,7 +14,7 @@ class TestTherapyType(unittest.TestCase):
 
         therapy_type.disabled = 1
         therapy_type.save()
-        self.assertEquals(frappe.db.get_value("Item", therapy_type.item, "disabled"), 1)
+        self.assertEquals(frappe.get_cached_value("Item", therapy_type.item, "disabled"), 1)
 
 
 def create_therapy_type():

--- a/hms_tz/hms_tz/doctype/therapy_type/therapy_type.py
+++ b/hms_tz/hms_tz/doctype/therapy_type/therapy_type.py
@@ -118,7 +118,7 @@ def create_item_from_therapy(doc):
 
 
 def make_item_price(item, item_price):
-    price_list_name = frappe.db.get_value("Price List", {"selling": 1})
+    price_list_name = frappe.get_cached_value("Price List", {"selling": 1})
     frappe.get_doc(
         {
             "doctype": "Item Price",

--- a/hms_tz/hms_tz/report/ipd_billing_report/ipd_billing_report.py
+++ b/hms_tz/hms_tz/report/ipd_billing_report/ipd_billing_report.py
@@ -330,8 +330,8 @@ def get_transaction_data(args):
 
 
 def get_report_summary(args, summary_data, is_summary=False):
-    customer = frappe.get_value("Patient", {"name": args.patient}, ["customer"])
-    cash_limit = frappe.get_value(
+    customer = frappe.get_cached_value("Patient", {"name": args.patient}, ["customer"])
+    cash_limit = frappe.get_cached_value(
         "Inpatient Record", args.inpatient_record, "cash_limit"
     )
 

--- a/hms_tz/hms_tz/report/itemized_bill_report/itemized_bill_report.py
+++ b/hms_tz/hms_tz/report/itemized_bill_report/itemized_bill_report.py
@@ -28,7 +28,7 @@ def execute(filters=None):
             "status",
         ],
     )
-    appointment_date = frappe.db.get_value(
+    appointment_date = frappe.get_cached_value(
         "Patient Appointment", filters.patient_appointment, "appointment_date"
     )
 
@@ -36,7 +36,7 @@ def execute(filters=None):
         frappe.throw(frappe.bold("This Appointment is not Closed..!!"))
 
     else:
-        admitted_discharge_date = frappe.db.get_value(
+        admitted_discharge_date = frappe.get_cached_value(
             "Inpatient Record",
             {"patient_appointment": filters.patient_appointment},
             ["admitted_datetime as admitted_date", "discharge_date", "scheduled_date"],
@@ -107,7 +107,7 @@ def execute(filters=None):
                 "appointment_date": appointment_date,
             }
 
-            print_person = frappe.get_value("User", frappe.session.user, "full_name")
+            print_person = frappe.get_cached_value("User", frappe.session.user, "full_name")
 
             last_row["printed_by"] = print_person
 
@@ -170,7 +170,7 @@ def execute(filters=None):
                 "appointment_date": appointment_date,
             }
 
-            print_person = frappe.get_value("User", frappe.session.user, "full_name")
+            print_person = frappe.get_cached_value("User", frappe.session.user, "full_name")
 
             last_row["printed_by"] = print_person
 
@@ -237,7 +237,7 @@ def execute(filters=None):
                 "appointment_date": appointment_date,
             }
 
-            print_person = frappe.get_value("User", frappe.session.user, "full_name")
+            print_person = frappe.get_cached_value("User", frappe.session.user, "full_name")
 
             last_row["printed_by"] = print_person
 
@@ -495,7 +495,7 @@ def get_appointment_consultancy(filters):
 			LEFT JOIN `tabInpatient Record` ipd_rec ON pa.name = ipd_rec.patient_appointment
 		WHERE pa.status = "Closed"
 		AND pa.follow_up = 0 {conditions}
-	"""
+	""",
         filters,
         as_dict=1,
     )
@@ -931,8 +931,8 @@ def get_insurance_lrpmt_transaction(filters):
 
 
 def get_report_summary(filters, total_amount):
-    customer = frappe.get_value("Patient", filters.get("patient"), "customer")
-    company = frappe.get_value(
+    customer = frappe.get_cached_value("Patient", filters.get("patient"), "customer")
+    company = frappe.get_cached_value(
         "Patient Appointment", filters.get("patient_appointment"), "company"
     )
 

--- a/hms_tz/hms_tz/report/patient_time_report/patient_time_report.py
+++ b/hms_tz/hms_tz/report/patient_time_report/patient_time_report.py
@@ -84,7 +84,7 @@ def get_data(filters=None):
 
     data = []
     for appointment in appointments:
-        vital_edit = frappe.get_value(
+        vital_edit = frappe.get_cached_value(
             "Vital Signs", {"appointment": appointment.name}, "modified"
         )
         encounters = frappe.get_all(
@@ -114,7 +114,7 @@ def get_data(filters=None):
             if len(encounter_versions):
                 first_encounter_first_update = encounter_versions[0].creation
 
-        patient_claim_creation = frappe.get_value(
+        patient_claim_creation = frappe.get_cached_value(
             "NHIF Patient Claim", {"patient_appointment": appointment.name}, "creation"
         )
 

--- a/hms_tz/hms_tz/utils.py
+++ b/hms_tz/hms_tz/utils.py
@@ -37,7 +37,7 @@ def get_healthcare_services_to_invoice(patient, company):
 
 
 def validate_customer_created(patient):
-    if not frappe.db.get_value("Patient", patient.name, "customer"):
+    if not frappe.get_cached_value("Patient", patient.name, "customer"):
         msg = _("Please set a Customer linked to the Patient")
         msg += f" <b><a href='#Form/Patient/{patient.name}'>{patient.name}</a></b>"
         frappe.throw(msg, title=_("Customer Not Found"))
@@ -60,7 +60,7 @@ def get_appointments_to_invoice(patient, company):
     for appointment in patient_appointments:
         # Procedure Appointments
         if appointment.procedure_template:
-            if frappe.db.get_value(
+            if frappe.get_cached_value(
                 "Clinical Procedure Template",
                 appointment.procedure_template,
                 "is_billable",
@@ -348,7 +348,7 @@ def get_inpatient_services_to_invoice(patient, company):
     )
 
     for inpatient_occupancy in inpatient_services:
-        service_unit_type = frappe.db.get_value(
+        service_unit_type = frappe.get_cached_value(
             "Healthcare Service Unit",
             inpatient_occupancy.service_unit,
             "service_unit_type",
@@ -400,7 +400,7 @@ def get_therapy_plans_to_invoice(patient, company):
             {
                 "reference_type": "Therapy Plan",
                 "reference_name": plan.name,
-                "service": frappe.db.get_value(
+                "service": frappe.get_cached_value(
                     "Therapy Plan Template", plan.therapy_plan_template, "linked_item"
                 ),
             }
@@ -430,14 +430,14 @@ def get_therapy_sessions_to_invoice(patient, company):
     )
     for therapy in therapy_sessions:
         if not therapy.appointment:
-            if therapy.therapy_type and frappe.db.get_value(
+            if therapy.therapy_type and frappe.get_cached_value(
                 "Therapy Type", therapy.therapy_type, "is_billable"
             ):
                 therapy_sessions_to_invoice.append(
                     {
                         "reference_type": "Therapy Session",
                         "reference_name": therapy.name,
-                        "service": frappe.db.get_value(
+                        "service": frappe.get_cached_value(
                             "Therapy Type", therapy.therapy_type, "item"
                         ),
                     }
@@ -600,13 +600,13 @@ def throw_config_practitioner_charge(is_inpatient, practitioner):
 
 
 def get_practitioner_service_item(practitioner, service_item_field):
-    return frappe.db.get_value(
+    return frappe.get_cached_value(
         "Healthcare Practitioner", practitioner, service_item_field
     )
 
 
 def get_appointment_type_service_item(appointment_type, service_item_field):
-    return frappe.db.get_value("Appointment Type", appointment_type, service_item_field)
+    return frappe.get_cached_value("Appointment Type", appointment_type, service_item_field)
 
 
 def get_healthcare_service_item(service_item_field):
@@ -615,11 +615,11 @@ def get_healthcare_service_item(service_item_field):
 
 def get_practitioner_charge(practitioner, is_inpatient):
     if is_inpatient:
-        practitioner_charge = frappe.db.get_value(
+        practitioner_charge = frappe.get_cached_value(
             "Healthcare Practitioner", practitioner, "inpatient_visit_charge"
         )
     else:
-        practitioner_charge = frappe.db.get_value(
+        practitioner_charge = frappe.get_cached_value(
             "Healthcare Practitioner", practitioner, "op_consulting_charge"
         )
     if practitioner_charge:
@@ -666,7 +666,7 @@ def set_invoiced(item, method, ref_invoice=None):
         frappe.db.set_value(item.reference_dt, item.reference_dn, "invoiced", invoiced)
 
     if item.reference_dt == "Patient Appointment":
-        if frappe.db.get_value(
+        if frappe.get_cached_value(
             "Patient Appointment", item.reference_dn, "procedure_template"
         ):
             dt_from_appointment = "Clinical Procedure"
@@ -702,11 +702,11 @@ def validate_invoiced_on_submit(item):
         and get_healthcare_service_item("clinical_procedure_consumable_item")
         == item.item_code
     ):
-        is_invoiced = frappe.db.get_value(
+        is_invoiced = frappe.get_cached_value(
             item.reference_dt, item.reference_dn, "consumption_invoiced"
         )
     else:
-        is_invoiced = frappe.db.get_value(
+        is_invoiced = frappe.get_cached_value(
             item.reference_dt, item.reference_dn, "invoiced"
         )
     if is_invoiced:
@@ -716,10 +716,10 @@ def validate_invoiced_on_submit(item):
 
 
 def manage_prescriptions(invoiced, ref_dt, ref_dn, dt, created_check_field):
-    created = frappe.db.get_value(ref_dt, ref_dn, created_check_field)
+    created = frappe.get_cached_value(ref_dt, ref_dn, created_check_field)
     if created:
         # Fetch the doc created for the prescription
-        doc_created = frappe.db.get_value(dt, {"prescription": ref_dn})
+        doc_created = frappe.get_cached_value(dt, {"prescription": ref_dn})
         frappe.db.set_value(dt, doc_created, "invoiced", invoiced)
 
 
@@ -763,7 +763,7 @@ def manage_fee_validity(appointment):
 
 
 def manage_doc_for_appointment(dt_from_appointment, appointment, invoiced):
-    dn_from_appointment = frappe.db.get_value(
+    dn_from_appointment = frappe.get_cached_value(
         dt_from_appointment, filters={"appointment": appointment}
     )
     if dn_from_appointment:
@@ -784,7 +784,7 @@ def get_drugs_to_invoice(encounter):
                     if drug_line.drug_code:
                         qty = 1
                         if (
-                            frappe.db.get_value(
+                            frappe.get_cached_value(
                                 "Item", drug_line.drug_code, "stock_uom"
                             )
                             == "Nos"
@@ -1063,7 +1063,7 @@ def update_address_link(address, method):
             if link.link_doctype == "Patient":
                 address_patient = link.link_name
         if address_patient:
-            customer = frappe.db.get_value("Patient", address_patient, "customer")
+            customer = frappe.get_cached_value("Patient", address_patient, "customer")
             if not address.has_link("Customer", customer):
                 address.append(
                     "links", dict(link_doctype="Customer", link_name=customer)
@@ -1098,11 +1098,11 @@ def create_item_from_doc(doc, item_name):
     # insert item price
     # get item price list to insert item price
     if doc.rate != 0.0:
-        price_list_name = frappe.db.get_value(
+        price_list_name = frappe.get_cached_value(
             "Selling Settings", None, "selling_price_list"
         )
         if not price_list_name:
-            price_list_name = frappe.db.get_value("Price List", {"selling": 1})
+            price_list_name = frappe.get_cached_value("Price List", {"selling": 1})
         if price_list_name:
             if doc.rate:
                 make_item_price(item.name, price_list_name, doc.rate)
@@ -1345,7 +1345,7 @@ def valid_insurance(insurance_subscription, insurance_company, posting_date):
 def get_insurance_price_list_rate(healthcare_insurance_coverage_plan, billing_item):
     rate = 0.0
     if healthcare_insurance_coverage_plan:
-        price_list = frappe.db.get_value(
+        price_list = frappe.get_cached_value(
             "Healthcare Insurance Coverage Plan",
             healthcare_insurance_coverage_plan,
             "price_list",
@@ -1355,7 +1355,7 @@ def get_insurance_price_list_rate(healthcare_insurance_coverage_plan, billing_it
                 "Item Price", {"item_code": billing_item, "price_list": price_list}
             )
         if item_price:
-            rate = frappe.db.get_value("Item Price", item_price, "price_list_rate")
+            rate = frappe.get_cached_value("Item Price", item_price, "price_list_rate")
     return rate
 
 
@@ -1372,18 +1372,18 @@ def get_insurance_coverage_details(healthcare_insurance_coverage_plan, service):
             },
         )
         if healthcare_service_coverage:
-            coverage, discount = frappe.db.get_value(
+            coverage, discount = frappe.get_cached_value(
                 "Healthcare Service Insurance Coverage",
                 healthcare_service_coverage,
                 ["coverage", "discount"],
             )
-            approval_mandatory_for_claim = frappe.db.get_value(
+            approval_mandatory_for_claim = frappe.get_cached_value(
                 "Healthcare Service Insurance Coverage",
                 healthcare_service_coverage,
                 "approval_mandatory_for_claim",
             )
             if approval_mandatory_for_claim:
-                manual_approval_only = frappe.db.get_value(
+                manual_approval_only = frappe.get_cached_value(
                     "Healthcare Service Insurance Coverage",
                     healthcare_service_coverage,
                     "manual_approval_only",

--- a/hms_tz/nhif/api/delivery_note.py
+++ b/hms_tz/nhif/api/delivery_note.py
@@ -57,7 +57,7 @@ def update_dosage_details(item):
     """Update dosage details for Cash Patient only if dosage is not set"""
 
     if item.si_detail:
-        reference_dn = frappe.get_value(
+        reference_dn = frappe.get_cached_value(
             "Sales Invoice Item", item.si_detail, "reference_dn"
         )
         if not reference_dn:
@@ -193,12 +193,12 @@ def validate_medication_class(doc, row):
 def set_missing_values(doc):
     if doc.form_sales_invoice:
         if not doc.hms_tz_appointment_no or not doc.healthcare_practitioner:
-            si_reference_dn = frappe.get_value(
+            si_reference_dn = frappe.get_cached_value(
                 "Sales Invoice Item", doc.items[0].si_detail, "reference_dn"
             )
 
             if si_reference_dn:
-                parent_encounter = frappe.get_value(
+                parent_encounter = frappe.get_cached_value(
                     "Drug Prescription", si_reference_dn, "parent"
                 )
                 doc.reference_name = parent_encounter
@@ -206,7 +206,7 @@ def set_missing_values(doc):
                 (
                     doc.hms_tz_appointment_no,
                     doc.healthcare_practitioner,
-                ) = frappe.get_value(
+                ) = frappe.get_cached_value(
                     "Patient Encounter",
                     parent_encounter,
                     ["appointment", "practitioner"],
@@ -217,7 +217,7 @@ def set_missing_values(doc):
         and doc.reference_name
         and doc.reference_doctype == "Patient Encounter"
     ):
-        doc.patient = frappe.get_value(
+        doc.patient = frappe.get_cached_value(
             "Patient Encounter", doc.reference_name, "patient"
         )
 

--- a/hms_tz/nhif/api/healthcare_utils.py
+++ b/hms_tz/nhif/api/healthcare_utils.py
@@ -2412,7 +2412,7 @@ def validate_nhif_patient_claim_status(
         )
     if insurance_company and "NHIF" in insurance_company:
         if not claim_no:
-            claim_no = frappe.db.get_value(
+            claim_no = frappe.get_cached_value(
                 "Patient Appointment", appointment, "nhif_patient_claim"
             )
 

--- a/hms_tz/nhif/api/inpatient_record.py
+++ b/hms_tz/nhif/api/inpatient_record.py
@@ -134,7 +134,7 @@ def set_beds_price(self):
                     bed.hms_tz_is_discount_applied = 1
                 payment_type = "Insurance"
             else:
-                mode_of_payment = frappe.get_value(
+                mode_of_payment = frappe.get_cached_value(
                     "Patient Encounter", self.admission_encounter, "mode_of_payment"
                 )
                 service_unit_type = frappe.get_cached_value(
@@ -171,7 +171,7 @@ def make_deposit(
     if not mode_of_payment:
         frappe.throw(_("The mode of payment is required"))
 
-    if frappe.get_value("Mode of Payment", mode_of_payment, "type") != "Cash":
+    if frappe.get_cached_value("Mode of Payment", mode_of_payment, "type") != "Cash":
         if not reference_number:
             frappe.throw(
                 _(
@@ -266,7 +266,7 @@ def create_sales_invoice(args):
     invoice_doc.patient = args.patient
     invoice_doc.customer = frappe.get_cached_value("Patient", args.patient, "customer")
     invoice_doc.company = args.company
-    mode_of_payment = frappe.get_value(
+    mode_of_payment = frappe.get_cached_value(
         "Patient Encounter", patient_encounter_list[0].name, "mode_of_payment"
     )
     price_list = frappe.get_cached_value(
@@ -282,7 +282,7 @@ def create_sales_invoice(args):
         item.reference_dt = service.get("reference_type")
         item.reference_dn = service.get("reference_name")
         if item.reference_dt == "Drug Prescription":
-            item.healthcare_service_unit = frappe.get_value(
+            item.healthcare_service_unit = frappe.get_cached_value(
                 service.get("reference_type"),
                 service.get("reference_name"),
                 "healthcare_service_unit",
@@ -333,14 +333,14 @@ def validate_similary_authozation_number(doc):
     insurance_company = doc.insurance_company
 
     if not insurance_company:
-        insurance_company = frappe.get_value(
+        insurance_company = frappe.get_cached_value(
             "Healthcare Insurance Subscription",
             doc.insurance_subscription,
             "insurance_company",
         )
 
     if insurance_company and "NHIF" in insurance_company:
-        auth_no = frappe.get_value(
+        auth_no = frappe.get_cached_value(
             "Patient Appointment", doc.patient_appointment, "authorization_number"
         )
         claims = frappe.get_all(

--- a/hms_tz/nhif/api/medical_record.py
+++ b/hms_tz/nhif/api/medical_record.py
@@ -93,7 +93,7 @@ def set_subject_field(doc):
 def get_date_field(doctype):
     dt = get_patient_history_config_dt(doctype)
 
-    return frappe.db.get_value(dt, {"document_type": doctype}, "date_fieldname")
+    return frappe.get_cached_value(dt, {"document_type": doctype}, "date_fieldname")
 
 
 def validate_medical_record_required(doc):
@@ -115,7 +115,7 @@ def get_patient_history_fields(doc):
     dt = get_patient_history_config_dt(doc.doctype)
     if doc.doctype == "Delivery Note":
         dt = "Patient History Custom Document Type"
-    patient_history_fields = frappe.db.get_value(
+    patient_history_fields = frappe.get_cached_value(
         dt, {"document_type": doc.doctype}, "selected_fields"
     )
 
@@ -167,7 +167,7 @@ def set_practitioner(doc):
 
         for field in ["practitioner", "healthcare_practitioner", "referring_practitioner"]:
             if meta.get_field(field):
-                practitioner = frappe.db.get_value(
+                practitioner = frappe.get_cached_value(
                     doc.reference_doctype, doc.reference_name, field
                 )
                 if practitioner:

--- a/hms_tz/nhif/api/patient.py
+++ b/hms_tz/nhif/api/patient.py
@@ -353,7 +353,7 @@ def update_cash_limit(kwargs):
 
 @frappe.whitelist()
 def validate_missing_patient_dob(patient: str):
-    patient_name, dob = frappe.get_value("Patient", patient, ["patient_name", "dob"])
+    patient_name, dob = frappe.get_cached_value("Patient", patient, ["patient_name", "dob"])
     if not dob:
         return False
     return True

--- a/hms_tz/nhif/api/patient_appointment.py
+++ b/hms_tz/nhif/api/patient_appointment.py
@@ -299,7 +299,7 @@ def make_encounter(doc, method):
         if not doc.appointment or doc.inpatient_record:
             return
         if (
-            frappe.get_value("Patient Appointment", doc.appointment, "status")
+            frappe.get_cached_value("Patient Appointment", doc.appointment, "status")
             == "Cancelled"
         ):
             frappe.throw("<b>Appointment is already cancelled</b>")
@@ -405,7 +405,7 @@ def send_vfd(invoice_name):
         from vfd_tz.vfd_tz.api.sales_invoice import enqueue_posting_vfd_invoice
 
         enqueue_posting_vfd_invoice(invoice_name)
-        pos_profile_name = frappe.get_value(
+        pos_profile_name = frappe.get_cached_value(
             "Sales Invoice", invoice_name, "pos_profile"
         )
         pos_profile = frappe.get_cached_doc("POS Profile", pos_profile_name)
@@ -566,7 +566,7 @@ def make_next_doc(doc, method, from_hook=True):
 
 @frappe.whitelist()
 def validate_insurance_company(insurance_company: str) -> str:
-    if frappe.get_value("Healthcare Insurance Company", insurance_company, "disabled"):
+    if frappe.get_cached_value("Healthcare Insurance Company", insurance_company, "disabled"):
         frappe.msgprint(
             _(
                 f"<b>Insurance Company: <strong>{insurance_company}</strong> is disabled, Please choose different insurance subscription</b>"
@@ -582,7 +582,7 @@ def validate_insurance_subscription(doc):
         return
 
     if (
-        frappe.db.get_value(
+        frappe.get_cached_value(
             "Healthcare Insurance Subscription", doc.insurance_subscription, "docstatus"
         )
         == 0
@@ -599,7 +599,7 @@ def validate_insurance_subscription(doc):
 
 
 def calculate_patient_age(patient):
-    dob = frappe.get_value("Patient", patient, "dob")
+    dob = frappe.get_cached_value("Patient", patient, "dob")
     if not dob:
         frappe.msgprint(
             "<h4 style='background-color: LightCoral'>Please update date of birth for this patient</h4>"

--- a/hms_tz/nhif/api/sales_invoice.py
+++ b/hms_tz/nhif/api/sales_invoice.py
@@ -43,7 +43,7 @@ def validate_create_delivery_note(doc):
         "Patient", doc.patient, "inpatient_record"
     )
     if inpatient_record:
-        insurance_subscription = frappe.get_value(
+        insurance_subscription = frappe.get_cached_value(
             "Inpatient Record", inpatient_record, "insurance_subscription"
         )
         if not insurance_subscription:
@@ -74,7 +74,7 @@ def before_submit(doc, method):
     # do not validate stock for cash inpatient sales invoice
     if doc.enabled_auto_create_delivery_notes == 1:
         for row in doc.items:
-            if frappe.get_value("Item", row.item_code, "is_stock_item") == 1:
+            if frappe.get_cached_value("Item", row.item_code, "is_stock_item") == 1:
                 validate_stock_item(row, row.warehouse, method)
 
     if doc.is_return == 1:
@@ -202,7 +202,7 @@ def update_drug_prescription(doc):
                 and item.reference_dt
                 and item.reference_dt == "Drug Prescription"
             ):
-                dn_name = frappe.get_value(
+                dn_name = frappe.get_cached_value(
                     "Delivery Note", {"form_sales_invoice": doc.name}, "name"
                 )
                 if not dn_name:
@@ -287,7 +287,7 @@ def reset_invoiced_status(doc):
 
 @frappe.whitelist()
 def get_pos_profile(current_user):
-    pos = frappe.db.get_value("POS Profile User", {"user": current_user},["parent"])
+    pos = frappe.get_cached_value("POS Profile User", {"user": current_user},["parent"])
     if pos:
         modes = frappe.db.get_all("POS Payment Method",filters={"parent": pos},fields=["mode_of_payment"])
         

--- a/hms_tz/nhif/api/sales_order.py
+++ b/hms_tz/nhif/api/sales_order.py
@@ -26,7 +26,7 @@ def create_sales_order(doc, method):
     if doc.mode_of_payment and doc.inpatient_record:
         return
 
-    company_details = frappe.get_value(
+    company_details = frappe.get_cached_value(
         "Company",
         doc.company,
         [
@@ -81,7 +81,7 @@ def get_items_from_encounter(doc, warehouse):
             ):
                 continue
 
-            item_code = frappe.get_value(
+            item_code = frappe.get_cached_value(
                 field.get("template"), row.get(field.get("item_field")), "item"
             )
             if not item_code:
@@ -92,7 +92,7 @@ def get_items_from_encounter(doc, warehouse):
                     )
                 )
 
-            item_name, item_description = frappe.get_value(
+            item_name, item_description = frappe.get_cached_value(
                 "Item", item_code, ["item_name", "description"]
             )
 
@@ -142,22 +142,22 @@ def get_items_from_encounter(doc, warehouse):
 def create_sales_order_from_encounter(
     doc, items, warehouse, allow_md_change_request=False
 ):
-    price_list = frappe.get_value(
+    price_list = frappe.get_cached_value(
         "Mode of Payment", doc.get("mode_of_payment"), "price_list"
     )
     if not price_list:
-        price_list = frappe.get_value(
+        price_list = frappe.get_cached_value(
             "Mode of Payment", doc.get("encounter_mode_of_payment"), "price_list"
         )
     if not price_list:
-        price_list = frappe.get_value(
+        price_list = frappe.get_cached_value(
             "Company", doc.get("company"), "default_price_list"
         )
     if not price_list:
         frappe.throw("Please set Price List in Mode of Payment or Company")
 
-    mobile = frappe.get_value("Patient", doc.get("patient"), "mobile")
-    customer = frappe.get_value("Patient", doc.get("patient"), "customer")
+    mobile = frappe.get_cached_value("Patient", doc.get("patient"), "mobile")
+    customer = frappe.get_cached_value("Patient", doc.get("patient"), "customer")
     order_doc = frappe.new_doc("Sales Order")
     order_doc.update(
         {

--- a/hms_tz/nhif/api/service_order.py
+++ b/hms_tz/nhif/api/service_order.py
@@ -17,7 +17,7 @@ def after_save(doc, method):
 
 def set_missing_values(doc, method):
     if doc.order_reference_doctype and doc.order_reference_name:
-        prescribe = frappe.get_value(
+        prescribe = frappe.get_cached_value(
             doc.order_reference_doctype, doc.order_reference_name, "prescribe"
         )
         if not prescribe:

--- a/hms_tz/nhif/api/therapy_session.py
+++ b/hms_tz/nhif/api/therapy_session.py
@@ -44,7 +44,7 @@ def on_submit(doc, method):
 
 def validate_not_serviced(doc):
     if doc.therapy_plan:
-        status = frappe.db.get_value("Therapy Plan", doc.therapy_plan, "status")
+        status = frappe.get_cached_value("Therapy Plan", doc.therapy_plan, "status")
         if status == "Not Serviced":
             frappe.throw(
                 f"This Therapy Plan: {frappe.bold(doc.therapy_plan)} is Not Serviced,\

--- a/hms_tz/nhif/doctype/healthcare_package_order/healthcare_package_order.py
+++ b/hms_tz/nhif/doctype/healthcare_package_order/healthcare_package_order.py
@@ -37,7 +37,7 @@ class HealthcarePackageOrder(Document):
 		self.posting_time = nowtime()
 	
 	def set_total_price(self):
-		price_of_services, price_package = frappe.get_value("Healthcare Package",
+		price_of_services, price_package = frappe.get_cached_value("Healthcare Package",
 			self.healthcare_package, ["total_price_of_services", "price_of_package"]
 		)
 		self.total_price = price_package if price_package > 0 else price_of_services

--- a/hms_tz/nhif/doctype/medication_change_request/medication_change_request.py
+++ b/hms_tz/nhif/doctype/medication_change_request/medication_change_request.py
@@ -299,10 +299,10 @@ class MedicationChangeRequest(Document):
 
     def get_warehouse_per_dn_or_so(self):
         if self.sales_order:
-            return frappe.get_value("Sales Order", self.sales_order, "set_warehouse")
+            return frappe.get_cached_value("Sales Order", self.sales_order, "set_warehouse")
 
         if self.delivery_note:
-            return frappe.get_value(
+            return frappe.get_cached_value(
                 "Delivery Note", self.delivery_note, "set_warehouse"
             )
 
@@ -419,7 +419,7 @@ class MedicationChangeRequest(Document):
             ):
                 continue
 
-            item_code = frappe.get_value("Medication", row.get("drug_code"), "item")
+            item_code = frappe.get_cached_value("Medication", row.get("drug_code"), "item")
             if not item_code:
                 frappe.throw(
                     _(
@@ -428,7 +428,7 @@ class MedicationChangeRequest(Document):
                     )
                 )
 
-            item_name, item_description = frappe.get_value(
+            item_name, item_description = frappe.get_cached_value(
                 "Item", item_code, ["item_name", "description"]
             )
 
@@ -625,10 +625,10 @@ def get_delivery_note(patient, patient_encounter):
 @frappe.whitelist()
 def get_patient_encounter_name(delivery_note, sales_order):
     if delivery_note:
-        return frappe.db.get_value("Delivery Note", delivery_note, "reference_name")
+        return frappe.get_cached_value("Delivery Note", delivery_note, "reference_name")
 
     elif sales_order:
-        return frappe.db.get_value("Sales Order", sales_order, "patient_encounter")
+        return frappe.get_cached_value("Sales Order", sales_order, "patient_encounter")
 
     return ""
 
@@ -640,7 +640,7 @@ def get_patient_encounter_doc(patient_encounter):
 
 
 def get_insurance_details(self):
-    insurance_subscription, insurance_company, mop = frappe.get_value(
+    insurance_subscription, insurance_company, mop = frappe.get_cached_value(
         "Patient Appointment",
         self.appointment,
         ["insurance_subscription", "insurance_company", "mode_of_payment"],
@@ -805,7 +805,7 @@ def create_medication_change_request_from_so(doctype, name):
                 Please keep a comment and save the sales order, before creating med change request</b>"
         )
 
-    appointment, practitioner = frappe.db.get_value(
+    appointment, practitioner = frappe.get_cached_value(
         "Patient Encounter",
         source_doc.patient_encounter,
         ["appointment", "practitioner"],

--- a/hms_tz/nhif/doctype/nhif_custom_excluded_services/nhif_custom_excluded_services.py
+++ b/hms_tz/nhif/doctype/nhif_custom_excluded_services/nhif_custom_excluded_services.py
@@ -18,7 +18,7 @@ class NHIFCustomExcludedServices(Document):
 	def set_missing_values(self):
 		if not self.time_stamp:
 			self.time_stamp = now_datetime()
-		self.itemcode = frappe.get_value('Item Customer Detail', {'parent': self.item}, 'ref_code')
+		self.itemcode = frappe.get_cached_value('Item Customer Detail', {'parent': self.item}, 'ref_code')
 		if not self.itemcode:
 			frappe.throw(
 				_(
@@ -29,7 +29,7 @@ class NHIFCustomExcludedServices(Document):
 
 @frappe.whitelist()
 def validate_item(company, item, name):
-    record = frappe.get_value(
+    record = frappe.get_cached_value(
         "NHIF Custom Excluded Services",
         {"name": ["!=", name], "company": company, "item": item},
     )

--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -72,7 +72,7 @@ class NHIFPatientClaim(Document):
 
     def on_trash(self):
         # check if claim number exist in appointment record
-        nhif_patient_claim = frappe.get_value(
+        nhif_patient_claim = frappe.get_cached_value(
             "Patient Appointment", self.patient_appointment, "nhif_patient_claim"
         )
         if nhif_patient_claim == self.name:
@@ -237,7 +237,7 @@ class NHIFPatientClaim(Document):
                 scheduled_date,
                 admitted_datetime,
                 time_created,
-            ) = frappe.get_value(
+            ) = frappe.get_cached_value(
                 "Inpatient Record",
                 self.inpatient_record,
                 ["discharge_date", "scheduled_date", "admitted_datetime", "creation"],
@@ -262,7 +262,7 @@ class NHIFPatientClaim(Document):
                 # because there is no field of discharge time on Inpatient Record
                 self.discharge_time = nowtime()
 
-        self.attendance_date, self.attendance_time = frappe.get_value(
+        self.attendance_date, self.attendance_time = frappe.get_cached_value(
             "Patient Appointment",
             self.patient_appointment,
             ["appointment_date", "appointment_time"],
@@ -434,7 +434,7 @@ class NHIFPatientClaim(Document):
                         if row.prescribe or row.is_cancelled:
                             continue
 
-                        item_code = frappe.get_value(
+                        item_code = frappe.get_cached_value(
                             child.get("doctype"), row.get(child.get("item")), "item"
                         )
 
@@ -582,7 +582,7 @@ class NHIFPatientClaim(Document):
                             if row.prescribe or row.is_cancelled:
                                 continue
                             
-                            item_code = frappe.get_value(
+                            item_code = frappe.get_cached_value(
                                 child.get("doctype"),
                                 row.get(child.get("item")),
                                 "item",
@@ -880,7 +880,7 @@ def get_missing_patient_signature(self):
 def validate_submit_date(self):
     import calendar
 
-    submit_claim_month, submit_claim_year = frappe.get_value(
+    submit_claim_month, submit_claim_year = frappe.get_cached_value(
         "Company NHIF Settings",
         self.company,
         ["submit_claim_month", "submit_claim_year"],
@@ -986,7 +986,7 @@ def generate_pdf(doc):
         data_list.append(i.name)
     doctype = dict({"Patient Encounter": data_list})
     print_format = ""
-    default_print_format = frappe.db.get_value(
+    default_print_format = frappe.db.get_cached_value(
         "Property Setter",
         dict(property="default_print_format", doc_type="Patient Encounter"),
         "value",
@@ -1062,7 +1062,7 @@ def get_claim_pdf_file(doc):
 
     doctype = doc.doctype
     docname = doc.name
-    default_print_format = frappe.db.get_value(
+    default_print_format = frappe.get_cached_value(
         "Property Setter",
         dict(property="default_print_format", doc_type=doctype),
         "value",
@@ -1158,7 +1158,7 @@ def get_LRPMT_status(encounter_no, row, child):
         status = "Submitted"
 
     elif child["doctype"] == "Lab Test Template" and not row.get(child["ref_docname"]):
-        lab_workflow_state = frappe.get_value(
+        lab_workflow_state = frappe.get_cached_value(
             "Lab Test",
             {
                 "ref_docname": encounter_no,

--- a/hms_tz/nhif/doctype/nhif_product/nhif_product.py
+++ b/hms_tz/nhif/doctype/nhif_product/nhif_product.py
@@ -16,9 +16,9 @@ def add_product(company, id, name=None):
         return
     abbr = frappe.get_cached_value("Company", company, "abbr")
     product_id = str(id) + "-" + str(abbr)
-    nhif_product_pr_key = frappe.get_value("NHIF Product", {"company": company, "nhif_product_code": id})
+    nhif_product_pr_key = frappe.get_cached_value("NHIF Product", {"company": company, "nhif_product_code": id})
     if not nhif_product_pr_key:
-        nhif_product_pr_key = frappe.get_value("NHIF Product", {"company": "", "nhif_product_code": id})
+        nhif_product_pr_key = frappe.get_cached_value("NHIF Product", {"company": "", "nhif_product_code": id})
     
     if nhif_product_pr_key:
         if (

--- a/hms_tz/nhif/doctype/nhif_tracking_claim_change/nhif_tracking_claim_change.py
+++ b/hms_tz/nhif/doctype/nhif_tracking_claim_change/nhif_tracking_claim_change.py
@@ -119,7 +119,7 @@ def handle_drug_prescription_changes(item, claim_doc, ref_docnames_list):
             )
 
         elif child_encounter and is_cancelled == 1:
-            lrpmt_return = frappe.db.get_value(
+            lrpmt_return = frappe.get_cached_value(
                 "Medication Return",
                 {
                     "parentfield": "drug_items",
@@ -144,7 +144,7 @@ def handle_drug_prescription_changes(item, claim_doc, ref_docnames_list):
         is_cancelled = None
         child_encounter = None
         try:
-            is_cancelled, child_encounter = frappe.db.get_value(
+            is_cancelled, child_encounter = frappe.get_cached_value(
                 item.ref_doctype,
                 item.ref_docname,
                 ["is_cancelled", "parent as encounter"],
@@ -167,7 +167,7 @@ def handle_drug_prescription_changes(item, claim_doc, ref_docnames_list):
                 is_cancelled = None
                 child_encounter = None
                 try:
-                    is_cancelled, child_encounter = frappe.db.get_value(
+                    is_cancelled, child_encounter = frappe.get_cached_value(
                         item.ref_doctype,
                         ref_name,
                         ["is_cancelled", "parent as encounter"],
@@ -198,7 +198,7 @@ def handle_lrpt_prescription_changes(item, claim_doc, ref_docnames_list):
             )
 
         elif child_encounter and is_cancelled == 1:
-            lrpmt_return = frappe.db.get_value(
+            lrpmt_return = frappe.get_cached_value(
                 "Item Return",
                 {
                     "parentfield": "lrpt_items",
@@ -220,7 +220,7 @@ def handle_lrpt_prescription_changes(item, claim_doc, ref_docnames_list):
                 )
 
     if "," not in item.ref_docname and item.ref_docname not in ref_docnames_list:
-        is_cancelled, child_encounter = frappe.db.get_value(
+        is_cancelled, child_encounter = frappe.get_cached_value(
             item.ref_doctype, item.ref_docname, ["is_cancelled", "parent as encounter"]
         )
         handle_lrpt_changes(item, item.ref_docname, is_cancelled, child_encounter)
@@ -229,7 +229,7 @@ def handle_lrpt_prescription_changes(item, claim_doc, ref_docnames_list):
     elif "," in item.ref_docname:
         for ref_name in item.ref_docname.split(","):
             if ref_name not in ref_docnames_list:
-                is_cancelled, child_encounter = frappe.db.get_value(
+                is_cancelled, child_encounter = frappe.get_cached_value(
                     item.ref_doctype, ref_name, ["is_cancelled", "parent as encounter"]
                 )
                 handle_lrpt_changes(item, ref_name, is_cancelled, child_encounter)
@@ -252,7 +252,7 @@ def handle_inpatient_changes(item, claim_doc, ref_docnames_list):
             )
 
     if "," not in item.ref_docname and item.ref_docname not in ref_docnames_list:
-        is_confirmed = frappe.db.get_value(
+        is_confirmed = frappe.get_cached_value(
             item.ref_doctype, item.ref_docname, ["is_confirmed"]
         )
         handle_beds_cons_changes(item, item.ref_docname, is_confirmed)
@@ -261,7 +261,7 @@ def handle_inpatient_changes(item, claim_doc, ref_docnames_list):
     elif "," in item.ref_docname:
         for ref_name in item.ref_docname.split(","):
             if ref_name not in ref_docnames_list:
-                is_confirmed = frappe.db.get_value(
+                is_confirmed = frappe.get_cached_value(
                     item.ref_doctype, ref_name, ["is_confirmed"]
                 )
                 handle_beds_cons_changes(item, ref_name, is_confirmed)

--- a/hms_tz/nhif/doctype/patient_discount_request/patient_discount_request.py
+++ b/hms_tz/nhif/doctype/patient_discount_request/patient_discount_request.py
@@ -41,7 +41,7 @@ class PatientDiscountRequest(Document):
         self.posting_date = nowdate()
         self.posting_time = nowtime()
 
-        inpatient_record = frappe.get_value("Patient", self.patient, "inpatient_record")
+        inpatient_record = frappe.get_cached_value("Patient", self.patient, "inpatient_record")
         if inpatient_record:
             self.inpatient_record = inpatient_record
 
@@ -49,14 +49,14 @@ class PatientDiscountRequest(Document):
 
     def validate_patient(self):
         if self.patient:
-            if self.sales_invoice and self.patient != frappe.db.get_value(
+            if self.sales_invoice and self.patient != frappe.get_cached_value(
                 "Sales Invoice", self.sales_invoice, "patient"
             ):
                 frappe.throw(
                     f"This sales invoice: {self.sales_invoice} is not for this patient: {self.patient}"
                 )
 
-            if self.inpatient_record and self.patient != frappe.db.get_value(
+            if self.inpatient_record and self.patient != frappe.get_cached_value(
                 "Inpatient Record", self.inpatient_record, "patient"
             ):
                 frappe.throw(
@@ -69,7 +69,7 @@ class PatientDiscountRequest(Document):
                 self.insurance_subscription,
                 self.insurance_coverage_plan,
                 self.insurance_company,
-            ) = frappe.db.get_value(
+            ) = frappe.get_cached_value(
                 "Patient Appointment",
                 self.appointment,
                 [
@@ -92,7 +92,7 @@ class PatientDiscountRequest(Document):
 
     def set_discount_amount(self):
         if self.apply_discount_on == "Grand Total" and self.sales_invoice:
-            self.total_actual_amount = frappe.db.get_value(
+            self.total_actual_amount = frappe.get_cached_value(
                 "Sales Invoice", self.sales_invoice, "grand_total"
             )
             discount_amount = 0
@@ -108,7 +108,7 @@ class PatientDiscountRequest(Document):
             self.total_discounted_amount = discount_amount
 
         elif self.apply_discount_on == "Net Total" and self.sales_invoice:
-            self.total_actual_amount = frappe.db.get_value(
+            self.total_actual_amount = frappe.get_cached_value(
                 "Sales Invoice", self.sales_invoice, "net_total"
             )
             discount_amount = 0

--- a/hms_tz/nhif/nhif_api/admission.py
+++ b/hms_tz/nhif/nhif_api/admission.py
@@ -64,7 +64,7 @@ def get_admission_types(company=None, caller=None):
             return
         
         for row in data:
-            admission = frappe.db.get_value("Healthcare Admission Type", {"admission_type_name": row["AdmissionTypeName"]}, "name")
+            admission = frappe.get_cached_value("Healthcare Admission Type", {"admission_type_name": row["AdmissionTypeName"]}, "name")
             if admission:
                 has_changed = False
                 doc = frappe.get_doc("Healthcare Admission Type", admission)
@@ -145,7 +145,7 @@ def get_discharge_types(company=None, caller=None):
             return
         
         for row in data:
-            discharge_type = frappe.db.get_value("Healthcare Discharge Type", {"discharge_type_name": row["DischargeTypeName"]}, "name")
+            discharge_type = frappe.get_cached_value("Healthcare Discharge Type", {"discharge_type_name": row["DischargeTypeName"]}, "name")
             if discharge_type:
                 has_changed = False
                 doc = frappe.get_doc("Healthcare Discharge Type", discharge_type)
@@ -226,7 +226,7 @@ def get_ward_types(company=None, caller=None):
             return
         
         for row in data:
-            ward_type = frappe.db.get_value("Healthcare Ward Type", {"ward_type_name": row["WardTypeName"]}, "name")
+            ward_type = frappe.get_cached_value("Healthcare Ward Type", {"ward_type_name": row["WardTypeName"]}, "name")
             if ward_type:
                 has_changed = False
                 doc = frappe.get_doc("Healthcare Ward Type", ward_type)
@@ -317,7 +317,7 @@ def get_room_types(company=None, caller=None):
             return
         
         for row in data:
-            room_type = frappe.db.get_value("Healthcare Room Type", {"room_type_name": row["RoomTypeName"]}, "name")
+            room_type = frappe.get_cached_value("Healthcare Room Type", {"room_type_name": row["RoomTypeName"]}, "name")
             if room_type:
                 has_changed = False
                 doc = frappe.get_doc("Healthcare Room Type", room_type)

--- a/hms_tz/nhif/nhif_api/price_package.py
+++ b/hms_tz/nhif/nhif_api/price_package.py
@@ -911,7 +911,7 @@ def  get_nhif_schemes(company=None, caller=None):
             return
         
         for row in data:
-            scheme_id = frappe.db.get_value("NHIF Scheme", {"scheme_id": row["SchemeID"]}, "name")
+            scheme_id = frappe.get_cached_value("NHIF Scheme", {"scheme_id": row["SchemeID"]}, "name")
             if scheme_id:
                 has_changed = False
                 doc = frappe.get_doc("NHIF Scheme", scheme_id)
@@ -1024,9 +1024,9 @@ def get_nhif_product_per_company(company, product_dict):
 def add_nhif_product(row, company, abbr):
     product_id = str(row["ProductCode"]) + "-" + str(abbr)
 
-    nhif_product_pr_key = frappe.db.get_value("NHIF Product", {"company": company, "nhif_product_code": row["ProductCode"]}, "name")
+    nhif_product_pr_key = frappe.get_cached_value("NHIF Product", {"company": company, "nhif_product_code": row["ProductCode"]}, "name")
     if not nhif_product_pr_key:
-        nhif_product_pr_key = frappe.db.get_value("NHIF Product", {"company": "", "nhif_product_code": row["ProductCode"]})
+        nhif_product_pr_key = frappe.get_cached_value("NHIF Product", {"company": "", "nhif_product_code": row["ProductCode"]})
 
     if nhif_product_pr_key:
         if (
@@ -1149,7 +1149,7 @@ def  get_item_types(company=None, caller=None):
         )
 
         for item in data:
-            item_type = frappe.db.get_value("NHIF Item Type", {"item_type_id": item["ItemTypeID"]}, "name")
+            item_type = frappe.get_cached_value("NHIF Item Type", {"item_type_id": item["ItemTypeID"]}, "name")
             if item_type:
                 has_changed = False
                 doc = frappe.get_doc("NHIF Item Type", item_type)

--- a/hms_tz/nhif/report/claims_reconciliation_report/claims_reconciliation_report.py
+++ b/hms_tz/nhif/report/claims_reconciliation_report/claims_reconciliation_report.py
@@ -139,7 +139,7 @@ def get_data(filters):
 
 def get_nhif_data(filters):
     token = get_claimsservice_token(filters.company)
-    claimsserver_url, facility_code = frappe.get_value(
+    claimsserver_url, facility_code = frappe.get_cached_value(
         "Company NHIF Settings", filters.company, ["claimsserver_url", "facility_code"]
     )
     headers = {"Authorization": "Bearer " + token, "Content-Type": "application/json"}

--- a/hms_tz/patches/custom_fields/add_fasttrack_and_follow_up_consultation_fields.py
+++ b/hms_tz/patches/custom_fields/add_fasttrack_and_follow_up_consultation_fields.py
@@ -151,7 +151,7 @@ def removed_type_custom_field():
     for row in fields:
         for key, value in row.items():
             for fieldname in value:
-                custom_field = frappe.get_value(
+                custom_field = frappe.get_cached_value(
                     "Custom Field", {"fieldname": fieldname, "dt": key}, "name"
                 )
                 if custom_field:

--- a/hms_tz/patches/custom_fields/custom_fields_for_medical_code.py
+++ b/hms_tz/patches/custom_fields/custom_fields_for_medical_code.py
@@ -10,7 +10,7 @@ def execute():
         "Therapy Plan Detail",
         "Diet Recommendation"
     ]:
-        custom_field_name = frappe.get_value("Custom Field", f"{doctype}-medical_code", "name")
+        custom_field_name = frappe.get_cached_value("Custom Field", f"{doctype}-medical_code", "name")
         if custom_field_name:
             frappe.db.set_value("Custom Field", f"{doctype}-medical_code", "reqd", 0)
     

--- a/hms_tz/patches/custom_fields/fasttrack_and_follow_up_consultation_fields.py
+++ b/hms_tz/patches/custom_fields/fasttrack_and_follow_up_consultation_fields.py
@@ -112,7 +112,7 @@ def removed_type_custom_field():
     for row in fields:
         for key, value in row.items():
             for fieldname in value:
-                custom_field = frappe.get_value(
+                custom_field = frappe.get_cached_value(
                     "Custom Field", {"fieldname": fieldname, "dt": key}, "name"
                 )
                 if custom_field:

--- a/hms_tz/patches/v2_0/migrate_hsu_into_the_child_table.py
+++ b/hms_tz/patches/v2_0/migrate_hsu_into_the_child_table.py
@@ -17,7 +17,7 @@ def execute():
             doc = frappe.get_doc(doctype, doc_name.get("name"))
             if not doc.healthcare_service_unit:
                 continue
-            company = frappe.get_value(
+            company = frappe.get_cached_value(
                 "Healthcare Service Unit", doc.healthcare_service_unit, "company"
             )
             row = doc.append("company_options", {})


### PR DESCRIPTION

- Updated multiple instances in the utils, nhif, and patches modules to replace `frappe.db.get_value` with `frappe.get_cached_value`.
- This change enhances the efficiency of data retrieval by utilizing cached values, reducing database load and improving response times.
- Affected files include utils.py, delivery_note.py, healthcare_utils.py, inpatient_record.py, medical_record.py, patient.py, patient_appointment.py, sales_invoice.py, sales_order.py, service_order.py, therapy_session.py, various doctype files, and patches.