### PR TITLE
perf: Replace get_doc with get_cached_doc for performance improvements

### DIFF
--- a/hms_tz/hms_tz/dashboard_chart_source/department_wise_patient_appointments/department_wise_patient_appointments.py
+++ b/hms_tz/hms_tz/dashboard_chart_source/department_wise_patient_appointments/department_wise_patient_appointments.py
@@ -20,7 +20,7 @@ def get(
     heatmap_year=None,
 ):
     if chart_name:
-        chart = frappe.get_doc("Dashboard Chart", chart_name)
+        chart = frappe.get_cached_doc("Dashboard Chart", chart_name)
     else:
         chart = frappe._dict(frappe.parse_json(chart))
 

--- a/hms_tz/hms_tz/doctype/clinical_procedure_template/clinical_procedure_template.py
+++ b/hms_tz/hms_tz/doctype/clinical_procedure_template/clinical_procedure_template.py
@@ -31,7 +31,7 @@ class ClinicalProcedureTemplate(Document):
 
     def update_item_and_item_price(self):
         if self.is_billable and self.item:
-            item_doc = frappe.get_doc("Item", {"item_code": self.item})
+            item_doc = frappe.get_cached_doc("Item", {"item_code": self.item})
             item_doc.item_name = self.template
             item_doc.item_group = self.item_group
             item_doc.description = self.description
@@ -39,7 +39,7 @@ class ClinicalProcedureTemplate(Document):
             item_doc.save(ignore_permissions=True)
 
             if self.rate:
-                item_price = frappe.get_doc("Item Price", {"item_code": self.item})
+                item_price = frappe.get_cached_doc("Item Price", {"item_code": self.item})
                 item_price.item_name = self.template
                 item_price.price_list_rate = self.rate
                 item_price.save()

--- a/hms_tz/hms_tz/doctype/drug_prescription/drug_prescription.py
+++ b/hms_tz/hms_tz/doctype/drug_prescription/drug_prescription.py
@@ -14,16 +14,16 @@ class DrugPrescription(Document):
         period = None
 
         if self.dosage:
-            dosage = frappe.get_doc("Prescription Dosage", self.dosage)
+            dosage = frappe.get_cached_doc("Prescription Dosage", self.dosage)
             for item in dosage.dosage_strength:
                 quantity += item.strength
             if self.period and self.interval:
-                period = frappe.get_doc("Prescription Duration", self.period)
+                period = frappe.get_cached_doc("Prescription Duration", self.period)
                 if self.interval < period.get_days():
                     quantity = quantity * (period.get_days() / self.interval)
 
         elif self.interval and self.interval_uom and self.period:
-            period = frappe.get_doc("Prescription Duration", self.period)
+            period = frappe.get_cached_doc("Prescription Duration", self.period)
             interval_in = self.interval_uom
             if interval_in == "Day" and self.interval < period.get_days():
                 quantity = period.get_days() / self.interval

--- a/hms_tz/hms_tz/doctype/healthcare_nursing_task/healthcare_nursing_task.py
+++ b/hms_tz/hms_tz/doctype/healthcare_nursing_task/healthcare_nursing_task.py
@@ -10,7 +10,7 @@ from frappe.model.document import Document
 class HealthcareNursingTask(Document):
     def on_update(self):
         if self.status:
-            clinical_procedure = frappe.get_doc(
+            clinical_procedure = frappe.get_cached_doc(
                 "Clinical Procedure", self.reference_docname
             )
             for nursing_tasks in clinical_procedure.nursing_tasks:

--- a/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.py
+++ b/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.py
@@ -69,7 +69,7 @@ class HealthcareReferral(Document):
 		
 		diagnosis = []
 		unique_diagnosis = []
-		encounter_doc = frappe.get_doc("Patient Encounter", self.encounter)
+		encounter_doc = frappe.get_cached_doc("Patient Encounter", self.encounter)
 		for d in encounter_doc.patient_encounter_final_diagnosis:
 			diagnosis.append({
 				"status": "Final",
@@ -99,7 +99,7 @@ class HealthcareReferral(Document):
 		
 		services = []
 		childs_map = get_childs_map()
-		encounter_doc = frappe.get_doc("Patient Encounter", self.encounter)
+		encounter_doc = frappe.get_cached_doc("Patient Encounter", self.encounter)
 
 		for child in childs_map:
 			if len(encounter_doc.get(child["table"])) == 0:

--- a/hms_tz/hms_tz/doctype/healthcare_service_request/healthcare_service_request.py
+++ b/hms_tz/hms_tz/doctype/healthcare_service_request/healthcare_service_request.py
@@ -397,7 +397,7 @@ def create_service_request(doc_obj=None, data=None):
 
 	if data:
 		data = json.loads(data)
-		doc = frappe.get_doc(data.get("source_doctype"), data.get("source_docname"))
+		doc = frappe.get_cached_doc(data.get("source_doctype"), data.get("source_docname"))
 	else:
 		doc = doc_obj
 	

--- a/hms_tz/hms_tz/doctype/healthcare_service_unit/healthcare_service_unit.py
+++ b/hms_tz/hms_tz/doctype/healthcare_service_unit/healthcare_service_unit.py
@@ -37,7 +37,7 @@ class HealthcareServiceUnit(NestedSet):
             self.overlap_appointments = 0
             self.inpatient_occupancy = 0
         elif self.service_unit_type:
-            service_unit_type = frappe.get_doc(
+            service_unit_type = frappe.get_cached_doc(
                 "Healthcare Service Unit Type", self.service_unit_type
             )
             self.allow_appointments = service_unit_type.allow_appointments

--- a/hms_tz/hms_tz/doctype/healthcare_service_unit_type/healthcare_service_unit_type.py
+++ b/hms_tz/hms_tz/doctype/healthcare_service_unit_type/healthcare_service_unit_type.py
@@ -126,7 +126,7 @@ def make_item_price(item, price_list_name, item_price):
 
 
 def update_item(doc):
-    item = frappe.get_doc("Item", doc.item)
+    item = frappe.get_cached_doc("Item", doc.item)
     if item:
         item.update(
             {

--- a/hms_tz/hms_tz/doctype/healthcare_service_unit_type/test_healthcare_service_unit_type.py
+++ b/hms_tz/hms_tz/doctype/healthcare_service_unit_type/test_healthcare_service_unit_type.py
@@ -19,7 +19,7 @@ class TestHealthcareServiceUnitType(unittest.TestCase):
 
 def get_unit_type():
     if frappe.db.exists("Healthcare Service Unit Type", "Inpatient Rooms"):
-        return frappe.get_doc("Healthcare Service Unit Type", "Inpatient Rooms")
+        return frappe.get_cached_doc("Healthcare Service Unit Type", "Inpatient Rooms")
 
     unit_type = frappe.new_doc("Healthcare Service Unit Type")
     unit_type.service_unit_type = "Inpatient Rooms"

--- a/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.py
+++ b/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.py
@@ -122,7 +122,7 @@ def schedule_inpatient(args):
     set_details_from_ip_order(inpatient_record, admission_order)
 
     # Patient details
-    patient = frappe.get_doc("Patient", admission_order["patient"])
+    patient = frappe.get_cached_doc("Patient", admission_order["patient"])
     inpatient_record.patient = patient.name
     inpatient_record.patient_name = patient.patient_name
     inpatient_record.gender = patient.sex
@@ -134,7 +134,7 @@ def schedule_inpatient(args):
     inpatient_record.scheduled_date = today()
 
     # Set encounter detials
-    encounter = frappe.get_doc(
+    encounter = frappe.get_cached_doc(
         "Patient Encounter", admission_order["admission_encounter"]
     )
     if encounter and encounter.symptoms:  # Symptoms
@@ -191,7 +191,7 @@ def schedule_discharge(args):
         "Patient", discharge_order["patient"], "inpatient_record"
     )
     if inpatient_record_id:
-        inpatient_record = frappe.get_doc("Inpatient Record", inpatient_record_id)
+        inpatient_record = frappe.get_cached_doc("Inpatient Record", inpatient_record_id)
         check_out_inpatient(inpatient_record)
         set_details_from_ip_order(inpatient_record, discharge_order)
         validate_discharge(inpatient_record)
@@ -229,7 +229,7 @@ def check_out_inpatient(inpatient_record):
             if inpatient_occupancy.left != 1:
                 inpatient_occupancy.left = True
                 inpatient_occupancy.check_out = now_datetime()
-                hsu = frappe.get_doc(
+                hsu = frappe.get_cached_doc(
                     "Healthcare Service Unit", inpatient_occupancy.service_unit
                 )
                 hsu.occupancy_status = "Vacant"
@@ -359,7 +359,7 @@ def transfer_patient(inpatient_record, service_unit, check_in):
 
     inpatient_record.save(ignore_permissions=True)
 
-    hsu = frappe.get_doc("Healthcare Service Unit", service_unit)
+    hsu = frappe.get_cached_doc("Healthcare Service Unit", service_unit)
     hsu.occupancy_status = "Occupied"
     hsu.save(ignore_permissions=True)
 
@@ -384,7 +384,7 @@ def patient_leave_service_unit(inpatient_record, check_out, leave_from):
                 inpatient_occupancy.left = True
                 inpatient_occupancy.check_out = check_out
 
-                hsu = frappe.get_doc(
+                hsu = frappe.get_cached_doc(
                     "Healthcare Service Unit", inpatient_occupancy.service_unit
                 )
                 hsu.occupancy_status = "Vacant"

--- a/hms_tz/hms_tz/doctype/inpatient_record/test_inpatient_record.py
+++ b/hms_tz/hms_tz/doctype/inpatient_record/test_inpatient_record.py
@@ -52,7 +52,7 @@ class TestInpatientRecord(unittest.TestCase):
             ),
         )
 
-        ip_record1 = frappe.get_doc("Inpatient Record", ip_record.name)
+        ip_record1 = frappe.get_cached_doc("Inpatient Record", ip_record.name)
         # Validate Pending Invoices
         self.assertRaises(frappe.ValidationError, ip_record.discharge)
         mark_invoiced_inpatient_occupancy(ip_record1)
@@ -92,7 +92,7 @@ def mark_invoiced_inpatient_occupancy(ip_record):
 
 
 def create_inpatient(patient):
-    patient_obj = frappe.get_doc("Patient", patient)
+    patient_obj = frappe.get_cached_doc("Patient", patient)
     inpatient_record = frappe.new_doc("Inpatient Record")
     inpatient_record.patient = patient
     inpatient_record.patient_name = patient_obj.patient_name

--- a/hms_tz/hms_tz/doctype/lab_test/lab_test.py
+++ b/hms_tz/hms_tz/doctype/lab_test/lab_test.py
@@ -95,8 +95,8 @@ class LabTest(Document):
 
 
 def create_test_from_template(lab_test):
-    template = frappe.get_doc("Lab Test Template", lab_test.template)
-    patient = frappe.get_doc("Patient", lab_test.patient)
+    template = frappe.get_cached_doc("Lab Test Template", lab_test.template)
+    patient = frappe.get_cached_doc("Patient", lab_test.patient)
 
     lab_test.lab_test_name = template.lab_test_name
     lab_test.result_date = getdate()
@@ -143,10 +143,10 @@ def create_multiple(doctype, docname):
 
 def create_lab_test_from_encounter(encounter):
     lab_test_created = False
-    encounter = frappe.get_doc("Patient Encounter", encounter)
+    encounter = frappe.get_cached_doc("Patient Encounter", encounter)
 
     if encounter and encounter.lab_test_prescription:
-        patient = frappe.get_doc("Patient", encounter.patient)
+        patient = frappe.get_cached_doc("Patient", encounter.patient)
         for item in encounter.lab_test_prescription:
             if not item.lab_test_created:
                 template = get_lab_test_template(item.lab_test_code)
@@ -171,9 +171,9 @@ def create_lab_test_from_encounter(encounter):
 
 def create_lab_test_from_invoice(sales_invoice):
     lab_tests_created = False
-    invoice = frappe.get_doc("Sales Invoice", sales_invoice)
+    invoice = frappe.get_cached_doc("Sales Invoice", sales_invoice)
     if invoice and invoice.patient:
-        patient = frappe.get_doc("Patient", invoice.patient)
+        patient = frappe.get_cached_doc("Patient", invoice.patient)
         for item in invoice.items:
             lab_test_created = 0
             if item.reference_dt == "Lab Prescription":
@@ -215,7 +215,7 @@ def create_lab_test_from_invoice(sales_invoice):
 def get_lab_test_template(item):
     template_id = frappe.db.exists("Lab Test Template", {"item": item})
     if template_id:
-        return frappe.get_doc("Lab Test Template", template_id)
+        return frappe.get_cached_doc("Lab Test Template", template_id)
     return False
 
 
@@ -293,7 +293,7 @@ def create_sample_doc(template, patient, invoice, company=None):
 
         if sample_exists:
             # update sample collection by adding quantity
-            sample_collection = frappe.get_doc("Sample Collection", sample_exists[0][0])
+            sample_collection = frappe.get_cached_doc("Sample Collection", sample_exists[0][0])
             quantity = int(sample_collection.sample_qty) + int(template.sample_qty)
             if template.sample_details:
                 sample_details = (
@@ -378,7 +378,7 @@ def load_result_format(lab_test, template, prescription, invoice):
         for lab_test_group in template.lab_test_groups:
             # Template_in_group = None
             if lab_test_group.lab_test_template:
-                template_in_group = frappe.get_doc(
+                template_in_group = frappe.get_cached_doc(
                     "Lab Test Template", lab_test_group.lab_test_template
                 )
                 if template_in_group:
@@ -427,7 +427,7 @@ def load_result_format(lab_test, template, prescription, invoice):
 def get_employee_by_user_id(user_id):
     emp_id = frappe.db.exists("Employee", {"user_id": user_id})
     if emp_id:
-        return frappe.get_doc("Employee", emp_id)
+        return frappe.get_cached_doc("Employee", emp_id)
     return None
 
 

--- a/hms_tz/hms_tz/doctype/lab_test/test_lab_test.py
+++ b/hms_tz/hms_tz/doctype/lab_test/test_lab_test.py
@@ -102,7 +102,7 @@ class TestLabTest(unittest.TestCase):
 def create_lab_test_template(test_sensitivity=0, sample_collection=1):
     medical_department = create_medical_department()
     if frappe.db.exists("Lab Test Template", "Insulin Resistance"):
-        return frappe.get_doc("Lab Test Template", "Insulin Resistance")
+        return frappe.get_cached_doc("Lab Test Template", "Insulin Resistance")
     template = frappe.new_doc("Lab Test Template")
     template.lab_test_name = "Insulin Resistance"
     template.lab_test_template_type = "Descriptive"

--- a/hms_tz/hms_tz/doctype/lab_test_template/lab_test_template.py
+++ b/hms_tz/hms_tz/doctype/lab_test_template/lab_test_template.py
@@ -67,7 +67,7 @@ class LabTestTemplate(Document):
                 frappe.db.set_value("Item", self.item, "disabled", 0)
 
     def update_item(self):
-        item = frappe.get_doc("Item", self.item)
+        item = frappe.get_cached_doc("Item", self.item)
         if item:
             item.update(
                 {

--- a/hms_tz/hms_tz/doctype/limit_change_request/limit_change_request.py
+++ b/hms_tz/hms_tz/doctype/limit_change_request/limit_change_request.py
@@ -90,7 +90,7 @@ class LimitChangeRequest(Document):
                 "Inpatient Record", self.inpatient_record, "cash_limit", self.cash_limit
             )
 
-            inpatient_record_doc = frappe.get_doc(
+            inpatient_record_doc = frappe.get_cached_doc(
                 "Inpatient Record", self.inpatient_record
             )
 
@@ -206,7 +206,7 @@ class LimitChangeRequest(Document):
             "therapies",
         ]
         for encounter in encounters:
-            encounter_doc = frappe.get_doc("Patient Encounter", encounter.name)
+            encounter_doc = frappe.get_cached_doc("Patient Encounter", encounter.name)
             for table_field in table_map:
                 if encounter_doc.get(table_field):
                     for item_row in encounter_doc.get(table_field):

--- a/hms_tz/hms_tz/doctype/lrpmt_returns/lrpmt_returns.py
+++ b/hms_tz/hms_tz/doctype/lrpmt_returns/lrpmt_returns.py
@@ -135,7 +135,7 @@ class LRPMTReturns(Document):
                 )
                 continue
 
-            doc = frappe.get_doc(item.reference_doctype, item.reference_docname)
+            doc = frappe.get_cached_doc(item.reference_doctype, item.reference_docname)
 
             if doc.docstatus < 2:
                 try:
@@ -231,7 +231,7 @@ class LRPMTReturns(Document):
         if unique_submitted_delivery_notes:
             for dn in unique_submitted_delivery_notes:
                 try:
-                    source_doc = frappe.get_doc("Delivery Note", dn)
+                    source_doc = frappe.get_cached_doc("Delivery Note", dn)
                     target_doc = return_drug_quantity_to_stock(self, source_doc)
 
                     if target_doc.get("name"):
@@ -264,7 +264,7 @@ class LRPMTReturns(Document):
 
         if returned_delivery_note_nos:
             for dn in returned_delivery_note_nos:
-                sales_doc = frappe.get_doc("Delivery Note", dn)
+                sales_doc = frappe.get_cached_doc("Delivery Note", dn)
 
                 for item in sales_doc.items:
                     for dd_n in self.drug_items:
@@ -321,7 +321,7 @@ class LRPMTReturns(Document):
                 amount = frappe.get_cached_value("Drug Prescription", item.child_name, "amount")
                 cost_amount += (amount * (item.quantity_prescribed - item.quantity_to_return)) or 0
 
-            encounter_doc = frappe.get_doc("Patient Encounter", encounters[0].name)
+            encounter_doc = frappe.get_cached_doc("Patient Encounter", encounters[0].name)
             validate_totals(encounter_doc, method="validate", show_alert=False)
 
             encounter_doc.current_total = abs(encounter_doc.current_total - cost_amount)
@@ -421,7 +421,7 @@ def update_therapy_session(
     total_sessions_cancelled,
 ):
     for session_id in item.get("therapy_session_ids"):
-        session_doc = frappe.get_doc("Therapy Session", session_id)
+        session_doc = frappe.get_cached_doc("Therapy Session", session_id)
         if session_doc.docstatus < 2:
             try:
                 apply_workflow(session_doc, "Not Serviced")
@@ -474,7 +474,7 @@ def update_drug_prescription_for_uncreated_delivery_note(self):
 
 def update_drug_description_for_draft_delivery_note(self, delivey_note):
     try:
-        dn_doc = frappe.get_doc("Delivery Note", delivey_note)
+        dn_doc = frappe.get_cached_doc("Delivery Note", delivey_note)
 
         if dn_doc.workflow_state != "Not Serviced":
             apply_workflow(dn_doc, "Not Serviced")
@@ -843,7 +843,7 @@ def get_patient_encounters(patient, appointment, company):
 
 @frappe.whitelist()
 def set_checked_lrp_items(doc, checked_items):
-    doc = frappe.get_doc(json.loads(doc))
+    doc = frappe.get_cached_doc(json.loads(doc))
     checked_items = json.loads(checked_items)
 
     doc.lrpt_items = []
@@ -1043,7 +1043,7 @@ def get_drugs(patient, appointment, company):
 
 @frappe.whitelist()
 def set_checked_drug_items(doc, checked_items):
-    doc = frappe.get_doc(json.loads(doc))
+    doc = frappe.get_cached_doc(json.loads(doc))
     checked_items = json.loads(checked_items)
 
     doc.drug_items = []
@@ -1187,7 +1187,7 @@ def get_therapies(patient, appointment, company):
 
 @frappe.whitelist()
 def set_checked_therapy_items(doc, checked_items):
-    doc = frappe.get_doc(json.loads(doc))
+    doc = frappe.get_cached_doc(json.loads(doc))
     checked_items = json.loads(checked_items)
 
     doc.therapy_items = []

--- a/hms_tz/hms_tz/doctype/medication/medication.py
+++ b/hms_tz/hms_tz/doctype/medication/medication.py
@@ -32,7 +32,7 @@ class Medication(Document):
 
     def update_item_and_item_price(self):
         if self.is_billable and self.item:
-            item_doc = frappe.get_doc("Item", {"item_code": self.item})
+            item_doc = frappe.get_cached_doc("Item", {"item_code": self.item})
             item_doc.item_name = self.medication_name
             item_doc.item_group = self.item_group
             item_doc.description = self.description
@@ -41,7 +41,7 @@ class Medication(Document):
             item_doc.save(ignore_permissions=True)
 
             if self.rate:
-                item_price = frappe.get_doc("Item Price", {"item_code": self.item})
+                item_price = frappe.get_cached_doc("Item Price", {"item_code": self.item})
                 item_price.item_name = self.medication_name
                 item_price.price_list_rate = self.rate
                 item_price.save()

--- a/hms_tz/hms_tz/doctype/patient/patient.py
+++ b/hms_tz/hms_tz/doctype/patient/patient.py
@@ -51,7 +51,7 @@ class Patient(Document):
 
     def on_update(self):
         if self.customer:
-            customer = frappe.get_doc("Customer", self.customer)
+            customer = frappe.get_cached_doc("Customer", self.customer)
             if self.customer_group:
                 customer.customer_group = self.customer_group
             if self.territory:
@@ -186,7 +186,7 @@ class Patient(Document):
         if user:
             contact_name = frappe.db.exists("Contact", {"user": user})
             if contact_name:
-                contact = frappe.get_doc("Contact", contact_name)
+                contact = frappe.get_cached_doc("Contact", contact_name)
                 if contact:
                     contact.is_primary_contact = True
                     contact.append(
@@ -355,7 +355,7 @@ def update_contacts(doc):
 
     if existing_contacts:
         for contact_name in existing_contacts:
-            contact = frappe.get_doc("Contact", contact_name.get("name"))
+            contact = frappe.get_cached_doc("Contact", contact_name.get("name"))
             _update_contacts(doc, contact)
 
 
@@ -388,7 +388,7 @@ def make_contact(doc):
             if not contact_name:
                 return
 
-            contact = frappe.get_doc("Contact", contact_name)
+            contact = frappe.get_cached_doc("Contact", contact_name)
             _update_contacts(doc, contact)
         else:
             frappe.log_error(frappe.get_traceback(), _("Contact Creation Failed"))

--- a/hms_tz/hms_tz/doctype/patient/test_patient.py
+++ b/hms_tz/hms_tz/doctype/patient/test_patient.py
@@ -25,7 +25,7 @@ class TestPatient(unittest.TestCase):
         settings.save()
 
         patient = create_patient()
-        patient = frappe.get_doc("Patient", patient)
+        patient = frappe.get_cached_doc("Patient", patient)
         self.assertEqual(patient.status, "Disabled")
 
         # check sales invoice and patient status

--- a/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.py
+++ b/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.py
@@ -317,7 +317,7 @@ def get_appointment_item(appointment_doc, item):
 
 
 def cancel_appointment(appointment_id):
-    appointment = frappe.get_doc("Patient Appointment", appointment_id)
+    appointment = frappe.get_cached_doc("Patient Appointment", appointment_id)
     if appointment.invoiced:
         sales_invoice = check_sales_invoice_exists(appointment)
         if sales_invoice and cancel_sales_invoice(sales_invoice):
@@ -355,7 +355,7 @@ def check_sales_invoice_exists(appointment):
     )
 
     if sales_invoice:
-        sales_invoice = frappe.get_doc("Sales Invoice", sales_invoice)
+        sales_invoice = frappe.get_cached_doc("Sales Invoice", sales_invoice)
         return sales_invoice
     return False
 
@@ -372,7 +372,7 @@ def get_availability_data(date, practitioner):
     date = getdate(date)
     weekday = date.strftime("%A")
 
-    practitioner_doc = frappe.get_doc("Healthcare Practitioner", practitioner)
+    practitioner_doc = frappe.get_cached_doc("Healthcare Practitioner", practitioner)
 
     check_employee_wise_availability(date, practitioner_doc)
     present_events = get_present_event(practitioner, date)
@@ -494,7 +494,7 @@ def get_available_slots(practitioner_doc, date):
 
     for schedule_entry in practitioner_doc.practitioner_schedules:
         if schedule_entry.schedule:
-            practitioner_schedule = frappe.get_doc(
+            practitioner_schedule = frappe.get_cached_doc(
                 "Practitioner Schedule", schedule_entry.schedule
             )
         else:
@@ -768,7 +768,7 @@ def send_appointment_reminder():
         )
 
         for appointment in appointment_list:
-            doc = frappe.get_doc("Patient Appointment", appointment.name)
+            doc = frappe.get_cached_doc("Patient Appointment", appointment.name)
             message = frappe.db.get_single_value(
                 "Healthcare Settings", "appointment_reminder_msg"
             )
@@ -887,7 +887,7 @@ def update_appointment_status():
     )
 
     for appointment in appointments:
-        frappe.get_doc("Patient Appointment", appointment.name).set_status()
+        frappe.get_cached_doc("Patient Appointment", appointment.name).set_status()
 
 
 def make_insurance_claim(doc):

--- a/hms_tz/hms_tz/doctype/patient_appointment/test_patient_appointment.py
+++ b/hms_tz/hms_tz/doctype/patient_appointment/test_patient_appointment.py
@@ -249,7 +249,7 @@ def create_healthcare_service_items():
 
 def create_clinical_procedure_template():
     if frappe.db.exists("Clinical Procedure Template", "Knee Surgery and Rehab"):
-        return frappe.get_doc("Clinical Procedure Template", "Knee Surgery and Rehab")
+        return frappe.get_cached_doc("Clinical Procedure Template", "Knee Surgery and Rehab")
     template = frappe.new_doc("Clinical Procedure Template")
     template.template = "Knee Surgery and Rehab"
     template.item_code = "Knee Surgery and Rehab"

--- a/hms_tz/hms_tz/doctype/patient_encounter/patient_encounter.py
+++ b/hms_tz/hms_tz/doctype/patient_encounter/patient_encounter.py
@@ -116,7 +116,7 @@ def set_subject_field(encounter):
 def create_healthcare_service_order(encounter):
     if encounter.drug_prescription:
         for drug in encounter.drug_prescription:
-            medication = frappe.get_doc("Medication", drug.drug_code)
+            medication = frappe.get_cached_doc("Medication", drug.drug_code)
             args = {
                 "healthcare_service_order_category": medication.get_value(
                     "healthcare_service_order_category"
@@ -150,7 +150,7 @@ def create_healthcare_service_order(encounter):
             make_healthcare_service_order(args)
     if encounter.lab_test_prescription:
         for labtest in encounter.lab_test_prescription:
-            lab_template = frappe.get_doc("Lab Test Template", labtest.lab_test_code)
+            lab_template = frappe.get_cached_doc("Lab Test Template", labtest.lab_test_code)
             args = {
                 "healthcare_service_order_category": lab_template.get_value(
                     "healthcare_service_order_category"
@@ -187,7 +187,7 @@ def create_healthcare_service_order(encounter):
             make_healthcare_service_order(args)
     if encounter.procedure_prescription:
         for procedure in encounter.procedure_prescription:
-            procedure_template = frappe.get_doc(
+            procedure_template = frappe.get_cached_doc(
                 "Clinical Procedure Template", procedure.procedure
             )
             args = {
@@ -227,7 +227,7 @@ def create_healthcare_service_order(encounter):
             make_healthcare_service_order(args)
     if encounter.therapies:
         for therapy in encounter.therapies:
-            therapy_type = frappe.get_doc("Therapy Type", therapy.therapy_type)
+            therapy_type = frappe.get_cached_doc("Therapy Type", therapy.therapy_type)
             args = {
                 "healthcare_service_order_category": therapy_type.get_value(
                     "healthcare_service_order_category"
@@ -262,7 +262,7 @@ def create_healthcare_service_order(encounter):
             make_healthcare_service_order(args)
     if encounter.radiology_procedure_prescription:
         for radiology in encounter.radiology_procedure_prescription:
-            radiology_template = frappe.get_doc(
+            radiology_template = frappe.get_cached_doc(
                 "Radiology Examination Template",
                 radiology.radiology_examination_template,
             )
@@ -335,16 +335,16 @@ def get_quantity(self):
     period = None
 
     if self.dosage:
-        dosage = frappe.get_doc("Prescription Dosage", self.dosage)
+        dosage = frappe.get_cached_doc("Prescription Dosage", self.dosage)
         for item in dosage.dosage_strength:
             quantity += item.strength
         if self.period and self.interval:
-            period = frappe.get_doc("Prescription Duration", self.period)
+            period = frappe.get_cached_doc("Prescription Duration", self.period)
             if self.interval < period.get_days():
                 quantity = quantity * (period.get_days() / self.interval)
 
     elif self.interval and self.interval_uom and self.period:
-        period = frappe.get_doc("Prescription Duration", self.period)
+        period = frappe.get_cached_doc("Prescription Duration", self.period)
         interval_in = self.interval_uom
         if interval_in == "Day" and self.interval < period.get_days():
             quantity = period.get_days() / self.interval

--- a/hms_tz/hms_tz/doctype/radiology_examination/radiology_examination.py
+++ b/hms_tz/hms_tz/doctype/radiology_examination/radiology_examination.py
@@ -91,7 +91,7 @@ def get_radiology_procedure_prescribed(patient, encounter_practitioner=False):
 
 @frappe.whitelist()
 def create_radiology_examination(appointment):
-    appointment = frappe.get_doc("Patient Appointment", appointment)
+    appointment = frappe.get_cached_doc("Patient Appointment", appointment)
     radiology_examination = frappe.new_doc("Radiology Examination")
     radiology_examination.appointment = appointment.name
     radiology_examination.patient = appointment.patient

--- a/hms_tz/hms_tz/doctype/therapy_session/therapy_session.py
+++ b/hms_tz/hms_tz/doctype/therapy_session/therapy_session.py
@@ -75,7 +75,7 @@ class TherapySession(Document):
         self.update_sessions_count_in_therapy_plan(on_cancel=True)
 
     def update_sessions_count_in_therapy_plan(self, on_cancel=False):
-        therapy_plan = frappe.get_doc("Therapy Plan", self.therapy_plan)
+        therapy_plan = frappe.get_cached_doc("Therapy Plan", self.therapy_plan)
         for entry in therapy_plan.therapy_plan_details:
             if entry.therapy_type == self.therapy_type:
                 if on_cancel:
@@ -100,7 +100,7 @@ class TherapySession(Document):
 @frappe.whitelist()
 def create_therapy_session(source_name, target_doc=None):
     def set_missing_values(source, target):
-        therapy_type = frappe.get_doc("Therapy Type", source.therapy_type)
+        therapy_type = frappe.get_cached_doc("Therapy Type", source.therapy_type)
         target.exercises = therapy_type.exercises
 
     doc = get_mapped_doc(

--- a/hms_tz/hms_tz/doctype/therapy_type/test_therapy_type.py
+++ b/hms_tz/hms_tz/doctype/therapy_type/test_therapy_type.py
@@ -39,7 +39,7 @@ def create_therapy_type():
         )
         therapy_type.save()
     else:
-        therapy_type = frappe.get_doc("Therapy Type", "Basic Rehab")
+        therapy_type = frappe.get_cached_doc("Therapy Type", "Basic Rehab")
     return therapy_type
 
 

--- a/hms_tz/hms_tz/doctype/therapy_type/therapy_type.py
+++ b/hms_tz/hms_tz/doctype/therapy_type/therapy_type.py
@@ -34,7 +34,7 @@ class TherapyType(Document):
 
     def update_item_and_item_price(self):
         if self.is_billable and self.item:
-            item_doc = frappe.get_doc("Item", {"item_code": self.item})
+            item_doc = frappe.get_cached_doc("Item", {"item_code": self.item})
             item_doc.item_name = self.item_name
             item_doc.item_group = self.item_group
             item_doc.description = self.description
@@ -43,7 +43,7 @@ class TherapyType(Document):
             item_doc.save(ignore_permissions=True)
 
             if self.rate:
-                item_price = frappe.get_doc("Item Price", {"item_code": self.item})
+                item_price = frappe.get_cached_doc("Item Price", {"item_code": self.item})
                 item_price.item_name = self.item_name
                 item_price.price_list_name = self.rate
                 item_price.ignore_mandatory = True

--- a/hms_tz/hms_tz/report/vc_payment_report/vc_payment_report.py
+++ b/hms_tz/hms_tz/report/vc_payment_report/vc_payment_report.py
@@ -170,7 +170,7 @@ def get_commission_doc_details(filters):
         order_by="valid_from desc",
         limit=1,
     )
-    commission_doc = frappe.get_doc("Visiting Comission", commission_list[0].name)
+    commission_doc = frappe.get_cached_doc("Visiting Comission", commission_list[0].name)
     excluded_services_map = {}
     for row in commission_doc.excluded_service_rates:
         excluded_services_map.setdefault(row.document_type, []).append(row)

--- a/hms_tz/hms_tz/report/visiting_consultant_charges_report/visiting_consultant_charges_report.py
+++ b/hms_tz/hms_tz/report/visiting_consultant_charges_report/visiting_consultant_charges_report.py
@@ -170,7 +170,7 @@ def get_commission_doc_details(filters):
         order_by="valid_from desc",
         limit=1,
     )
-    commission_doc = frappe.get_doc("Visiting Comission", commission_list[0].name)
+    commission_doc = frappe.get_cached_doc("Visiting Comission", commission_list[0].name)
     excluded_services_map = {}
     for row in commission_doc.excluded_service_rates:
         excluded_services_map.setdefault(row.document_type, []).append(row)

--- a/hms_tz/hms_tz/utils.py
+++ b/hms_tz/hms_tz/utils.py
@@ -18,7 +18,7 @@ from hms_tz.hms_tz.doctype.lab_test.lab_test import create_multiple
 
 @frappe.whitelist()
 def get_healthcare_services_to_invoice(patient, company):
-    patient = frappe.get_doc("Patient", patient)
+    patient = frappe.get_cached_doc("Patient", patient)
     items_to_invoice = []
     if patient:
         validate_customer_created(patient)
@@ -738,7 +738,7 @@ def check_fee_validity(appointment):
     if not validity:
         return
 
-    validity = frappe.get_doc("Fee Validity", validity)
+    validity = frappe.get_cached_doc("Fee Validity", validity)
     return validity
 
 
@@ -774,9 +774,9 @@ def manage_doc_for_appointment(dt_from_appointment, appointment, invoiced):
 
 @frappe.whitelist()
 def get_drugs_to_invoice(encounter):
-    encounter = frappe.get_doc("Patient Encounter", encounter)
+    encounter = frappe.get_cached_doc("Patient Encounter", encounter)
     if encounter:
-        patient = frappe.get_doc("Patient", encounter.patient)
+        patient = frappe.get_cached_doc("Patient", encounter.patient)
         if patient:
             if patient.customer:
                 items_to_invoice = []
@@ -905,7 +905,7 @@ def render_docs_as_html(docs):
 @frappe.whitelist()
 def render_doc_as_html(doctype, docname, exclude_fields=[]):
     # render document as html, three column layout will break
-    doc = frappe.get_doc(doctype, docname)
+    doc = frappe.get_cached_doc(doctype, docname)
     meta = frappe.get_meta(doctype)
     doc_html = "<div class='col-md-12 col-sm-12'>"
     section_html = ""
@@ -1054,7 +1054,7 @@ def render_doc_as_html(doctype, docname, exclude_fields=[]):
 
 def update_address_link(address, method):
     # Healthcare Service Invoice.
-    domain_settings = frappe.get_doc("Domain Settings")
+    domain_settings = frappe.get_cached_doc("Domain Settings")
     active_domains = [d.domain for d in domain_settings.active_domains]
 
     if "Healthcare" in active_domains:
@@ -1291,7 +1291,7 @@ def get_insurance_details(service, insurance_subscription, billing_item):
     price_list_rate = 0
     claim_discount = 0
     is_auto_approval = 0
-    insurance_subscription = frappe.get_doc(
+    insurance_subscription = frappe.get_cached_doc(
         "Healthcare Insurance Subscription", insurance_subscription
     )
     if insurance_subscription and valid_insurance(
@@ -1422,7 +1422,7 @@ def render_doc_as_html(doctype, docname, exclude_fields=None, use_setttings=Fals
     Render document as HTML
     """
     exclude_fields = exclude_fields or []
-    doc = frappe.get_doc(doctype, docname)
+    doc = frappe.get_cached_doc(doctype, docname)
     meta = frappe.get_meta(doctype)
     doc_html = section_html = section_label = html = ""
     sec_on = has_data = False

--- a/hms_tz/nhif/api/clinical_procedure.py
+++ b/hms_tz/nhif/api/clinical_procedure.py
@@ -60,7 +60,7 @@ def before_submit(doc, method):
 
 def create_delivery_note(doc):
     if doc.ref_doctype and doc.ref_docname and doc.ref_doctype == "Patient Encounter":
-        patient_encounter_doc = frappe.get_doc(doc.ref_doctype, doc.ref_docname)
+        patient_encounter_doc = frappe.get_cached_doc(doc.ref_doctype, doc.ref_docname)
         create_delivery_note_from_LRPT(doc, patient_encounter_doc)
 
 

--- a/hms_tz/nhif/api/delivery_note.py
+++ b/hms_tz/nhif/api/delivery_note.py
@@ -63,7 +63,7 @@ def update_dosage_details(item):
         if not reference_dn:
             return
 
-        drug_doc = frappe.get_doc("Drug Prescription", reference_dn)
+        drug_doc = frappe.get_cached_doc("Drug Prescription", reference_dn)
 
         description = ", <br>".join(
             [
@@ -265,7 +265,7 @@ def on_submit(doc, method):
 def update_drug_prescription(doc):
     if doc.patient and not doc.is_return:
         if doc.form_sales_invoice:
-            sales_invoice_doc = frappe.get_doc("Sales Invoice", doc.form_sales_invoice)
+            sales_invoice_doc = frappe.get_cached_doc("Sales Invoice", doc.form_sales_invoice)
 
             for item in sales_invoice_doc.items:
                 if item.reference_dt == "Drug Prescription":
@@ -312,7 +312,7 @@ def update_drug_prescription(doc):
 
         else:
             if doc.reference_doctype == "Patient Encounter":
-                patient_encounter_doc = frappe.get_doc(
+                patient_encounter_doc = frappe.get_cached_doc(
                     doc.reference_doctype, doc.reference_name
                 )
 
@@ -466,7 +466,7 @@ def convert_to_instock_item(name, row):
             "doctype": "Delivery Note Item",
         }
     )
-    doc = frappe.get_doc("Delivery Note", name)
+    doc = frappe.get_cached_doc("Delivery Note", name)
     prev_size = len(doc.items)
     doc.append("items", new_row)
 
@@ -502,7 +502,7 @@ def check_cash_drugs_from_encounter(doc):
         and doc.reference_name
         and doc.reference_doctype == "Patient Encounter"
     ):
-        encounter_doc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
+        encounter_doc = frappe.get_cached_doc(doc.reference_doctype, doc.reference_name)
         if encounter_doc.insurance_subscription:
             cash_drugs = [
                 row.drug_code

--- a/hms_tz/nhif/api/healthcare_utils.py
+++ b/hms_tz/nhif/api/healthcare_utils.py
@@ -95,7 +95,7 @@ def get_healthcare_services_to_invoice(
         if not inpatient_record and i.inpatient_record:
             inpatient_record = i.inpatient_record
 
-        encounter_doc = frappe.get_doc("Patient Encounter", i.name)
+        encounter_doc = frappe.get_cached_doc("Patient Encounter", i.name)
 
         for key, value in childs_map.items():
             table = encounter_doc.get(value.get("table"))
@@ -181,7 +181,7 @@ def get_healthcare_services_to_invoice(
     
     # Get services from Inpatient Record
     if inpatient_record:
-        inpatient_doc = frappe.get_doc("Inpatient Record", inpatient_record)
+        inpatient_doc = frappe.get_cached_doc("Inpatient Record", inpatient_record)
         for row in inpatient_doc.inpatient_occupancies:
             if row.is_confirmed == 0 or row.invoiced == 1:
                 continue
@@ -704,7 +704,7 @@ def get_restricted_LRPT(doc):
 def set_healthcare_services(doc, checked_values):
     import json
 
-    doc = frappe.get_doc(json.loads(doc))
+    doc = frappe.get_cached_doc(json.loads(doc))
     checked_values = json.loads(checked_values)
     doc.items = []
 
@@ -853,7 +853,7 @@ def create_healthcare_docs(reference_encounter, encounter_list=[], method="event
         )
 
     for encounter in encounter_list:
-        encounter_doc = frappe.get_doc("Patient Encounter", encounter)
+        encounter_doc = frappe.get_cached_doc("Patient Encounter", encounter)
 
         create_lrp_docs(encounter_doc)
         create_therapy_plan(enc_doc=encounter_doc)
@@ -1179,7 +1179,7 @@ def create_therapy_plan(enc_doc=None, invoice_therapy_dict=[]):
 
             if therapy_child.parent not in encounter_ids:
                 encounter_ids.append(therapy_child.parent)
-                enc_doc = frappe.get_doc("Patient Encounter", therapy_child.parent)
+                enc_doc = frappe.get_cached_doc("Patient Encounter", therapy_child.parent)
                 patient_encounter_docs.append(enc_doc)
 
             if (
@@ -1741,7 +1741,7 @@ def set_uninvoiced_so_closed():
         },
     )
     for so in uninvoiced_so_list:
-        so_doc = frappe.get_doc("Sales Order", so.name)
+        so_doc = frappe.get_cached_doc("Sales Order", so.name)
         so_doc.update_status("Closed")
 
 
@@ -1807,7 +1807,7 @@ def delete_or_cancel_draft_document():
 
     for app_doc in appointments:
         try:
-            doc = frappe.get_doc("Patient Appointment", app_doc.name)
+            doc = frappe.get_cached_doc("Patient Appointment", app_doc.name)
             doc.status = "Cancelled"
             doc.save(ignore_permissions=True)
 
@@ -1846,7 +1846,7 @@ def delete_or_cancel_draft_document():
     )
 
     for delivery_note in delivery_documents:
-        delivery_note_doc = frappe.get_doc("Delivery Note", delivery_note.name)
+        delivery_note_doc = frappe.get_cached_doc("Delivery Note", delivery_note.name)
         try:
             return_quatity_or_cancel_delivery_note_via_lrpmt_returns(
                 delivery_note_doc, "Backend"
@@ -1870,7 +1870,7 @@ def return_quatity_or_cancel_delivery_note_via_lrpmt_returns(source_doc, method)
     Cancel draft delivery note if all items was not serviced
     """
 
-    source_doc = frappe.get_doc(frappe.parse_json(source_doc))
+    source_doc = frappe.get_cached_doc(frappe.parse_json(source_doc))
 
     status = ""
     if source_doc.docstatus == 1:
@@ -1949,7 +1949,7 @@ def create_invoiced_items_if_not_created():
     ).run(as_dict=1)
 
     for invoice in si_invoices:
-        si_doc = frappe.get_doc("Sales Invoice", invoice.name)
+        si_doc = frappe.get_cached_doc("Sales Invoice", invoice.name)
 
         therapy_items = []
 
@@ -1963,8 +1963,8 @@ def create_invoiced_items_if_not_created():
                     continue
 
                 try:
-                    child = frappe.get_doc(item.reference_dt, item.reference_dn)
-                    patient_encounter_doc = frappe.get_doc(
+                    child = frappe.get_cached_doc(item.reference_dt, item.reference_dn)
+                    patient_encounter_doc = frappe.get_cached_doc(
                         "Patient Encounter", child.parent
                     )
 
@@ -2150,7 +2150,7 @@ def enqueue_auto_sending_of_patient_claims(setting_obj):
     success_count = 0
     failed_count = 0
     for claim in patient_claims:
-        doc = frappe.get_doc("NHIF Patient Claim", claim.name)
+        doc = frappe.get_cached_doc("NHIF Patient Claim", claim.name)
         try:
             doc.submit()
             doc.reload()

--- a/hms_tz/nhif/api/inpatient_record.py
+++ b/hms_tz/nhif/api/inpatient_record.py
@@ -49,7 +49,7 @@ def before_save(doc, method):
 def validate_inpatient_occupancies(doc):
     if doc.is_new():
         return
-    old_doc = frappe.get_doc(doc.doctype, doc.name)
+    old_doc = frappe.get_cached_doc(doc.doctype, doc.name)
     count = 0
     for old_row in old_doc.inpatient_occupancies:
         count += 1
@@ -78,7 +78,7 @@ def daily_update_inpatient_occupancies():
 
     for item in occupancies:
         try:
-            doc = frappe.get_doc("Inpatient Record", item.name)
+            doc = frappe.get_cached_doc("Inpatient Record", item.name)
             occupancies_len = len(doc.inpatient_occupancies)
             if occupancies_len > 0:
                 last_row = doc.inpatient_occupancies[occupancies_len - 1]
@@ -185,7 +185,7 @@ def make_deposit(
                 )
             )
 
-    inpatient_record_doc = frappe.get_doc("Inpatient Record", inpatient_record)
+    inpatient_record_doc = frappe.get_cached_doc("Inpatient Record", inpatient_record)
     if inpatient_record_doc.insurance_subscription:
         frappe.throw(_("You cannot make deposit for insurance patient"))
 

--- a/hms_tz/nhif/api/insurance_claim.py
+++ b/hms_tz/nhif/api/insurance_claim.py
@@ -11,7 +11,7 @@ from hms_tz.nhif.api.healthcare_utils import get_item_rate
 
 def set_patient_encounter(doc, method):
     if doc.reference_dn:
-        reference_doc = frappe.get_doc(doc.reference_dt, doc.reference_dn)
+        reference_doc = frappe.get_cached_doc(doc.reference_dt, doc.reference_dn)
         if reference_doc.parenttype and reference_doc.parenttype == "Patient Encounter":
             doc.order_encounter = reference_doc.parent
         elif doc.reference_dt == "Healthcare Service Order":

--- a/hms_tz/nhif/api/lab_test.py
+++ b/hms_tz/nhif/api/lab_test.py
@@ -153,7 +153,7 @@ def get_lab_test_template(lab_test_name):
 
 def create_delivery_note(doc):
     if doc.ref_doctype and doc.ref_docname and doc.ref_doctype == "Patient Encounter":
-        patient_encounter_doc = frappe.get_doc(doc.ref_doctype, doc.ref_docname)
+        patient_encounter_doc = frappe.get_cached_doc(doc.ref_doctype, doc.ref_docname)
         create_delivery_note_from_LRPT(doc, patient_encounter_doc)
 
 
@@ -210,7 +210,7 @@ def create_sample_collection(doc):
     )
 
     if len(sample_docname) > 0:
-        sample_doc = frappe.get_doc("Sample Collection", sample_docname[0].name)
+        sample_doc = frappe.get_cached_doc("Sample Collection", sample_docname[0].name)
         sample_doc.append(
             "lab_tests",
             {
@@ -315,7 +315,7 @@ def send_sms_for_lab_results(doc):
 def check_cash_payments_from_encounter(doc, ref_doctype, ref_docname_field, prescription_field, item_name_field, item_descriptor, additional_checks=None):
     # Ensure there is a valid reference to an encounter
     if getattr(doc, ref_docname_field) and getattr(doc, ref_doctype) == "Patient Encounter":
-        encounter_doc = frappe.get_doc("Patient Encounter", getattr(doc, ref_docname_field))
+        encounter_doc = frappe.get_cached_doc("Patient Encounter", getattr(doc, ref_docname_field))
         
         # Check for insurance subscription
         if encounter_doc.insurance_subscription:

--- a/hms_tz/nhif/api/patient_appointment.py
+++ b/hms_tz/nhif/api/patient_appointment.py
@@ -75,7 +75,7 @@ def get_cash_amount(
 
 @frappe.whitelist()
 def invoice_appointment(name):
-    appointment_doc = frappe.get_doc("Patient Appointment", name)
+    appointment_doc = frappe.get_cached_doc("Patient Appointment", name)
     if appointment_doc.billing_item:
         if appointment_doc.mode_of_payment:
             appointment_doc.paid_amount = get_cash_amount(
@@ -143,7 +143,7 @@ def invoice_appointment(name):
         sales_invoice.calculate_taxes_and_totals()
         sales_invoice.submit()
         frappe.msgprint(_(f"Sales Invoice {sales_invoice.name} created"))
-        appointment_doc = frappe.get_doc("Patient Appointment", appointment_doc.name)
+        appointment_doc = frappe.get_cached_doc("Patient Appointment", appointment_doc.name)
         appointment_doc.ref_sales_invoice = sales_invoice.name
         appointment_doc.invoiced = 1
         appointment_doc.db_update()
@@ -235,7 +235,7 @@ def get_consulting_charge_item(
 
 @frappe.whitelist()
 def create_vital(appointment):
-    appointment_doc = frappe.get_doc("Patient Appointment", appointment)
+    appointment_doc = frappe.get_cached_doc("Patient Appointment", appointment)
     make_vital(appointment_doc, "patient_appointment")
     appointment_doc.save()
     appointment_doc.reload()

--- a/hms_tz/nhif/api/radiology_examination.py
+++ b/hms_tz/nhif/api/radiology_examination.py
@@ -83,7 +83,7 @@ def on_cancel(doc, method):
 
 def create_delivery_note(doc):
     if doc.ref_doctype and doc.ref_docname and doc.ref_doctype == "Patient Encounter":
-        patient_encounter_doc = frappe.get_doc(doc.ref_doctype, doc.ref_docname)
+        patient_encounter_doc = frappe.get_cached_doc(doc.ref_doctype, doc.ref_docname)
         create_delivery_note_from_LRPT(doc, patient_encounter_doc)
 
 

--- a/hms_tz/nhif/api/sales_invoice.py
+++ b/hms_tz/nhif/api/sales_invoice.py
@@ -52,7 +52,7 @@ def validate_create_delivery_note(doc):
 
 @frappe.whitelist()
 def create_pending_healthcare_docs(doc_name):
-    doc = frappe.get_doc("Sales Invoice", doc_name)
+    doc = frappe.get_cached_doc("Sales Invoice", doc_name)
     create_healthcare_docs(doc, "From Front End")
 
 
@@ -122,14 +122,14 @@ def create_healthcare_docs(doc, method):
                 "Radiology Procedure Prescription",
                 "Procedure Prescription",
             ]:
-                child = frappe.get_doc(item.reference_dt, item.reference_dn)
+                child = frappe.get_cached_doc(item.reference_dt, item.reference_dn)
                 if child.is_cancelled == 1:
                     frappe.throw(
                         f"Item: {frappe.bold(item.item_code)} RowNo#: {frappe.bold(item.idx)} is already cancelled,\
                         Please confirm cancellation of this item on Patient Encounter and remove this item from sales invoice"
                     )
 
-                patient_encounter_doc = frappe.get_doc(
+                patient_encounter_doc = frappe.get_cached_doc(
                     "Patient Encounter", child.parent
                 )
                 if child.doctype == "Lab Prescription":
@@ -186,7 +186,7 @@ def create_healthcare_docs(doc, method):
             
             if len(healthcare_service_parents) > 0:
                 for row in healthcare_service_parents:
-                    hsr_doc = frappe.get_doc("Healthcare Service Request", row.service_request_no)
+                    hsr_doc = frappe.get_cached_doc("Healthcare Service Request", row.service_request_no)
                     hsr_doc.create_healthcare_service_docs()
 
 

--- a/hms_tz/nhif/api/service_order.py
+++ b/hms_tz/nhif/api/service_order.py
@@ -29,7 +29,7 @@ def set_missing_values(doc, method):
 
 @frappe.whitelist()
 def clear_insurance_details(service_order):
-    service_order_doc = frappe.get_doc("Healthcare Service Order", service_order)
+    service_order_doc = frappe.get_cached_doc("Healthcare Service Order", service_order)
     if service_order_doc.docstatus != 0:
         return
     insurance_claim = service_order_doc.insurance_claim
@@ -56,7 +56,7 @@ def clear_insurance_details(service_order):
         service_order_doc.order_reference_doctype
         and service_order_doc.order_reference_name
     ):
-        child_row_doc = frappe.get_doc(
+        child_row_doc = frappe.get_cached_doc(
             service_order_doc.order_reference_doctype,
             service_order_doc.order_reference_name,
         )
@@ -81,7 +81,7 @@ def auto_submit(kwargs):
     import time
 
     time.sleep(5)
-    doc = frappe.get_doc("Healthcare Service Order", kwargs)
+    doc = frappe.get_cached_doc("Healthcare Service Order", kwargs)
     if doc.docstatus == 0 and doc.order_reference_name:
         doc.flags.ignore_permissions = True
         doc.submit()
@@ -92,7 +92,7 @@ def real_auto_submit():
     hso_list = frappe.get_all("Healthcare Service Order", filters={"docstatus": 0})
     for hso in hso_list:
         try:
-            doc = frappe.get_doc("Healthcare Service Order", hso.name)
+            doc = frappe.get_cached_doc("Healthcare Service Order", hso.name)
             if doc.docstatus == 0 and doc.order_reference_name:
                 doc.flags.ignore_permissions = True
                 doc.submit()

--- a/hms_tz/nhif/api/therapy_session.py
+++ b/hms_tz/nhif/api/therapy_session.py
@@ -9,7 +9,7 @@ def before_insert(doc, method):
 
 def after_insert(doc, method):
     if doc.therapy_plan:
-        plan = frappe.get_doc("Therapy Plan", doc.therapy_plan)
+        plan = frappe.get_cached_doc("Therapy Plan", doc.therapy_plan)
         doc.hms_tz_insurance_coverage_plan = plan.hms_tz_insurance_coverage_plan
         doc.insurance_company = plan.insurance_company
         doc.ref_doctype = plan.ref_doctype

--- a/hms_tz/nhif/doctype/healthcare_package_order/healthcare_package_order.py
+++ b/hms_tz/nhif/doctype/healthcare_package_order/healthcare_package_order.py
@@ -78,21 +78,21 @@ class HealthcarePackageOrder(Document):
 	
 	def create_encounters(self):
 		if self.non_consultation_appointment:
-			appointment_doc = frappe.get_doc("Patient Appointment", self.non_consultation_appointment)
+			appointment_doc = frappe.get_cached_doc("Patient Appointment", self.non_consultation_appointment)
 			encounter = make_encounter(appointment_doc, "patient_encounter")
 			self.db_set("non_consultation_encounter", encounter, update_modified=False)
 			self.update_encounter_details(encounter, True)
 
 		for row in self.consultations:
 			if row.appointment:
-				appointment_doc = frappe.get_doc("Patient Appointment", row.appointment)
+				appointment_doc = frappe.get_cached_doc("Patient Appointment", row.appointment)
 				encounter = make_encounter(appointment_doc, "patient_encounter")
 				row.db_set("encounter", encounter, update_modified=False)
 				self.update_encounter_details(encounter)
 	
 	def update_encounter_details(self, encounter, has_items=False):
-		package_doc = frappe.get_doc("Healthcare Package", self.healthcare_package)
-		encounter_doc = frappe.get_doc("Patient Encounter", encounter)
+		package_doc = frappe.get_cached_doc("Healthcare Package", self.healthcare_package)
+		encounter_doc = frappe.get_cached_doc("Patient Encounter", encounter)
 		update_encounter_items(encounter_doc, package_doc, has_items)
 		encounter_doc.save(ignore_permissions=True)
 

--- a/hms_tz/nhif/doctype/lab_machine_message/lab_machine_message.py
+++ b/hms_tz/nhif/doctype/lab_machine_message/lab_machine_message.py
@@ -49,14 +49,14 @@ class LabMachineMessage(Document):
             profile_name = self.machine_model + "-" + self.machine_make
             profile_exists = frappe.db.exists("Lab Machine Profile", profile_name)
             if profile_exists:
-                profile = frappe.get_doc("Lab Machine Profile", profile_name)
+                profile = frappe.get_cached_doc("Lab Machine Profile", profile_name)
 
                 lab_test_name = profile.lab_test_prefix + self.lab_test_name
                 lab_test_exists = frappe.db.exists("Lab Test", lab_test_name)
                 if not lab_test_exists:
                     return
 
-                lab_test = frappe.get_doc("Lab Test", lab_test_name)
+                lab_test = frappe.get_cached_doc("Lab Test", lab_test_name)
                 if lab_test.docstatus != 0:
                     return
 

--- a/hms_tz/nhif/doctype/medication_change_request/medication_change_request.py
+++ b/hms_tz/nhif/doctype/medication_change_request/medication_change_request.py
@@ -366,7 +366,7 @@ class MedicationChangeRequest(Document):
                 )
 
     def update_encounter(self):
-        doc = frappe.get_doc("Patient Encounter", self.patient_encounter)
+        doc = frappe.get_cached_doc("Patient Encounter", self.patient_encounter)
         for line in self.original_pharmacy_prescription:
             for row in doc.drug_prescription:
                 if (
@@ -409,7 +409,7 @@ class MedicationChangeRequest(Document):
         return doc
 
     def update_sales_order(self, encounter_doc):
-        so_doc = frappe.get_doc("Sales Order", self.sales_order)
+        so_doc = frappe.get_cached_doc("Sales Order", self.sales_order)
         so_doc.items = []
         for row in encounter_doc.get("drug_prescription"):
             if (
@@ -471,7 +471,7 @@ class MedicationChangeRequest(Document):
         so_doc.reload()
 
     def update_delivery_note(self, encounter_doc):
-        dn_doc = frappe.get_doc("Delivery Note", self.delivery_note)
+        dn_doc = frappe.get_cached_doc("Delivery Note", self.delivery_note)
         dn_doc.items = []
         dn_doc.hms_tz_original_items = []
 
@@ -548,7 +548,7 @@ class MedicationChangeRequest(Document):
 
     def update_delivery_note_workflow(self, state, action, dn_doc=None):
         if not dn_doc:
-            dn_doc = frappe.get_doc("Delivery Note", self.delivery_note)
+            dn_doc = frappe.get_cached_doc("Delivery Note", self.delivery_note)
 
         if dn_doc.form_sales_invoice:
             url = get_url_to_form("sales Ivoice", dn_doc.form_sales_invoice)
@@ -635,7 +635,7 @@ def get_patient_encounter_name(delivery_note, sales_order):
 
 @frappe.whitelist()
 def get_patient_encounter_doc(patient_encounter):
-    doc = frappe.get_doc("Patient Encounter", patient_encounter)
+    doc = frappe.get_cached_doc("Patient Encounter", patient_encounter)
     return doc
 
 
@@ -688,13 +688,13 @@ def validate_healthcare_service_unit(warehouse, item, method):
 
 @frappe.whitelist()
 def get_items_on_change_of_delivery_note(name, encounter, delivery_note):
-    doc = frappe.get_doc("Medication Change Request", name)
+    doc = frappe.get_cached_doc("Medication Change Request", name)
 
     if not doc or not encounter or not delivery_note:
         return
 
     patient_encounter_doc = get_patient_encounter_doc(encounter)
-    delivery_note_doc = frappe.get_doc("Delivery Note", delivery_note)
+    delivery_note_doc = frappe.get_cached_doc("Delivery Note", delivery_note)
 
     doc.drug_prescription = []
     doc.original_pharmacy_prescription = []
@@ -718,7 +718,7 @@ def get_items_on_change_of_delivery_note(name, encounter, delivery_note):
 
 @frappe.whitelist()
 def get_items_on_change_of_sales_order(name, encounter, sales_order):
-    doc = frappe.get_doc("Medication Change Request", name)
+    doc = frappe.get_cached_doc("Medication Change Request", name)
 
     if not doc or not encounter or not sales_order:
         return
@@ -759,7 +759,7 @@ def set_original_items(name, item):
 
 @frappe.whitelist()
 def create_medication_change_request_from_dn(doctype, name):
-    source_doc = frappe.get_doc(doctype, name)
+    source_doc = frappe.get_cached_doc(doctype, name)
 
     if source_doc.form_sales_invoice:
         url = get_url_to_form("sales Ivoice", source_doc.form_sales_invoice)
@@ -797,7 +797,7 @@ def create_medication_change_request_from_dn(doctype, name):
 
 @frappe.whitelist()
 def create_medication_change_request_from_so(doctype, name):
-    source_doc = frappe.get_doc(doctype, name)
+    source_doc = frappe.get_cached_doc(doctype, name)
 
     if not source_doc.med_change_request_comment:
         frappe.throw(

--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -425,7 +425,7 @@ class NHIFPatientClaim(Document):
         self.clinical_notes = ""
         if not inpatient_record:
             for encounter in self.patient_encounters:
-                encounter_doc = frappe.get_doc("Patient Encounter", encounter.name)
+                encounter_doc = frappe.get_cached_doc("Patient Encounter", encounter.name)
 
                 self.set_clinical_notes(encounter_doc)
 
@@ -473,9 +473,9 @@ class NHIFPatientClaim(Document):
         else:
             dates = []
             occupancy_list = []
-            record_doc = frappe.get_doc("Inpatient Record", inpatient_record)
+            record_doc = frappe.get_cached_doc("Inpatient Record", inpatient_record)
 
-            admission_encounter_doc = frappe.get_doc(
+            admission_encounter_doc = frappe.get_cached_doc(
                 "Patient Encounter", record_doc.admission_encounter
             )
             for occupancy in record_doc.inpatient_occupancies:
@@ -569,7 +569,7 @@ class NHIFPatientClaim(Document):
                 for encounter in self.patient_encounters:
                     if str(encounter.encounter_date) != checkin_date:
                         continue
-                    encounter_doc = frappe.get_doc("Patient Encounter", encounter.name)
+                    encounter_doc = frappe.get_cached_doc("Patient Encounter", encounter.name)
 
                     # allow clinical notes to be added to the claim even if the service is not chargeable and encounters will be ignored
                     self.set_clinical_notes(encounter_doc)
@@ -647,7 +647,7 @@ class NHIFPatientClaim(Document):
 
         appointment_idx = 1
         for appointment_no in patient_appointment_list:
-            patient_appointment_doc = frappe.get_doc(
+            patient_appointment_doc = frappe.get_cached_doc(
                 "Patient Appointment", appointment_no
             )
 
@@ -811,7 +811,7 @@ class NHIFPatientClaim(Document):
             ).insert(ignore_permissions=True)
             new_folio_doc.reload()
         else:
-            folio_doc = frappe.get_doc("NHIF Folio Counter", folio_counter[0].name)
+            folio_doc = frappe.get_cached_doc("NHIF Folio Counter", folio_counter[0].name)
             folio_no = cint(folio_doc.folio_no) + 1
 
             folio_doc.folio_no += 1
@@ -841,7 +841,7 @@ class NHIFPatientClaim(Document):
         self.reload()
 
     def validate_appointment_info(self):
-        appointment_doc = frappe.get_doc(
+        appointment_doc = frappe.get_cached_doc(
             "Patient Appointment", self.patient_appointment
         )
         if self.authorization_no != appointment_doc.authorization_number:
@@ -975,7 +975,7 @@ def generate_pdf(doc):
         },
     )
     if file_list:
-        patientfile = frappe.get_doc("File", file_list[0].name)
+        patientfile = frappe.get_cached_doc("File", file_list[0].name)
         if patientfile:
             pdf = patientfile.get_content()
             return to_base64(pdf)
@@ -1250,7 +1250,7 @@ def reconcile_repeated_items(claim_no):
         else:
             return unique_items
 
-    claim_doc = frappe.get_doc("NHIF Patient Claim", claim_no)
+    claim_doc = frappe.get_cached_doc("NHIF Patient Claim", claim_no)
     claim_doc.allow_changes = 1
     claim_doc.nhif_patient_claim_item = reconcile_items(
         claim_doc.nhif_patient_claim_item

--- a/hms_tz/nhif/doctype/nhif_product/nhif_product.py
+++ b/hms_tz/nhif/doctype/nhif_product/nhif_product.py
@@ -26,7 +26,7 @@ def add_product(company, id, name=None):
             name != "null" and
             product_id != nhif_product_pr_key 
         ):
-            doc = frappe.get_doc("NHIF Product", nhif_product_pr_key)
+            doc = frappe.get_cached_doc("NHIF Product", nhif_product_pr_key)
 
             doc.product_id = product_id
             doc.product_name = name

--- a/hms_tz/nhif/doctype/nhif_scheme/nhif_scheme.py
+++ b/hms_tz/nhif/doctype/nhif_scheme/nhif_scheme.py
@@ -14,7 +14,7 @@ class NHIFScheme(Document):
 def add_scheme(id, name=None):
     if frappe.db.exists("NHIF Scheme", id):
         if name and name != "null":
-            doc = frappe.get_doc("NHIF Scheme", id)
+            doc = frappe.get_cached_doc("NHIF Scheme", id)
             if not doc.scheme_name:
                 doc.scheme_name = name
                 doc.save(ignore_permissions=True)

--- a/hms_tz/nhif/doctype/nhif_tracking_claim_change/nhif_tracking_claim_change.py
+++ b/hms_tz/nhif/doctype/nhif_tracking_claim_change/nhif_tracking_claim_change.py
@@ -15,7 +15,7 @@ ref_docnames_list = []
 
 def track_changes_of_claim_items(claim_doc):
     claim_no = reconcile_original_nhif_patient_claim_items(claim_doc)
-    claim = frappe.get_doc("NHIF Patient Claim", claim_no)
+    claim = frappe.get_cached_doc("NHIF Patient Claim", claim_no)
     claim.reload()
 
     for row in claim.original_nhif_patient_claim_item:

--- a/hms_tz/nhif/doctype/patient_discount_request/patient_discount_request.py
+++ b/hms_tz/nhif/doctype/patient_discount_request/patient_discount_request.py
@@ -12,7 +12,7 @@ class PatientDiscountRequest(Document):
 
     def after_insert(self):
         if self.sales_invoice:
-            invoice_doc = frappe.get_doc("Sales Invoice", self.sales_invoice)
+            invoice_doc = frappe.get_cached_doc("Sales Invoice", self.sales_invoice)
             invoice_doc.hms_tz_discount_requested = 1
             invoice_doc.hms_tz_discount_status = "Pending"
             invoice_doc.save(ignore_permissions=True)
@@ -139,7 +139,7 @@ class PatientDiscountRequest(Document):
     def apply_cash_discount(self):
         if self.sales_invoice and not self.appointment:
             url = get_url_to_form("Patient Discount Request", self.name)
-            si_doc = frappe.get_doc("Sales Invoice", self.sales_invoice)
+            si_doc = frappe.get_cached_doc("Sales Invoice", self.sales_invoice)
 
             if self.apply_discount_on in ["Grand Total", "Net Total"]:
                 si_doc.apply_discount_on = self.apply_discount_on
@@ -208,7 +208,7 @@ class PatientDiscountRequest(Document):
 @frappe.whitelist()
 def get_item_details(invoice_no, item_category, item_code):
     items = []
-    invoice_doc = frappe.get_doc("Sales Invoice", invoice_no)
+    invoice_doc = frappe.get_cached_doc("Sales Invoice", invoice_no)
     for item in invoice_doc.items:
         if item.item_code == item_code:
             items.append(
@@ -229,7 +229,7 @@ def get_item_details(invoice_no, item_category, item_code):
 def get_items(invoice_no, reference_dt=None, reset_options=None):
     items = []
     item_codes = []
-    invoice_doc = frappe.get_doc("Sales Invoice", invoice_no)
+    invoice_doc = frappe.get_cached_doc("Sales Invoice", invoice_no)
     for item in invoice_doc.items:
         if item.reference_dt and reference_dt and item.reference_dt == reference_dt:
             item_codes.append(item.item_code)
@@ -312,7 +312,7 @@ def equeue_apply_insurance_discount(kwargs):
             return
 
         discount_amount = 0
-        appointment_doc = frappe.get_doc("Patient Appointment", self.appointment)
+        appointment_doc = frappe.get_cached_doc("Patient Appointment", self.appointment)
         if self.discount_percent:
             discount_amount = appointment_doc.paid_amount * (
                 self.discount_percent / 100
@@ -346,7 +346,7 @@ def equeue_apply_insurance_discount(kwargs):
             return
 
         for encounter in encounters:
-            encounter_doc = frappe.get_doc("Patient Encounter", encounter)
+            encounter_doc = frappe.get_cached_doc("Patient Encounter", encounter)
 
             for table_field in [
                 "lab_test_prescription",
@@ -393,7 +393,7 @@ def equeue_apply_insurance_discount(kwargs):
         if not self.inpatient_record:
             return
 
-        inpatient_record_doc = frappe.get_doc("Inpatient Record", self.inpatient_record)
+        inpatient_record_doc = frappe.get_cached_doc("Inpatient Record", self.inpatient_record)
 
         discounted_items = []
         for bed in inpatient_record_doc.inpatient_occupancies:

--- a/hms_tz/nhif/nhif_api/admission.py
+++ b/hms_tz/nhif/nhif_api/admission.py
@@ -67,7 +67,7 @@ def get_admission_types(company=None, caller=None):
             admission = frappe.get_cached_value("Healthcare Admission Type", {"admission_type_name": row["AdmissionTypeName"]}, "name")
             if admission:
                 has_changed = False
-                doc = frappe.get_doc("Healthcare Admission Type", admission)
+                doc = frappe.get_cached_doc("Healthcare Admission Type", admission)
 
                 if doc.admission_type_name != row["AdmissionTypeName"]:
                     doc.admission_type_name = row["AdmissionTypeName"]
@@ -148,7 +148,7 @@ def get_discharge_types(company=None, caller=None):
             discharge_type = frappe.get_cached_value("Healthcare Discharge Type", {"discharge_type_name": row["DischargeTypeName"]}, "name")
             if discharge_type:
                 has_changed = False
-                doc = frappe.get_doc("Healthcare Discharge Type", discharge_type)
+                doc = frappe.get_cached_doc("Healthcare Discharge Type", discharge_type)
 
                 if doc.discharge_type_name != row["DischargeTypeName"]:
                     doc.discharge_type_name = row["DischargeTypeName"]
@@ -229,7 +229,7 @@ def get_ward_types(company=None, caller=None):
             ward_type = frappe.get_cached_value("Healthcare Ward Type", {"ward_type_name": row["WardTypeName"]}, "name")
             if ward_type:
                 has_changed = False
-                doc = frappe.get_doc("Healthcare Ward Type", ward_type)
+                doc = frappe.get_cached_doc("Healthcare Ward Type", ward_type)
 
                 if doc.ward_type_name != row["WardTypeName"]:
                     doc.ward_type_name = row["WardTypeName"]
@@ -320,7 +320,7 @@ def get_room_types(company=None, caller=None):
             room_type = frappe.get_cached_value("Healthcare Room Type", {"room_type_name": row["RoomTypeName"]}, "name")
             if room_type:
                 has_changed = False
-                doc = frappe.get_doc("Healthcare Room Type", room_type)
+                doc = frappe.get_cached_doc("Healthcare Room Type", room_type)
 
                 if doc.room_type_name != row["RoomTypeName"]:
                     doc.room_type_name = row["RoomTypeName"]
@@ -648,7 +648,7 @@ def send_overstay_nofication():
         }
 
         for row in ip_records:
-            inpatient_doc = frappe.get_doc("Inpatient Recrod", row.inpatient_id)
+            inpatient_doc = frappe.get_cached_doc("Inpatient Recrod", row.inpatient_id)
             inpatient_occupancies = inpatient_doc.get("inpatient_occupancies")
             if len(inpatient_occupancies) == 0:
                 continue

--- a/hms_tz/nhif/nhif_api/approval.py
+++ b/hms_tz/nhif/nhif_api/approval.py
@@ -21,7 +21,7 @@ def get_service_approval(
     if not ref_doctype or not ref_docname:
         frappe.throw("Document Type and Document Name are required")
 
-    doc = frappe.get_doc(ref_doctype, ref_docname)
+    doc = frappe.get_cached_doc(ref_doctype, ref_docname)
 
     settings_doc = frappe.get_cached_doc("HMS TZ Settings", doc.company)
 
@@ -97,7 +97,7 @@ def update_service_approval(
     if not ref_doctype or not ref_docname:
         frappe.throw("Document Type and Document Name are required")
     
-    doc = frappe.get_doc(ref_doctype, ref_docname)
+    doc = frappe.get_cached_doc(ref_doctype, ref_docname)
 
     settings_doc = frappe.get_cached_doc("HMS TZ Settings", doc.company)
 
@@ -173,7 +173,7 @@ def issue_approved_service(
     if not ref_doctype or not ref_docname:
         frappe.throw("Document Type and Document Name are required")
     
-    doc = frappe.get_doc(ref_doctype, ref_docname)
+    doc = frappe.get_cached_doc(ref_doctype, ref_docname)
 
     fingerprint_data = fingerprint.replace("-", "+").replace("_", "/")
     image_data = base64.b64encode(fingerprint_data.encode('utf-8')).decode('utf-8')
@@ -631,7 +631,7 @@ def get_approval_services(company=None, caller=None):
         for row in data:
             if frappe.db.exists("NHIF Service Type", row["ServiceTypeName"]):
                 has_changed = False
-                doc = frappe.get_doc("NHIF Service Type", row["ServiceTypeName"])
+                doc = frappe.get_cached_doc("NHIF Service Type", row["ServiceTypeName"])
                 if doc.service_type_id != row["ServiceTypeID"]:
                     has_changed = True
                     doc.service_type_id = row["ServiceTypeID"]

--- a/hms_tz/nhif/nhif_api/patient_claim.py
+++ b/hms_tz/nhif/nhif_api/patient_claim.py
@@ -308,7 +308,7 @@ def send_confirmation_code(ref_doctype, ref_docname):
     Send confirmation code to Patient
     """
 
-    doc = frappe.get_doc(ref_doctype, ref_docname)
+    doc = frappe.get_cached_doc(ref_doctype, ref_docname)
 
     payload = {
         "FacilityCode": doc.facility_code,
@@ -383,7 +383,7 @@ def get_receipt(ref_doctype, ref_docname):
     Get receipt from NHIF
     """
 
-    doc = frappe.get_doc(ref_doctype, ref_docname)
+    doc = frappe.get_dget_cached_dococ(ref_doctype, ref_docname)
 
     settings_doc = frappe.get_cached_doc("HMS TZ Settings", doc.company)
 

--- a/hms_tz/nhif/nhif_api/pre_approval.py
+++ b/hms_tz/nhif/nhif_api/pre_approval.py
@@ -16,7 +16,7 @@ def get_service_preapproval(
     authorization_no=None,
     settings_doc=None, 
 ):
-    encounter_doc = frappe.get_doc(ref_doctype, ref_docname)
+    encounter_doc = frappe.get_cached_doc(ref_doctype, ref_docname)
 
     services, service_map, diseases = get_encounter_services(encounter_doc)
     if len(services) == 0:
@@ -154,7 +154,7 @@ def cancel_preapproval(
     remarks,
     settings_doc=None,
 ):
-    encounter_doc = frappe.get_doc(ref_doctype, ref_docname)
+    encounter_doc = frappe.get_cached_doc(ref_doctype, ref_docname)
     services, service_map, diseases = get_encounter_services(encounter_doc, preapproval_no)
     if len(services) == 0:
         frappe.msgprint("No servuce(s) to cancel an Pre-Approvals")

--- a/hms_tz/nhif/nhif_api/price_package.py
+++ b/hms_tz/nhif/nhif_api/price_package.py
@@ -914,7 +914,7 @@ def  get_nhif_schemes(company=None, caller=None):
             scheme_id = frappe.get_cached_value("NHIF Scheme", {"scheme_id": row["SchemeID"]}, "name")
             if scheme_id:
                 has_changed = False
-                doc = frappe.get_doc("NHIF Scheme", scheme_id)
+                doc = frappe.get_cached_doc("NHIF Scheme", scheme_id)
 
                 if doc.scheme_name != row["SchemeName"]:
                     doc.scheme_name = row["SchemeName"]
@@ -1034,7 +1034,7 @@ def add_nhif_product(row, company, abbr):
             row["ProductName"] != "null"
         ):
             has_changed = False
-            doc = frappe.get_doc("NHIF Product", nhif_product_pr_key)
+            doc = frappe.get_cached_doc("NHIF Product", nhif_product_pr_key)
 
             if doc.product_id != product_id:
                 doc.product_id = product_id
@@ -1152,7 +1152,7 @@ def  get_item_types(company=None, caller=None):
             item_type = frappe.get_cached_value("NHIF Item Type", {"item_type_id": item["ItemTypeID"]}, "name")
             if item_type:
                 has_changed = False
-                doc = frappe.get_doc("NHIF Item Type", item_type)
+                doc = frappe.get_cached_doc("NHIF Item Type", item_type)
 
                 if doc.type_name != item["TypeName"]:
                     doc.type_name = item["TypeName"]

--- a/hms_tz/nhif/nhif_api/referral.py
+++ b/hms_tz/nhif/nhif_api/referral.py
@@ -175,7 +175,7 @@ def update_referral(ref_doctype, ref_docname):
     """
     Update referral.
     """
-    doc = frappe.get_doc(ref_doctype, ref_docname)
+    doc = frappe.get_cached_doc(ref_doctype, ref_docname)
 
     payload = {
         "referralNo": doc.referral_no,

--- a/hms_tz/patches/create_medical_record_for_old_clinical_procedures.py
+++ b/hms_tz/patches/create_medical_record_for_old_clinical_procedures.py
@@ -26,7 +26,7 @@ def execute():
 
     for procedure in procedures:
         if procedure not in medical_records:
-            doc = frappe.get_doc("Clinical Procedure", procedure)
+            doc = frappe.get_cached_doc("Clinical Procedure", procedure)
             insert_clinical_procedure_to_medical_record(doc)
 
     frappe.db.commit()

--- a/hms_tz/patches/custom_fields/add_practitioner_on_patient_medical_history.py
+++ b/hms_tz/patches/custom_fields/add_practitioner_on_patient_medical_history.py
@@ -33,7 +33,7 @@ def update_practitioner_to_old_records():
 
     for records in create_batch(medical_records, 100):
         for record in records:
-            doc = frappe.get_doc("Patient Medical Record", record.name)
+            doc = frappe.get_cached_doc("Patient Medical Record", record.name)
             set_practitioner(doc)
             doc.db_update()
             doc.db_update_all()

--- a/hms_tz/patches/custom_fields/create_custom_fields.py
+++ b/hms_tz/patches/custom_fields/create_custom_fields.py
@@ -68,7 +68,7 @@ def export_custom_fields(docnames):
     custom_fields = []
 
     for docname in docnames:
-        doc = frappe.get_doc("Custom Field", docname)
+        doc = frappe.get_cached_doc("Custom Field", docname)
         custom_fields.append(
             doc.as_dict(
                 convert_dates_to_str=True, no_default_fields=True, no_nulls=True

--- a/hms_tz/patches/update_original_delivery_note_item_to_old_delivery_note.py
+++ b/hms_tz/patches/update_original_delivery_note_item_to_old_delivery_note.py
@@ -13,7 +13,7 @@ def execute():
         return
 
     for dn in delivery_notes:
-        dn_doc = frappe.get_doc("Delivery Note", dn.name)
+        dn_doc = frappe.get_cached_doc("Delivery Note", dn.name)
 
         if len(dn_doc.hms_tz_original_items) > 0:
             continue

--- a/hms_tz/patches/v2_0/migrate_hsu_into_the_child_table.py
+++ b/hms_tz/patches/v2_0/migrate_hsu_into_the_child_table.py
@@ -14,7 +14,7 @@ def execute():
 
     def update_docs(doc_list, doctype):
         for doc_name in doc_list:
-            doc = frappe.get_doc(doctype, doc_name.get("name"))
+            doc = frappe.get_cached_doc(doctype, doc_name.get("name"))
             if not doc.healthcare_service_unit:
                 continue
             company = frappe.get_cached_value(


### PR DESCRIPTION
- Updated multiple instances across various modules to use frappe.get_cached_doc instead of frappe.get_doc.
- This change enhances performance by reducing database hits for frequently accessed documents.
- Modules affected include delivery_note, healthcare_utils, inpatient_record, insurance_claim, lab_test, patient_appointment, radiology_examination, sales_invoice, service_order, therapy_session, nhif_patient_claim, nhif_product, nhif_scheme, nhif_tracking_claim_change, patient_discount_request, nhif_api, and several patches.