### PR TITLE
fix(healthcare package): duplication of services for insurance package orders

### DIFF
--- a/hms_tz/nhif/api/healthcare_utils.py
+++ b/hms_tz/nhif/api/healthcare_utils.py
@@ -870,7 +870,11 @@ def create_therapy_plan(enc_doc=None, invoice_therapy_dict=[]):
             )
             return
 
-        if not enc_doc.insurance_subscription and not enc_doc.inpatient_record:
+        if (
+            not enc_doc.insurance_subscription
+            and not enc_doc.inpatient_record
+            and not enc_doc.healthcare_package_order
+        ):
             return
 
         patient_encounter_docs.append(enc_doc)
@@ -951,9 +955,7 @@ def create_plan(patient_encounter_docs, therapies):
             for entry in therapies:
                 if entry.parent == encounter_doc.name:
                     entry.therapy_plan_created = 1
-                    entry.delivered_quantity = (
-                        entry.no_of_sessions - entry.sessions_cancelled
-                    )
+                    entry.delivered_quantity = entry.no_of_sessions - entry.sessions_cancelled
                     entry.db_update()
 
             frappe.msgprint(

--- a/hms_tz/nhif/api/patient_encounter.py
+++ b/hms_tz/nhif/api/patient_encounter.py
@@ -725,16 +725,18 @@ def on_submit(doc, method):
                 doc.company,
             )
         inpatient_billing(doc, method)
-    else:  # insurance patient
+    
+    elif not doc.healthcare_package_order:
+        # insurance patient
         on_submit_validation(doc, method)
         create_healthcare_docs(doc, method)
         create_delivery_note(doc, method)
 
     if (
         doc.healthcare_package_order
-        # and not doc.insurance_subscription
         and not doc.inpatient_record
     ):
+        # for cash and insurance patient with healthcare package order
         create_items_from_healthcare_package_orders(doc, method)
 
     if doc.inpatient_record:

--- a/hms_tz/nhif/doctype/healthcare_package_order/healthcare_package_order.py
+++ b/hms_tz/nhif/doctype/healthcare_package_order/healthcare_package_order.py
@@ -157,9 +157,11 @@ def create_single_appointment(doc, row, appointment_type, is_pratictioner_consul
 	if doc.payment_type == "Insurance":
 		appointment.insurance_subscription = doc.insurance_subscription
 		appointment.authorization_number = doc.authorization_number
+		appointment.mode_of_payment = None
 	if doc.payment_type == "Cash":
 		appointment.mode_of_payment = doc.mode_of_payment
 		appointment.invoiced = 1
+		appointment.insurance_subscription = None
 	appointment.department = row.department
 	appointment.billing_item = row.consultation_item
 	if is_pratictioner_consultation:
@@ -200,7 +202,7 @@ def update_encounter_items(encounter_doc, package_doc, has_items):
 				if row.healthcare_service_type == d["template"]:
 					new_row =  {
 						d["field"]: row.healthcare_service,
-						"prescribe": 1 if encounter_doc.mode_of_payment else 0,
+						"prescribe": 0 if encounter_doc.insurance_subscription else 1,
 						"medical_code": str("ICD-10 R69") + "\n " + str("Illness, unspecified"),
 						"amount": row.service_price,
 					}
@@ -216,6 +218,7 @@ def update_encounter_items(encounter_doc, package_doc, has_items):
 					
 					if row.healthcare_service_type == "Therapy Type":
 						new_row["no_of_sessions"] = 1
+						new_row["sessions_cancelled"] = 0
 					
 					encounter_doc.append(d["table"], new_row)
 	item_table += "</p>"


### PR DESCRIPTION
- Added healthcare_package_order check in create_therapy_plan function.
- Simplified delivered_quantity calculation in create_plan function.
- Updated on_submit method to handle cases without healthcare_package_order.
- Adjusted appointment creation logic to reset insurance_subscription when payment type is Cash.
- Initialized sessions_cancelled in update_encounter_items for therapy types.