### PR TITLE
fix(healthcare package): duplication of services for insurance package orders

### DIFF
--- a/hms_tz/nhif/api/healthcare_utils.py
+++ b/hms_tz/nhif/api/healthcare_utils.py
@@ -870,7 +870,11 @@ def create_therapy_plan(enc_doc=None, invoice_therapy_dict=[]):
             )
             return
 
-        if not enc_doc.insurance_subscription and not enc_doc.inpatient_record:
+        if (
+            not enc_doc.insurance_subscription
+            and not enc_doc.inpatient_record
+            and not enc_doc.healthcare_package_order
+        ):
             return
 
         patient_encounter_docs.append(enc_doc)
@@ -951,9 +955,7 @@ def create_plan(patient_encounter_docs, therapies):
             for entry in therapies:
                 if entry.parent == encounter_doc.name:
                     entry.therapy_plan_created = 1
-                    entry.delivered_quantity = (
-                        entry.no_of_sessions - entry.sessions_cancelled
-                    )
+                    entry.delivered_quantity = entry.no_of_sessions - entry.sessions_cancelled
                     entry.db_update()
 
             frappe.msgprint(

--- a/hms_tz/nhif/api/patient_encounter.py
+++ b/hms_tz/nhif/api/patient_encounter.py
@@ -725,16 +725,18 @@ def on_submit(doc, method):
                 doc.company,
             )
         inpatient_billing(doc, method)
-    else:  # insurance patient
+    
+    elif not doc.healthcare_package_order:
+        # insurance patient
         on_submit_validation(doc, method)
         create_healthcare_docs(doc, method)
         create_delivery_note(doc, method)
 
     if (
         doc.healthcare_package_order
-        # and not doc.insurance_subscription
         and not doc.inpatient_record
     ):
+        # for cash and insurance patient with healthcare package order
         create_items_from_healthcare_package_orders(doc, method)
 
     if doc.inpatient_record:

--- a/hms_tz/nhif/doctype/healthcare_package_order/healthcare_package_order.py
+++ b/hms_tz/nhif/doctype/healthcare_package_order/healthcare_package_order.py
@@ -157,9 +157,11 @@ def create_single_appointment(doc, row, appointment_type, is_pratictioner_consul
 	if doc.payment_type == "Insurance":
 		appointment.insurance_subscription = doc.insurance_subscription
 		appointment.authorization_number = doc.authorization_number
+		appointment.mode_of_payment = None
 	if doc.payment_type == "Cash":
 		appointment.mode_of_payment = doc.mode_of_payment
 		appointment.invoiced = 1
+		appointment.insurance_subscription = None
 	appointment.department = row.department
 	appointment.billing_item = row.consultation_item
 	if is_pratictioner_consultation:
@@ -200,7 +202,7 @@ def update_encounter_items(encounter_doc, package_doc, has_items):
 				if row.healthcare_service_type == d["template"]:
 					new_row =  {
 						d["field"]: row.healthcare_service,
-						"prescribe": 1 if encounter_doc.mode_of_payment else 0,
+						"prescribe": 0 if encounter_doc.insurance_subscription else 1,
 						"medical_code": str("ICD-10 R69") + "\n " + str("Illness, unspecified"),
 						"amount": row.service_price,
 					}
@@ -216,6 +218,7 @@ def update_encounter_items(encounter_doc, package_doc, has_items):
 					
 					if row.healthcare_service_type == "Therapy Type":
 						new_row["no_of_sessions"] = 1
+						new_row["sessions_cancelled"] = 0
 					
 					encounter_doc.append(d["table"], new_row)
 	item_table += "</p>"

--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -899,7 +899,11 @@ class NHIFPatientClaim(Document):
                 serv_info = ""
                 if row.medical_code:
                     serv_info  += f", Medical Code: {row.medical_code}"
-                self.clinical_notes += f"Lab Test Name: {row.lab_test_name} {serv_info} <br>"
+
+                self.clinical_notes += f"Lab Test Name: <b>{row.lab_test_name}</b> {serv_info} <br>"
+                result = self.get_lab_results(row)
+                if result:
+                    self.clinical_notes += result
         
         #Radiology
         if len(encounter_doc.get("radiology_procedure_prescription")) > 0:
@@ -908,7 +912,11 @@ class NHIFPatientClaim(Document):
                 serv_info = ""
                 if row.medical_code:
                     serv_info += f", Medical Code: {row.medical_code}"
-                self.clinical_notes += f"Service Name: {row.radiology_procedure_name} {serv_info} <br>"
+
+                self.clinical_notes += f"Service Name: <b>{row.radiology_procedure_name}</b> {serv_info} <br>"
+                radiology_report = self.get_radiology_results(row)
+                if radiology_report:
+                    self.clinical_notes += radiology_report
         
         #Clinical Procedures
         if len(encounter_doc.get("procedure_prescription")) > 0:
@@ -917,13 +925,11 @@ class NHIFPatientClaim(Document):
                 serv_info = ""
                 if row.medical_code:
                     serv_info += f", Medical Code: {row.medical_code}"
-                
-                if row.clinical_procedure:
-                    notes = frappe.get_cached_value("Clinical Procedure", row.clinical_procedure, "procedure_notes") or ""
-                    
-                    serv_info += f", Procedure Notes: {notes}"
-                
-                self.clinical_notes += f"Procedure: {row.procedure_name} {serv_info}<br>"
+
+                self.clinical_notes += f"Procedure: <b>{row.procedure_name}</b> {serv_info}<br>"
+                procedure_notes = self.get_procedure_notes(row)
+                if procedure_notes:
+                    self.clinical_notes += procedure_notes
         
         #Medications
         if len(encounter_doc.get("drug_prescription")) > 0:
@@ -1054,6 +1060,95 @@ class NHIFPatientClaim(Document):
                 )
             )
 
+    def get_lab_results(self, row):
+        if not row.lab_test:
+            return
+
+        lab_test_doc = frappe.get_cached_doc("Lab Test", row.lab_test)
+        if lab_test_doc.workflow_state == "Lab Test Requested":
+            return
+
+        result = ""
+
+        if lab_test_doc.normal_test_items:
+            result += '<div align="center"><i><u><b>Normal Test Results</b></u></i></div>'
+            result += '<table border="1" cellpadding="5" cellspacing="0" width="90%" align="center">'
+            result += '<tr bgcolor="#CCCCCC"><th>Test Name</th><th>Result</th><th>UOM</th></tr>'
+
+            for item in lab_test_doc.normal_test_items:
+                result += f'<tr><td>{item.lab_test_name}</td>'
+                result += f'<td>{item.result_value}</td>'
+                result += f'<td>{item.lab_test_uom or ""}</td></tr>'
+
+            result += '</table><br>'
+
+        # Descriptive test items table
+        if lab_test_doc.descriptive_test_items:
+            result += '<div align="center"><i><u><b>Descriptive Test Results</b></u></i></div>'
+            result += '<table border="1" cellpadding="5" cellspacing="0" width="90%" align="center">'
+            result += '<tr bgcolor="#CCCCCC"><th>Test Particulars</th><th>Result</th></tr>'
+
+            for item in lab_test_doc.descriptive_test_items:
+                result += f'<tr><td>{item.lab_test_particulars}</td>'
+                result += f'<td>{item.result_value}</td></tr>'
+
+            result += '</table><br>'
+
+        # Sensitivity test items table
+        if lab_test_doc.sensitivity_test_items:
+            result += '<div align="center"><i><u><b>Sensitivity Test Results</b></u></i></div>'
+            result += '<table border="1" cellpadding="5" cellspacing="0" width="90%" align="center">'
+            result += '<tr bgcolor="#CCCCCC"><th>Antibiotic</th><th>Sensitivity</th></tr>'
+
+            for item in lab_test_doc.sensitivity_test_items:
+                result += f'<tr><td>{item.antibiotic}</td>'
+                result += f'<td>{item.antibiotic_sensitivity}</td></tr>'
+
+            result += '</table><br>'
+
+        # Custom result
+        if lab_test_doc.custom_result:
+            result += '<div align="center"><i><u><b>Custom Result</b></u></i></div>'
+            result += '<table border="1" cellpadding="5" cellspacing="0" width="90%" align="center">'
+            result += f'<tr><td>{lab_test_doc.custom_result}</td></tr>'
+            result += '</table><br>'
+
+        return result
+
+    def get_radiology_results(self, row):
+        if not row.radiology_examination:
+            return
+
+        radiology_report = frappe.get_cached_value(
+            "Radiology Examination",
+            row.radiology_examination,
+            "radiology_report_details"
+        )
+        
+        result = ""
+        if radiology_report:
+            result += f"<div align='center'><i><u><b>Radiology Report</b></u></i></div>"
+            result += f"<table border='1' cellpadding='5' cellspacing='0' width='90%' align='center'>"
+            result += f"<tr><td>{radiology_report}</td></tr>"
+            result += f"</table><br>"
+
+        return result
+ 
+    def get_procedure_notes(self, row):
+        if not row.clinical_procedure:
+            return
+        
+        notes = frappe.get_cached_value("Clinical Procedure", row.clinical_procedure, "procedure_notes") or ""
+
+        result = ""
+        if notes:
+            result += f"<div align='center'><i><u><b>Procedure Notes</b></u></i></div>"
+            result += f"<table border='1' cellpadding='5' cellspacing='0' width='90%' align='center'>"
+            result += f"<tr><td>{notes}</td></tr>"
+            result += f"</table><br>"
+
+        return result
+    
 
 def get_missing_patient_signature(self):
     if self.patient:

--- a/hms_tz/nhif/report/itemwise_hospital_revenue/itemwise_hospital_revenue.py
+++ b/hms_tz/nhif/report/itemwise_hospital_revenue/itemwise_hospital_revenue.py
@@ -1166,7 +1166,7 @@ def get_insurance_drug_data(filters, appoints):
         .select(
             pe.encounter_date.as_("date"),
             pe.appointment.as_("appointment_no"),
-            dn.name.as_("bill_no"),
+            dp.delivery_note.as_("bill_no"),
             pe.patient.as_("patient"),
             pe.patient_name.as_("patient_name"),
             Case()
@@ -1193,6 +1193,11 @@ def get_insurance_drug_data(filters, appoints):
             & (dn.docstatus != 2)
             & (dn.is_return == 0)
             & (dn.reference_doctype == "Patient Encounter")
+        )
+        .groupby(
+            dp.name,
+            # pe.appointment,
+            # dp.delivery_note,
         )
     )
 


### PR DESCRIPTION
- Added healthcare_package_order check in create_therapy_plan function.
- Simplified delivered_quantity calculation in create_plan function.
- Updated on_submit method to handle cases without healthcare_package_order.
- Adjusted appointment creation logic to reset insurance_subscription when payment type is Cash.
- Initialized sessions_cancelled in update_encounter_items for therapy types.