### PR TITLE
fix: remove non-existent on_update_after_submit hook for Delivery Note

### DIFF
--- a/hms_tz/hooks.py
+++ b/hms_tz/hooks.py
@@ -211,7 +211,6 @@ doc_events = {
         "before_submit": "hms_tz.nhif.api.delivery_note.before_submit",
         "on_submit": "hms_tz.nhif.api.delivery_note.on_submit",
         "on_cancel": "hms_tz.nhif.api.delivery_note.on_cancel",
-        "on_update_after_submit": "hms_tz.nhif.api.delivery_note.on_update_after_submit",
     },
     "Inpatient Record": {
         "validate": "hms_tz.nhif.api.inpatient_record.validate",


### PR DESCRIPTION
- The on_update_after_submit hook was referencing a function that did not exist in delivery_note.py, causing an AttributeError during workflow transitions like 'Issue Returns' from LRPMT Returns.