### PR TITLE
feat: add GitHub Action for automatic backporting of PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,56 @@
+name: Backport PR
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport PR
+    if: >
+      github.event.pull_request.merged == true
+      && contains(join(github.event.pull_request.labels.*.name, ','), 'backport')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create backport PRs
+        uses: korthout/backport-action@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          label_pattern: "^backport-to-(.+)$"
+          pull_title: "[Backport ${target_branch}] ${pull_title}"
+          pull_description: |
+            Backport of #${pull_number} to `${target_branch}`.
+            
+            ---
+            
+            ${pull_description}
+          merge_commits: "skip"
+          copy_requested_reviewers: true
+          copy_assignees: true
+          copy_labels_pattern: "^(?!backport)"
+
+      - name: Report backport status
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pull_number,
+              body: `⚠️ **Backport failed!**\n\nThe automatic backport could not be completed. This might be due to merge conflicts.\n\nPlease manually cherry-pick the commits to the target branch:\n\n\`\`\`bash\ngit checkout <target-branch>\ngit cherry-pick -x ${context.payload.pull_request.merge_commit_sha}\n\`\`\`\n\nThen create a new PR targeting the branch.`
+            });
+


### PR DESCRIPTION
- Add backport.yml workflow that triggers on merged PRs with backport labels
- Supports label pattern 'backport-to-<branch-name>' for targeting specific branches
- Automatically creates backport PRs with proper titles and descriptions
- Reports failures with manual cherry-pick instructions
- Copies reviewers, assignees, and non-backport labels to new PRs