### PR TITLE
fix(nhif_patient_claim): change inner join to left join for patient encounters query

### DIFF
--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -154,8 +154,12 @@ class NHIFPatientClaim(Document):
 
         patient_encounters = (
             frappe.qb.from_(pe)
-            .inner_join(hsr)
-            .on(hsr.source_docname == pe.name)
+            .left_join(hsr)
+            .on(
+                (hsr.docstatus == 1)
+                & (hsr.source_docname == pe.name)
+                & (hsr.source_doctype == "Patient Encounter")
+            )
             .select(
                 pe.practitioner,
                 pe.encounter_date,
@@ -167,8 +171,6 @@ class NHIFPatientClaim(Document):
             .where(
                 (pe.docstatus == 1)
                 & (pe.appointment.isin(appointments))
-                & (hsr.docstatus == 1)
-                & (hsr.source_doctype == "Patient Encounter")
             )
             .orderby(pe.creation)
         ).run(as_dict=True)


### PR DESCRIPTION
- Changed from inner_join to left_join for Healthcare Service Request
- Moved docstatus and source_doctype conditions to the ON clause
- This ensures patient encounters are returned even when no service request exists