### PR TITLE
refactor: migrate dependencies from requirements.txt to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,8 @@ ignore = [
   "E402",
   "E741",
 ]
+
+[project.optional-dependencies]
+dev = [
+  "pre-commit",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-frappe
-erpnext
-healthcare
-pre-commit
+# dependencies are managed in pyproject.toml


### PR DESCRIPTION
- Remove frappe, erpnext, and healthcare from requirements.txt as these are handled by Frappe's dependency resolution system
- Add pre-commit as a dev dependency in pyproject.toml under [project.optional-dependencies] section
- Align with modern Python packaging standards using pyproject.toml for dependency management