### PR TITLE
fix: remove [project.optional-dependencies] from pyproject.toml to fix install error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,3 @@ ignore = [
   "E402",
   "E741",
 ]
-
-[project.optional-dependencies]
-dev = [
-  "pre-commit",
-]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-# dependencies are managed in pyproject.toml
+# frappe, erpnext, healthcare are resolved by Frappe's bench dependency system
+pre-commit


### PR DESCRIPTION
The [project.optional-dependencies] table requires a full [project] section with at least the 'name' field. Since hms_tz uses setup.py for package metadata (standard for Frappe v15 apps), adding a partial [project] table causes uv/pip to fail with:
  'pyproject.toml is using the [project] table, but the required
   project.name field is not set'

- Remove [project.optional-dependencies] from pyproject.toml
- Keep pre-commit in requirements.txt as a dev tool dependency
- Keep pyproject.toml for tooling config only (ruff, black, isort)