### PR TITLE
ci: modernize GitHub Actions CI workflow to follow Frappe ecosystem pattern

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+cd ~ || exit
+
+echo "::group::Install Dependencies"
+sudo apt update
+sudo apt remove mysql-server mysql-client
+sudo apt install libcups2-dev redis-server mariadb-client
+echo "::endgroup::"
+
+echo "::group::Install Bench"
+pip install frappe-bench
+echo "::endgroup::"
+
+echo "::group::Init Bench"
+git clone https://github.com/frappe/frappe --branch "$BRANCH_TO_CLONE" --depth 1
+bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
+echo "::endgroup::"
+
+echo "::group::Create Test Site"
+mkdir ~/frappe-bench/sites/test_site
+cp -r "${GITHUB_WORKSPACE}/.github/helper/site_config.json" ~/frappe-bench/sites/test_site/
+
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE USER 'test_frappe'@'localhost' IDENTIFIED BY 'test_frappe'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE DATABASE test_frappe"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON \`test_frappe\`.* TO 'test_frappe'@'localhost'"
+
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "FLUSH PRIVILEGES"
+echo "::endgroup::"
+
+cd ~/frappe-bench || exit
+
+echo "::group::Modify Processes"
+sed -i 's/^watch:/# watch:/g' Procfile
+sed -i 's/^schedule:/# schedule:/g' Procfile
+sed -i 's/^socketio:/# socketio:/g' Procfile
+sed -i 's/^redis_socketio:/# redis_socketio:/g' Procfile
+echo "::endgroup::"
+
+echo "::group::Install Apps"
+bench get-app payments --branch "$BRANCH_TO_CLONE"
+bench get-app erpnext --branch "$BRANCH_TO_CLONE"
+bench get-app healthcare --branch "$BRANCH_TO_CLONE"
+bench get-app hms_tz "${GITHUB_WORKSPACE}"
+
+bench setup requirements --dev
+echo "::endgroup::"
+
+echo "::group::Build & Install Site"
+CI=Yes bench build --app frappe &
+build_pid=$!
+
+bench start &> ~/frappe-bench/bench_start.log &
+
+bench --site test_site reinstall --yes
+
+bench --verbose --site test_site install-app hms_tz
+
+# wait till assets are built successfully
+wait $build_pid
+echo "::endgroup::"

--- a/.github/helper/site_config.json
+++ b/.github/helper/site_config.json
@@ -1,0 +1,17 @@
+{
+ "db_host": "127.0.0.1",
+ "db_port": 3306,
+ "db_name": "test_frappe",
+ "db_password": "test_frappe",
+ "auto_email_id": "test@example.com",
+ "mail_server": "smtp.example.com",
+ "mail_login": "test@example.com",
+ "mail_password": "test",
+ "admin_password": "admin",
+ "root_login": "root",
+ "root_password": "root",
+ "host_name": "http://test_site:8000",
+ "install_apps": ["payments", "erpnext", "healthcare"],
+ "allow_tests": true,
+ "throttle_user_limit": 100
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - version-15-beta
     types: [opened, synchronize, reopened]
 
+env:
+  BRANCH_TO_CLONE: version-15
+
 concurrency:
   group: ci-hms_tz-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -16,6 +19,7 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
     name: Server Tests
@@ -24,26 +28,14 @@ jobs:
       mariadb:
         image: mariadb:10.6
         env:
-          MYSQL_ROOT_PASSWORD: root
+          MARIADB_ROOT_PASSWORD: 'root'
         ports:
           - 3306:3306
-        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
-
-      redis-cache:
-        image: redis:alpine
-        ports:
-          - 13000:6379
-      redis-queue:
-        image: redis:alpine
-        ports:
-          - 11000:6379
+        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
       - name: Clone
         uses: actions/checkout@v4
-
-      - name: Install MariaDB Client
-        run: sudo apt-get -y install mariadb-client
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -53,8 +45,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 20
           check-latest: true
+
+      - name: Add to Hosts
+        run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
       - name: Cache pip
         uses: actions/cache@v4
@@ -78,35 +73,24 @@ jobs:
             ${{ runner.os }}-yarn-
             ${{ runner.os }}-
 
-      - name: Setup Bench
-        run: |
-          pip install frappe-bench
-          bench init --skip-redis-config-generation --skip-assets --frappe-branch version-15 --python "$(which python)" ~/frappe-bench
-          mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
-          mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
-
-      - name: Install Apps
-        working-directory: /home/runner/frappe-bench
-        run: |
-          bench get-app erpnext --branch version-15
-          bench get-app healthcare --branch version-15
-          bench get-app hms_tz $GITHUB_WORKSPACE
-
-      - name: Setup Test Site
-        working-directory: /home/runner/frappe-bench
-        run: |
-          bench new-site --db-root-password root --admin-password admin test_site
-          bench --site test_site install-app erpnext
-          bench --site test_site install-app healthcare
-          bench --site test_site install-app hms_tz
-          bench build --app frappe
+      - name: Install
+        run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:
-          CI: 'Yes'
+          BRANCH_TO_CLONE: ${{ env.BRANCH_TO_CLONE }}
 
       - name: Run Tests
         working-directory: /home/runner/frappe-bench
-        run: |
-          bench --site test_site set-config allow_tests true
-          bench --site test_site run-tests --app hms_tz
+        run: bench --site test_site run-tests --app hms_tz
         env:
           TYPE: server
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: |
+          cd ~/frappe-bench
+          cat bench_start.log || true
+          cd logs
+          for f in ./*.log*; do
+            echo "Printing log: $f";
+            cat $f
+          done


### PR DESCRIPTION
Problem:
- CI was failing with 'ModuleNotFoundError: No module named pkg_resources'
- The error occurred during 'bench new-site' when Frappe tried to load Dropbox Settings DocType, which imports the dropbox package that depends on pkg_resources (from setuptools)
- Recent Python/pip versions no longer bundle setuptools in virtual environments by default, causing the import chain to break

Root Cause:
- hms_tz CI used 'bench new-site --db-root-password root' to create the test site, which triggers full DocType synchronization including loading all Python modules (e.g., dropbox_settings.py -> dropbox -> pkg_resources)
- This approach is outdated and fragile — none of the other Frappe ecosystem apps (frappe, erpnext, healthcare, hrms) use bench new-site in their CI workflows

Solution — align with the standard Frappe CI pattern:
- Added .github/helper/install.sh: dedicated install script that handles bench init, DB setup, app installation, and site creation using 'bench --site test_site reinstall --yes' instead of 'bench new-site'
- Added .github/helper/site_config.json: pre-configured site config with DB credentials, admin password, host_name, install_apps (payments, erpnext, healthcare), and allow_tests flag
- Refactored .github/workflows/ci.yml to delegate setup to install.sh

Key changes in ci.yml:
- Removed manual Redis service containers (install.sh installs redis)
- Removed 'Install MariaDB Client' step (handled by install.sh)
- Fixed MariaDB env var: MYSQL_ROOT_PASSWORD -> MARIADB_ROOT_PASSWORD
- Fixed MariaDB healthcheck: healthcheck.sh -> mariadb-admin ping
- Added 'Add to Hosts' step for test_site hostname resolution
- Added timeout-minutes: 60 to prevent hung workflows
- Downgraded Node.js from 21 (EOL) to 20 (LTS, matches healthcare/hrms)
- Added 'Show bench output' step with if:always() for failure debugging
- Removed redundant 'set-config allow_tests' (now in site_config.json)

Pattern references:
- frappe:      .github/helper/install.sh + db/mariadb.json
- erpnext:     .github/helper/install.sh + site_config_mariadb.json
- healthcare:  .github/helper/install.sh + site_config.json
- hrms:        .github/helper/install.sh + site_config.json