### PR TITLE
chore(vscode): fix git.inputValidation setting type

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -49,6 +49,11 @@ bench get-app healthcare --branch "$BRANCH_TO_CLONE"
 bench get-app hms_tz "${GITHUB_WORKSPACE}"
 
 bench setup requirements --dev
+
+# setuptools is required by the dropbox package (frappe dependency)
+# which imports pkg_resources. Python 3.11+ venvs no longer include
+# setuptools by default, so we install it explicitly.
+~/frappe-bench/env/bin/pip install setuptools
 echo "::endgroup::"
 
 echo "::group::Build & Install Site"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
     // Git commit message settings
     "git.inputValidationSubjectLength": 72,
     "git.inputValidationLength": 500,
-    "git.inputValidation": "always",
+    "git.inputValidation": true,
     
     // Conventional Commits settings
     "conventionalCommits.scopes": [


### PR DESCRIPTION
- The git.inputValidation setting expects a boolean value (true/false), not a string. 
- Changed from 'always' to true to match the correct VS Code setting schema and avoid validation warnings.