### PR TITLE
feat: add missing third-party dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,14 @@ description = "Hms Tz"
 requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
+dependencies = [
+    "PyPDF2",
+    "requests",
+    "python-dateutil",
+    "numpy",
+    "pandas",
+    "pypika",
+]
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]


### PR DESCRIPTION
Add explicit runtime dependencies to fix CI installation failure caused by missing 'PyPDF2' module during DocType sync of NHIF Patient Claim.

Scanned all Python files across the hms_tz app and identified the following third-party packages imported directly:

- PyPDF2: PDF generation in NHIF Patient Claim (root cause of CI error)
- requests: HTTP calls in NHIF/Jubilee API layer (token, verification, claims, referrals, approvals, price packages, etc.)
- python-dateutil: date parsing in Patient and Lab Test modules
- numpy: Healthcare Service Unit Occupancy Chart report
- pandas: multiple reports (Item Price by Price List, Lab Report Chart, Healthcare Service Unit Occupancy Chart)
- pypika: query building in Itemized Bill, VC Payment, Visiting Consultant Charges, Itemwise Hospital Revenue reports, and admission API

While some of these (requests, python-dateutil, pypika) are transitive dependencies of frappe, declaring them explicitly is correct practice since hms_tz imports them directly at the module level. This ensures pip resolves them during 'bench get-app' / CI install regardless of installation order.

Fixes: ModuleNotFoundError: No module named 'PyPDF2' during app install