### PR TITLE
fix: delegate to ERPNext and Healthcare before_tests hooks

### DIFF
--- a/hms_tz/install.py
+++ b/hms_tz/install.py
@@ -1,20 +1,42 @@
 import frappe
+from erpnext.setup.utils import before_tests as erpnext_before_tests
+from healthcare.healthcare.utils import before_tests as healthcare_before_tests
 
 
 def before_tests():
     """Setup required master data before running tests.
 
-    ERPNext's setup wizard normally creates certain records (like Warehouse Types)
-    that are needed when Company test records are inserted. Since the wizard doesn't
-    run in CI, we ensure these records exist here.
+    When ``bench run-tests --app hms_tz`` is executed, Frappe's test runner
+    only invokes ``before_tests`` hooks registered by *hms_tz* (because it
+    passes ``app_name="hms_tz"`` to ``frappe.get_hooks``).  ERPNext's and
+    Healthcare's ``before_tests`` hooks — which bootstrap the full setup
+    wizard, fixture records, healthcare master data, etc. — are **not**
+    called automatically.
+
+    This function therefore delegates to the upstream apps first,
+    ensuring the test database has all required master data (Company,
+    Chart of Accounts, Warehouse Types, Genders, Medical Departments,
+    Item Groups, etc.) before hms_tz's own test records are created.
     """
-    create_warehouse_types()
 
 
-def create_warehouse_types():
-    warehouse_types = ["Transit"]
-    for wt in warehouse_types:
-        if not frappe.db.exists("Warehouse Type", wt):
-            frappe.get_doc({"doctype": "Warehouse Type", "name": wt}).insert(
-                ignore_permissions=True
-            )
+    # 1. ERPNext: runs setup_complete() → install_fixtures (Warehouse Types,
+    #    Genders, Item Groups, Territories, etc.), creates Company, Fiscal Year,
+    #    enables all roles for Administrator, sets selling/stock defaults.
+    erpnext_before_tests()
+
+
+    # 2. Healthcare: creates Frappe Care LLC (if needed), Medical Departments,
+    #    Antibiotics, Lab Test UOMs, Dosages, Prescription Durations,
+    #    Healthcare Item Groups, Sensitivities, Healthcare Service Units, etc.
+    healthcare_before_tests()
+
+    # 3. hms_tz-specific setup
+    # setup_hms_tz_test_data()
+
+    frappe.db.commit()
+
+
+def setup_hms_tz_test_data():
+    """Create any additional master data specific to hms_tz tests."""
+    return


### PR DESCRIPTION
Rewrite hms_tz/install.py to properly bootstrap the test database by calling upstream apps' before_tests functions instead of manually creating individual records.

Problem:
When 'bench run-tests --app hms_tz' runs, Frappe's test_runner passes app_name='hms_tz' to frappe.get_hooks('before_tests'), so only hms_tz's hook is invoked. ERPNext's and Healthcare's before_tests — which run setup_complete() to create Company, Chart of Accounts, and all fixture records — are skipped entirely. This causes LinkValidationErrors for missing master data (Warehouse Type: Transit, Gender: Female, etc.) when test records are inserted.

Solution:
- Call erpnext.setup.utils.before_tests() first, which runs the full setup wizard (setup_complete -> install_fixtures), creating:
  * Company 'Wind Power LLC' with Chart of Accounts
  * All fixture records: Warehouse Types (Transit), Genders, Item Groups, Territories, Customer Groups, Supplier Groups, Modes of Payment, Designations, UOMs, Party Types, etc.
  * Fiscal Year, Price Lists, Stock/Selling Settings defaults
  * All roles assigned to Administrator

- Then call healthcare.healthcare.utils.before_tests(), which creates:
  * Medical Departments, Antibiotics, Lab Test UOMs
  * Prescription Durations and Dosages, Dosage Forms
  * Healthcare Item Groups (Laboratory, Drug)
  * Sensitivities, Healthcare Service Units
  * Healthcare domain activation

- Replace the previous approach of manually creating individual records (only Warehouse Type: Transit) which was incomplete and fragile

- Add setup_hms_tz_test_data() placeholder for any future hms_tz- specific test fixtures