### PR TITLE
feat: auto-create accounting dimensions on install and before tests

### DIFF
--- a/hms_tz/hooks.py
+++ b/hms_tz/hooks.py
@@ -90,7 +90,7 @@ doctype_list_js = {
 # ------------
 
 # before_install = "hms_tz.install.before_install"
-# after_install = "hms_tz.install.after_install"
+after_install = "hms_tz.install.after_install"
 
 
 after_migrate = [

--- a/hms_tz/install.py
+++ b/hms_tz/install.py
@@ -8,6 +8,51 @@ from hms_tz.patches.custom_fields.create_custom_fields import execute as create_
 from hms_tz.patches.property_setter.create_property_setters import execute as create_property_setters
 
 
+def after_install():
+    """Hook called after hms_tz app installation on a site."""
+    create_accounting_dimensions()
+    frappe.db.commit()
+
+
+def create_accounting_dimensions():
+    """Create Accounting Dimensions for Healthcare Practitioner and Healthcare Service Unit.
+
+    These dimensions add corresponding custom fields on all applicable
+    accounting doctypes (Sales Invoice, Purchase Invoice, Journal Entry, etc.).
+    hms_tz code relies on these fields existing on transaction line items.
+    """
+    dimensions = [
+        {
+            "document_type": "Healthcare Practitioner",
+            "label": "Healthcare Practitioner",
+        },
+        {
+            "document_type": "Healthcare Service Unit",
+            "label": "Healthcare Service Unit",
+        },
+    ]
+
+    for dimension_data in dimensions:
+        document_type = dimension_data["document_type"]
+
+        if frappe.db.exists("Accounting Dimension", {"document_type": document_type}):
+            continue
+
+        try:
+            doc = frappe.new_doc("Accounting Dimension")
+            doc.document_type = document_type
+            doc.label = dimension_data["label"]
+            doc.disabled = 0
+            doc.save(ignore_permissions=True)
+            frappe.db.commit()
+        except Exception:
+            frappe.log_error(
+                title=f"Error creating Accounting Dimension for '{document_type}'",
+                message=frappe.get_traceback(),
+            )
+            frappe.db.rollback()
+
+
 def before_tests():
     """Setup required master data before running tests.
 
@@ -34,7 +79,10 @@ def before_tests():
     #    Healthcare Item Groups, Sensitivities, Healthcare Service Units, etc.
     healthcare_before_tests()
 
-    # 3. hms_tz-specific setup: custom fields, property setters, etc.
+    # 3. hms_tz accounting dimensions (Healthcare Practitioner, Healthcare Service Unit)
+    create_accounting_dimensions()
+
+    # 4. hms_tz-specific setup: custom fields, property setters, etc.
     setup_hms_tz_test_data()
 
     frappe.db.commit()

--- a/hms_tz/nhif/api/healthcare_utils.py
+++ b/hms_tz/nhif/api/healthcare_utils.py
@@ -620,12 +620,12 @@ def get_item_form_LRPT(LRPT_doc):
 def update_dimensions(doc):
     for item in doc.items:
         refd, refn = get_references(item)
-        if doc.healthcare_practitioner:
+        if doc.get("healthcare_practitioner"):
             item.healthcare_practitioner = doc.healthcare_practitioner
         elif refd and refn:
             item.healthcare_practitioner = get_healthcare_practitioner(item)
 
-        if doc.healthcare_service_unit and not item.healthcare_service_unit and not refn:
+        if doc.get("healthcare_service_unit") and not item.get("healthcare_service_unit") and not refn:
             item.healthcare_service_unit = doc.healthcare_service_unit
 
         if refd and refn:


### PR DESCRIPTION
healthcare_practitioner and healthcare_service_unit are accounting dimension fields that hms_tz code expects on Sales Invoice (and other accounting doctypes). Previously these were created manually, causing AttributeError in CI where they don't exist.

Changes:
- Add create_accounting_dimensions() to install.py that creates Accounting Dimension records for Healthcare Practitioner and Healthcare Service Unit
- Add after_install() hook so dimensions are created on app install
- Call create_accounting_dimensions() from before_tests() for CI
- Uncomment after_install hook in hooks.py
- Use doc.get() in update_dimensions() for defensive field access