### PR TITLE
fix: remove dead insurance_assignment Link field from Insurance Coverage Request

### DIFF
--- a/hms_tz/hms_tz/doctype/insurance_coverage_request/insurance_coverage_request.json
+++ b/hms_tz/hms_tz/doctype/insurance_coverage_request/insurance_coverage_request.json
@@ -14,7 +14,6 @@
   "patient",
   "patient_name",
   "column_break_4",
-  "insurance_assignment",
   "insurance_company",
   "section_break_7",
   "sales_invoice",
@@ -71,12 +70,6 @@
   {
    "fieldname": "column_break_4",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "insurance_assignment",
-   "fieldtype": "Link",
-   "label": "Insurance Assignment",
-   "options": "Insurance Assignment"
   },
   {
    "fieldname": "insurance_company",


### PR DESCRIPTION
The insurance_assignment field links to DocType 'Insurance Assignment' which does not exist in any installed app, causing:
  DoesNotExistError: DocType Insurance Assignment not found

The field is not referenced in any Python code. Removed from field_order and field definitions.