### PR TITLE
fix: correct import path for create_lab_test_template in test_lab_test

### DIFF
--- a/hms_tz/hms_tz/doctype/lab_test/test_lab_test.py
+++ b/hms_tz/hms_tz/doctype/lab_test/test_lab_test.py
@@ -11,12 +11,12 @@ from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings impor
     get_income_account,
     get_receivable_account,
 )
+from healthcare.healthcare.doctype.patient_medical_record.test_patient_medical_record import (
+    create_lab_test_template as create_blood_test_template,
+)
 
 from hms_tz.hms_tz.doctype.lab_test.lab_test import create_multiple
 from hms_tz.hms_tz.doctype.patient_appointment.test_patient_appointment import create_patient
-from hms_tz.hms_tz.doctype.patient_medical_record.test_patient_medical_record import (
-    create_lab_test_template as create_blood_test_template,
-)
 
 
 class TestLabTest(unittest.TestCase):


### PR DESCRIPTION
patient_medical_record is a healthcare app doctype, not hms_tz. Fixed import from healthcare.healthcare.doctype instead of hms_tz.hms_tz.doctype.