### PR TITLE
fix: resolve CI test failures (ward_type, mobile None, Phisiotherapy)

### DIFF
--- a/hms_tz/hms_tz/doctype/healthcare_service_unit_type/test_healthcare_service_unit_type.py
+++ b/hms_tz/hms_tz/doctype/healthcare_service_unit_type/test_healthcare_service_unit_type.py
@@ -23,6 +23,13 @@ def get_unit_type():
     if frappe.db.exists("Healthcare Service Unit Type", "Inpatient Rooms"):
         return frappe.get_cached_doc("Healthcare Service Unit Type", "Inpatient Rooms")
 
+    # Ensure Healthcare Ward Type exists
+    if not frappe.db.exists("Healthcare Ward Type", "General Ward"):
+        frappe.get_doc({
+            "doctype": "Healthcare Ward Type",
+            "ward_type_name": "General Ward",
+        }).insert(ignore_permissions=True)
+
     unit_type = frappe.new_doc("Healthcare Service Unit Type")
     unit_type.service_unit_type = "Inpatient Rooms"
     unit_type.inpatient_occupancy = 1
@@ -32,5 +39,6 @@ def get_unit_type():
     unit_type.uom = "Hour"
     unit_type.no_of_hours = 1
     unit_type.rate = 4000
+    unit_type.ward_type = "General Ward"
     unit_type.save()
     return unit_type

--- a/hms_tz/hms_tz/doctype/therapy_type/test_therapy_type.py
+++ b/hms_tz/hms_tz/doctype/therapy_type/test_therapy_type.py
@@ -20,6 +20,14 @@ class TestTherapyType(unittest.TestCase):
 
 def create_therapy_type():
     exercise = create_exercise_type()
+
+    # Ensure Healthcare Points of Care record exists for default value
+    if not frappe.db.exists("Healthcare Points of Care", "Phisiotherapy"):
+        frappe.get_doc({
+            "doctype": "Healthcare Points of Care",
+            "point_of_care_name": "Phisiotherapy",
+        }).insert(ignore_permissions=True)
+
     therapy_type = frappe.db.exists("Therapy Type", "Basic Rehab")
     if not therapy_type:
         therapy_type = frappe.new_doc("Therapy Type")

--- a/hms_tz/nhif/api/patient.py
+++ b/hms_tz/nhif/api/patient.py
@@ -25,12 +25,13 @@ def validate(doc, method):
     check_card_number(doc.card_no, doc.is_new(), doc.name, "validate")
 
     # replace initial 0 with 255 and remove all the unnecessray characters
-    doc.mobile = remove_special_characters(doc.mobile)
-    if doc.mobile[0] == "0":
-        doc.mobile = "255" + doc.mobile[1:]
+    if doc.mobile:
+        doc.mobile = remove_special_characters(doc.mobile)
+        if doc.mobile and doc.mobile[0] == "0":
+            doc.mobile = "255" + doc.mobile[1:]
     if doc.next_to_kin_mobile_no:
         doc.next_to_kin_mobile_no = remove_special_characters(doc.next_to_kin_mobile_no)
-        if doc.next_to_kin_mobile_no[0] == "0":
+        if doc.next_to_kin_mobile_no and doc.next_to_kin_mobile_no[0] == "0":
             doc.next_to_kin_mobile_no = "255" + doc.next_to_kin_mobile_no[1:]
     validate_mobile_number(doc.name, doc.mobile)
     if not doc.is_new():


### PR DESCRIPTION
1. test_healthcare_service_unit_type: Create Healthcare Ward Type record before testing, and set ward_type on the unit type (now mandatory via custom field).

2. patient.py validate: Guard doc.mobile and doc.next_to_kin_mobile_no against None before calling remove_special_characters and indexing.

3. test_therapy_type: Create Healthcare Points of Care 'Phisiotherapy' record before testing, since it's the default value on the points_of_care Link field.