### PR TITLE
fix: handle non-numeric lab machine result values in normal range calculation

### DIFF
--- a/hms_tz/nhif/api/lab_test.py
+++ b/hms_tz/nhif/api/lab_test.py
@@ -9,7 +9,7 @@ import frappe
 from frappe import _
 from frappe.core.doctype.sms_settings.sms_settings import send_sms
 from frappe.query_builder import DocType
-from frappe.utils import get_fullname, getdate
+from frappe.utils import flt, get_fullname, getdate
 
 from hms_tz.hms_tz.doctype.hospital_revenue_entry.hospital_revenue_entry import (
     create_revenue_entry,
@@ -77,6 +77,14 @@ def set_normals(doc):
 
             if not row.result_value:
                 continue
+
+            try:
+                float(row.result_value)
+            except ValueError:
+                row.detailed_normal_range = ""
+                row.result_status = ""
+                continue
+
             data_normals = calc_data_normals(normals, row.result_value)
             row.detailed_normal_range = data_normals["detailed_normal_range"]
             row.result_status = data_normals["result_status"]
@@ -84,7 +92,7 @@ def set_normals(doc):
 
 def calc_data_normals(data, value):
     data = frappe._dict(data)
-    value = float(value)
+    value = flt(value)
     result = {"detailed_normal_range": "", "result_status": ""}
 
     if data.min and not data.max:


### PR DESCRIPTION
Lab machines (e.g., MindRay BC-5380) output '***.**' for values beyond their measurable range. This caused a ValueError crash in calc_data_normals() when float() tried to parse the non-numeric string.

Changes:
- Add try/except guard in set_normals() to skip normal range calculation for non-numeric result values (e.g., '***.**'), clearing detailed_normal_range and result_status instead of crashing
- Replace float() with flt() (from frappe.utils) in calc_data_normals() as a safety net, which returns 0.0 for unparseable values instead of raising ValueError
- Import flt from frappe.utils