### PR TITLE
fix: use frappe.db.set_value to cancel stale appointments in background routine

### DIFF
--- a/hms_tz/nhif/api/healthcare_utils.py
+++ b/hms_tz/nhif/api/healthcare_utils.py
@@ -23,6 +23,8 @@ from frappe.utils import (
     nowtime,
 )
 
+from hms_tz.hms_tz.utils import manage_fee_validity
+
 
 def get_childs_map():
     childs_map = {
@@ -1880,15 +1882,18 @@ def delete_or_cancel_draft_document():
 
     for app_doc in appointments:
         try:
-            doc = frappe.get_cached_doc("Patient Appointment", app_doc.name)
-            doc.status = "Cancelled"
-            doc.save(ignore_permissions=True)
+            frappe.db.set_value("Patient Appointment", app_doc.name, "status", "Cancelled")
+            appointment_doc = frappe.get_cached_doc("Patient Appointment", app_doc.name)
+            appointment_doc.status = "Cancelled"
+
+            manage_fee_validity(appointment_doc)
 
         except Exception:
             frappe.log_error(
                 frappe.get_traceback(),
                 str("Error in cancelling draft appointment"),
             )
+        frappe.db.commit()
 
     vital_docs = frappe.db.sql(
         f"""


### PR DESCRIPTION
Replace doc.save() with frappe.db.set_value() in delete_or_cancel_draft_document() to bypass validation hooks when cancelling open appointments older than 7 days.

The previous approach using doc.save() triggered the full validation chain (overlap checks, insurance subscription validation, etc.) which caused errors like MaximumCapacityError and ValidationError for insurance subscription mismatches — unrelated to the simple status change.

Changes:
- Use frappe.db.set_value() to directly set status to 'Cancelled' in DB, bypassing all validate hooks (matching frontend update_status pattern)
- Import and call manage_fee_validity() directly to properly handle fee validity (decrement visited count and remove fee validity references)
- Set appointment_doc.status in-memory before calling manage_fee_validity so it correctly detects the 'Cancelled' status for fee adjustments
- Add frappe.db.commit() after each appointment to persist progress and avoid losing changes if a later appointment fails