### PR TITLE
refactor: use keyword args for frappe.log_error in delete_or_cancel_draft_document

### DIFF
--- a/hms_tz/nhif/api/healthcare_utils.py
+++ b/hms_tz/nhif/api/healthcare_utils.py
@@ -1892,8 +1892,8 @@ def delete_or_cancel_draft_document():
 
         except Exception:
             frappe.log_error(
-                frappe.get_traceback(),
-                str("Error in cancelling draft appointment"),
+                title=str(f"Cancelling draft appointment: {app_doc.name}"),
+                message=frappe.get_traceback(),
             )
         frappe.db.commit()
 
@@ -1914,8 +1914,8 @@ def delete_or_cancel_draft_document():
 
         except Exception:
             frappe.log_error(
-                frappe.get_traceback(),
-                str("Error in deleting draft vital signs"),
+                title=str(f"Deleting draft vital signs: {vs_doc.name}"),
+                message=frappe.get_traceback(),
             )
         frappe.db.commit()
 
@@ -1937,10 +1937,8 @@ def delete_or_cancel_draft_document():
 
         except Exception:
             frappe.log_error(
-                frappe.get_traceback(),
-                str(
-                    f"Error for Return or Cancel Delivery Note: {frappe.bold(delivery_note_doc.name)} Via LRPMT Returns"
-                ),
+                title=str(f"Error for Return or Cancel Delivery Note: {frappe.bold(delivery_note_doc.name)} Via LRPMT Returns"),
+                message=frappe.get_traceback(),
             )
 
         frappe.db.commit()


### PR DESCRIPTION
Update all three frappe.log_error calls to use explicit keyword arguments (title, message) instead of positional arguments, aligning with the Frappe v15 API signature:

- Appointment cancellation: include appointment name in title
- Vital signs deletion: include vital signs name in title
- Delivery note return/cancel: include delivery note name in title

This improves readability and ensures correct argument mapping as frappe.log_error(title, message) keyword order.