### PR TITLE
fix: remove duplicate Medication-company_options Custom Field from fixture

### DIFF
--- a/hms_tz/patches/fixtures/custom_field.json
+++ b/hms_tz/patches/fixtures/custom_field.json
@@ -19209,21 +19209,5 @@
         "fieldtype": "Link",
         "options": "Healthcare Service Unit",
         "doctype": "Custom Field"
-    },
-    {
-        "name": "Medication-company_options",
-        "owner": "info@aakvatech.com",
-        "creation": "2021-08-09 00:35:21.147403",
-        "modified": "2021-08-09 00:35:21.147403",
-        "modified_by": "info@aakvatech.com",
-        "idx": 30,
-        "docstatus": 0,
-        "dt": "Medication",
-        "label": "Company Options",
-        "fieldname": "company_options",
-        "insert_after": "column_break_6",
-        "fieldtype": "Table",
-        "options": "Healthcare Company Option",
-        "doctype": "Custom Field"
     }
 ]


### PR DESCRIPTION

The 'company_options' field on Medication existed as both a native DocField (in medication.json) and a Custom Field ('Medication-company_options') in the custom_field.json fixture. This caused Frappe's meta.get_table_fields() to return 2 entries for the same field, making get_all_children() return each Healthcare Company Option child row twice. On insert/save, the second insert attempt failed with DuplicateEntryError:
  'Healthcare Company Option <name> already exists'

Removed the duplicate Custom Field entry from the fixture to ensure only the native DocField remains, resolving the DuplicateEntryError on Medication creation and save.