### PR TITLE
feat(nhif_patient_claim): add Main Diagnosis Code field and validate before submit

### DIFF
--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.json
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.json
@@ -51,6 +51,7 @@
   "practitioner_name",
   "practitioner_no",
   "serial_no",
+  "main_diagnosis_code",
   "column_break_znuxw",
   "patient_type_code",
   "attendance_date",
@@ -187,6 +188,7 @@
   {
    "fieldname": "practitioner_no",
    "fieldtype": "Small Text",
+   "hidden": 1,
    "label": "Practitioner No",
    "read_only": 1
   },
@@ -437,6 +439,7 @@
   {
    "fieldname": "practitioner_name",
    "fieldtype": "Data",
+   "hidden": 1,
    "label": "Practitioner Name",
    "read_only": 1,
    "search_index": 1
@@ -714,13 +717,19 @@
    "fieldtype": "Small Text",
    "label": "Visit Type Description",
    "read_only": 1
+  },
+  {
+   "fieldname": "main_diagnosis_code",
+   "fieldtype": "Data",
+   "label": "Main Diagnosis Code",
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-16 17:03:45.891972",
+ "modified": "2026-02-25 12:37:53.080241",
  "modified_by": "Administrator",
  "module": "NHIF",
  "name": "NHIF Patient Claim",

--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -113,6 +113,8 @@ class NHIFPatientClaim(Document):
             frappe.qb.update(pa).set(pa.nhif_patient_claim, "").where(pa.name == self.patient_appointment).run()
 
     def before_submit(self):
+        self.validate_reqd_fields()
+
         if not self.allow_changes:
             self.db_set("allow_changes", 1)
 
@@ -863,6 +865,10 @@ class NHIFPatientClaim(Document):
 
         self.folio_no = folio_no
         self.db_set("folio_no", folio_no)
+
+    def validate_reqd_fields(self):
+        if not self.main_diagnosis_code:
+            frappe.throw(_("Main Diagnosis Code is required"))
 
 def get_missing_patient_signature(self):
     if self.patient:

--- a/hms_tz/nhif/nhif_api/patient_claim.py
+++ b/hms_tz/nhif/nhif_api/patient_claim.py
@@ -293,9 +293,7 @@ def get_payload(doc):
         "AttendingPractitioners": [d.mct_code for d in doc.practitioners if d.mct_code],
         "LateSubmissionReason": doc.delayreason,
         "AmountClaimed": doc.total_amount,
-        "MainDiagnosisCode": ", ".join(
-            d.get("DiseaseCode") for d in diseases if d.get("Status") == "Final" and d.get("DiseaseCode")
-        ),
+        "MainDiagnosisCode": doc.main_diagnosis_code,
         "ConfirmationCode": doc.confirmation_code or "",
         "FolioDiseases": diseases,
         "FolioItems": items,


### PR DESCRIPTION
- Added new 'main_diagnosis_code' field (Data, searchable) to NHIF Patient Claim doctype
- Hidden 'practitioner_name' and 'practitioner_no' fields from the form view
- Added 'validate_reqd_fields' method to enforce Main Diagnosis Code is set before submission
- Simplified 'MainDiagnosisCode' in claim payload to use the new field directly instead of deriving it from FolioDiseases with 'Final' status