### PR TITLE
fix(verification): handle non-ACCEPTED authorization with existing AuthorizationNo

### DIFF
--- a/hms_tz/nhif/nhif_api/verification.py
+++ b/hms_tz/nhif/nhif_api/verification.py
@@ -553,7 +553,14 @@ def authorize_patient(
             card_no=card_no or national_id,
         )
 
-        if auth_data.get("AuthorizationStatus") != "ACCEPTED":
+        # Ticket No: 1869
+        if auth_data.get("AuthorizationNo") and auth_data.get("AuthorizationStatus") != "ACCEPTED":
+            frappe.msgprint(
+                title=auth_data.get("AuthorizationStatus"),
+                msg=auth_data["Remarks"],
+            )
+
+        elif not auth_data.get("AuthorizationNo") and auth_data.get("AuthorizationStatus") != "ACCEPTED":
             frappe.throw(
                 title=auth_data.get("AuthorizationStatus"),
                 msg=auth_data["Remarks"],


### PR DESCRIPTION
Ticket No: 1869

- When AuthorizationNo is present but AuthorizationStatus is not ACCEPTED, show a non-blocking msgprint instead of throwing an error, allowing the workflow to continue
- When AuthorizationNo is absent and status is not ACCEPTED, retain the existing frappe.throw behavior to block the process
- This prevents unnecessary interruptions when authorization has already been partially processed by NHIF