### PR TITLE
fix(price_package): correct operator precedence in price_package length check

### DIFF
--- a/hms_tz/nhif/nhif_api/price_package.py
+++ b/hms_tz/nhif/nhif_api/price_package.py
@@ -267,7 +267,7 @@ def set_package_diff(company):
         add_price_packages_records(doc, new_price_packages, "New", service_map)
         add_price_packages_records(doc, deleted_price_packages, "Deleted", service_map)
 
-        if (doc.get("price_package") and len(doc.price_package)) > 0:
+        if doc.get("price_package") and len(doc.price_package) > 0:
             doc.timestamp = now_datetime()
             doc.user_id = frappe.session.user
             doc.company = company


### PR DESCRIPTION
- Fix parenthesis placement in set_package_diff condition: the previous code wrapped 'doc.get("price_package") and len(doc.price_package)' in parentheses before comparing with > 0, causing the boolean result of doc.get() to be compared instead of the list length
- Now correctly checks doc.get("price_package") first, then separately verifies len(doc.price_package) > 0