### PR TITLE
perf(nhif): switch NHIF Response Log and NHIF Update to hash-based naming and optimize grid

### DIFF
--- a/hms_tz/nhif/doctype/nhif_response_log/nhif_response_log.json
+++ b/hms_tz/nhif/doctype/nhif_response_log/nhif_response_log.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "naming_series:",
+ "autoname": "hash",
  "creation": "2020-11-10 17:06:43.332385",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -165,13 +165,14 @@
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-07 11:59:04.645295",
+ "modified": "2026-02-25 18:34:39.390501",
  "modified_by": "Administrator",
  "module": "NHIF",
  "name": "NHIF Response Log",
- "naming_rule": "By \"Naming Series\" field",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -187,6 +188,8 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/hms_tz/nhif/doctype/nhif_update/nhif_update.json
+++ b/hms_tz/nhif/doctype/nhif_update/nhif_update.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "NHIFU-.YY.-.#########",
+ "autoname": "hash",
  "creation": "2021-08-06 22:52:28.683289",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -89,14 +89,15 @@
    "search_index": 1
   }
  ],
+ "grid_page_length": 50,
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-07 15:22:56.612231",
+ "modified": "2026-02-25 22:33:31.432012",
  "modified_by": "Administrator",
  "module": "NHIF",
  "name": "NHIF Update",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -109,6 +110,8 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
NHIF Response Log:
- Change autoname from 'naming_series:' to 'hash' and naming_rule to 'Random' to avoid naming series contention and improve insert performance
- Add grid_page_length (50), row_format (Dynamic), and rows_threshold_for_grid_search (20) for better grid rendering

NHIF Update:
- Change autoname from 'NHIFU-.YY.-.#########' to 'hash' and naming_rule to 'Random' for consistent naming and faster document creation
- Add grid_page_length (50), row_format (Dynamic), and rows_threshold_for_grid_search (20) for better grid rendering