### PR TITLE
fix(custom_fields): remove conditional constraints from Patient card_no and national_id fields

### DIFF
--- a/hms_tz/patches/custom_fields/custom_fields_json/02_patient.json
+++ b/hms_tz/patches/custom_fields/custom_fields_json/02_patient.json
@@ -501,7 +501,6 @@
         "fetch_if_empty": 0,
         "collapsible": 0,
         "non_negative": 0,
-        "mandatory_depends_on": "eval: !doc.card_no",
         "reqd": 0,
         "unique": 1,
         "is_virtual": 0,

--- a/hms_tz/patches/custom_fields/hms_tz_custom_fields.py
+++ b/hms_tz/patches/custom_fields/hms_tz_custom_fields.py
@@ -2081,7 +2081,6 @@ def execute():
                 "label": "Card No",
                 "fieldname": "card_no",
                 "insert_after": "insurance_details",
-                "read_only_depends_on": "eval: doc.card_no",
                 "translatable": 1,
             },
             {


### PR DESCRIPTION
- Remove 'mandatory_depends_on: eval: !doc.card_no' from national_id field in 02_patient.json, so national_id is no longer conditionally mandatory based on card_no presence
- Remove 'read_only_depends_on: eval: doc.card_no' from card_no field in hms_tz_custom_fields.py, so card_no is no longer read-only once set