### PR TITLE
refactor(verification): update NHIF API response keys to camelCase format

### DIFF
--- a/hms_tz/nhif/api/patient_appointment.js
+++ b/hms_tz/nhif/api/patient_appointment.js
@@ -433,15 +433,15 @@ frappe.ui.form.on("Patient Appointment", {
           if (data.message && data.message !== "Error") {
             frappe.utils.play_sound("submit");
             const card = data.message;
-            if (card.AuthorizationStatus == "ACCEPTED") {
-              frm.set_value("coverage_plan_name", card.CoveragePlanName);
-              frm.set_value("authorization_number", card.AuthorizationNo);
-              frm.set_value("nhif_employer_name", card.EmployerName);
+            if (card.authorizationStatus == "ACCEPTED") {
+              frm.set_value("coverage_plan_name", card.coveragePlanName);
+              frm.set_value("authorization_number", card.authorizationNo);
+              frm.set_value("nhif_employer_name", card.employerName);
               frm.set_value("fpcode", card.fpCode);
               frm.set_value("poc_reference_no", card.ReferenceNo);
               frm.set_value(
                 "years_of_insurance",
-                card.ServiceYear === null ? 0 : parseInt(card.ServiceYear)
+                card.serviceYear === null ? 0 : parseInt(card.serviceYear)
               );
               frm.save().then(() => {
                 frm.reload_doc();

--- a/hms_tz/nhif/api/patient_appointment.py
+++ b/hms_tz/nhif/api/patient_appointment.py
@@ -375,11 +375,11 @@ def make_encounter(doc, method):
 def update_insurance_subscription(insurance_subscription, data):
     subscription_doc = frappe.get_cached_doc("Healthcare Insurance Subscription", insurance_subscription)
 
-    if subscription_doc.hms_tz_scheme_id == data["SchemeID"]:
+    if subscription_doc.hms_tz_scheme_id == data["schemeID"]:
         return data
 
     filters = {
-        "nhif_scheme_id": data["SchemeID"],
+        "nhif_scheme_id": data["schemeID"],
         "is_active": 1,
     }
 
@@ -395,13 +395,13 @@ def update_insurance_subscription(insurance_subscription, data):
     plan = plan_list[0] if len(plan_list) == 1 else None
 
     if plan:
-        data["CoveragePlanName"] = plan.name
+        data["coveragePlanName"] = plan.name
         subscription_doc.insurance_company = plan.insurance_company
         subscription_doc.healthcare_insurance_coverage_plan = plan.name
         subscription_doc.coverage_plan_name = plan.coverage_plan_name
 
-    subscription_doc.hms_tz_scheme_id = data["SchemeID"]
-    subscription_doc.hms_tz_scheme_name = data["SchemeName"]
+    subscription_doc.hms_tz_scheme_id = data["schemeID"]
+    subscription_doc.hms_tz_scheme_name = data["schemeName"]
 
     subscription_doc.save(ignore_permissions=True)
 

--- a/hms_tz/nhif/nhif_api/verification.py
+++ b/hms_tz/nhif/nhif_api/verification.py
@@ -528,24 +528,24 @@ def authorize_patient(
         )
 
         # Ticket No: 1869
-        if auth_data.get("AuthorizationNo") and auth_data.get("AuthorizationStatus") != "ACCEPTED":
+        if auth_data.get("authorizationNo") and auth_data.get("authorizationStatus") != "ACCEPTED":
             frappe.msgprint(
-                title=auth_data.get("AuthorizationStatus"),
-                msg=auth_data["Remarks"],
+                title=auth_data.get("authorizationStatus"),
+                msg=auth_data["remarks"],
             )
 
-        elif not auth_data.get("AuthorizationNo") and auth_data.get("AuthorizationStatus") != "ACCEPTED":
+        elif not auth_data.get("authorizationNo") and auth_data.get("authorizationStatus") != "ACCEPTED":
             frappe.throw(
-                title=auth_data.get("AuthorizationStatus"),
-                msg=auth_data["Remarks"],
+                title=auth_data.get("authorizationStatus"),
+                msg=auth_data["remarks"],
             )
 
-        frappe.msgprint(auth_data["Remarks"], alert=True)
-        add_scheme(auth_data.get("SchemeID"), auth_data.get("SchemeName"))
+        frappe.msgprint(auth_data["remarks"], alert=True)
+        add_scheme(auth_data.get("schemeID"), auth_data.get("schemeName"))
         auth_data = update_insurance_subscription(insurance_subscription, auth_data)
 
         auth_detail = get_authorization_details(
-            auth_data.get("AuthorizationNo"),
+            auth_data.get("authorizationNo"),
             card_no or national_id,
             company,
             settings_doc,
@@ -564,7 +564,7 @@ def authorize_patient(
             biometric_method,
             company,
             appointment_id=ref_docname,
-            authorization_no=auth_data.get("AuthorizationNo"),
+            authorization_no=auth_data.get("authorizationNo"),
             settings_doc=settings_doc,
             ref_doctype=ref_doctype,
             ref_docname=ref_docname,


### PR DESCRIPTION
Update all NHIF VerifyCard API response field references from PascalCase to camelCase to match the updated API response format.

verification.py:
- AuthorizationNo -> authorizationNo
- AuthorizationStatus -> authorizationStatus
- Remarks -> remarks
- SchemeID -> schemeID
- SchemeName -> schemeName

patient_appointment.py:
- SchemeID -> schemeID
- SchemeName -> schemeName
- CoveragePlanName -> coveragePlanName

patient_appointment.js:
- AuthorizationStatus -> authorizationStatus
- CoveragePlanName -> coveragePlanName
- AuthorizationNo -> authorizationNo
- EmployerName -> employerName
- ServiceYear -> serviceYear