### PR TITLE
fix: update radiology_test_comment property setters

### DIFF
--- a/hms_tz/patches/property_setter/property_setters_json/16_radiology_procedure_prescription.json
+++ b/hms_tz/patches/property_setter/property_setters_json/16_radiology_procedure_prescription.json
@@ -96,8 +96,8 @@
         "doc_type": "Radiology Procedure Prescription",
         "field_name": "radiology_test_comment",
         "property": "mandatory_depends_on",
-        "property_type": "Data",
-        "value": "eval:doc.override_subscription == 1 && doc.prescribe != 1;",
+        "property_type": "Small Text",
+        "value": "eval: doc.docstatus == 0;",
         "doctype": "Property Setter"
     },
     {
@@ -115,23 +115,6 @@
         "property": "ready_only",
         "property_type": "Check",
         "value": "0",
-        "doctype": "Property Setter"
-    },
-    {
-        "name": "Radiology Procedure Prescription-radiology_test_comment-reqd",
-        "owner": "nabeel.tharani@hc.shm.or.tz",
-        "creation": "2021-06-21 12:15:32.333056",
-        "modified": "2021-06-21 12:15:32.333056",
-        "modified_by": "nabeel.tharani@hc.shm.or.tz",
-        "docstatus": 0,
-        "idx": 0,
-        "is_system_generated": 0,
-        "doctype_or_field": "DocField",
-        "doc_type": "Radiology Procedure Prescription",
-        "field_name": "radiology_test_comment",
-        "property": "reqd",
-        "property_type": "Check",
-        "value": "1",
         "doctype": "Property Setter"
     }
 ]


### PR DESCRIPTION
- Change mandatory_depends_on condition from 'eval:doc.override_subscription == 1 && doc.prescribe != 1' to 'eval: doc.docstatus == 0' so the radiology test comment is mandatory whenever the document is in draft state, regardless of override_subscription or prescribe flags.

- Update mandatory_depends_on property_type from Data to Small Text to match the expected field type.

- Remove the obsolete reqd (required) property setter for radiology_test_comment, since the mandatory_depends_on condition now handles the requirement dynamically.