### PR TITLE
fix: exclude sales order items from cash IPD drug list in MCR

### DIFF
--- a/hms_tz/nhif/doctype/medication_change_request/medication_change_request.py
+++ b/hms_tz/nhif/doctype/medication_change_request/medication_change_request.py
@@ -242,7 +242,7 @@ class MedicationChangeRequest(Document):
                 self.append("drug_prescription", new_row)
 
             # add all cash items from pe for ipd patient
-            if inpatient_record and row.prescribe == 1:
+            if inpatient_record and row.prescribe == 1 and not self.sales_order:
                 new_row = row.as_dict()
                 new_row["name"] = None
                 new_row["parent"] = None


### PR DESCRIPTION
Add 'not self.sales_order' condition when populating drugs for cash inpatient patients to prevent items already handled via Sales Order from being duplicated into the Medication Change Request.

Previously, cash IPD drugs with prescribe=1 were always added when an inpatient_record existed, even if the MCR was created from a Sales Order. This caused duplicate entries since both the SO branch and the IPD branch would add the same drugs.