### PR TITLE
fix: guard against missing patient data in NHIF info lookup

### DIFF
--- a/hms_tz/nhif/api/insurance_subscription.js
+++ b/hms_tz/nhif/api/insurance_subscription.js
@@ -42,6 +42,10 @@ frappe.ui.form.on("Healthcare Insurance Subscription", {
     if (!frm.doc.insurance_company.includes("NHIF")) return;
     if (!frm.doc.coverage_plan_card_number && !frm.doc.national_id) return;
 
+    if (!frm.doc.patient || !frm.doc.patient_name) {
+      return;
+    }
+
     let args = {
       patient: frm.doc.patient,
       patient_name: frm.doc.patient_name,


### PR DESCRIPTION
Add early return in get_patient_name when patient or patient_name fields are empty. Without this check, the NHIF API call would be made with null/undefined values for patient and patient_name, leading to server-side errors or incorrect data lookups.