### PR TITLE
fix: filter out disabled and duplicate diagnosis codes when reusing previous encounter data

### DIFF
--- a/hms_tz/nhif/api/patient_encounter.py
+++ b/hms_tz/nhif/api/patient_encounter.py
@@ -1503,7 +1503,22 @@ def get_previous_diagnosis_and_lrpmt_items_to_reuse(kwargs, caller):
             },
             order_by="creation desc",
         )
-        data = list({v["item"]: v for v in diagnosis}.values())
+
+        unique_codes = []
+        for diag in diagnosis:
+            if diag.get("item") in unique_codes:
+                continue
+
+            unique_codes.append(diag.get("item"))
+
+            is_diabled = frappe.get_cached_value(
+                "Code Value", diag.get("item"), "disabled"
+            )
+            if is_diabled:
+                continue
+
+            data.append(diag)
+
     else:
         items = frappe.get_all(
             kwargs.doctype,


### PR DESCRIPTION

Replace the one-liner dict comprehension for deduplicating diagnosis items in 'get_previous_diagnosis_and_lrpmt_items_to_reuse' with an explicit loop that:

- Tracks already-seen diagnosis codes to skip duplicates
- Checks the 'disabled' flag on each Code Value via frappe.get_cached_value before including it in the results

This prevents disabled diagnosis codes from being suggested to practitioners when reusing items from previous patient encounters.