### PR TITLE
feat: filter out disabled and non-specific diagnosis codes in Patient Encounter

### DIFF
--- a/hms_tz/nhif/api/patient_encounter.js
+++ b/hms_tz/nhif/api/patient_encounter.js
@@ -117,6 +117,8 @@ frappe.ui.form.on("Patient Encounter", {
       function () {
         return {
           filters: {
+            disabled: 0,
+            is_non_specific: 0,
             code_system: ["in", ["ICD-9", "ICD-10", "ICD-11"]],
           },
         };
@@ -128,6 +130,8 @@ frappe.ui.form.on("Patient Encounter", {
       function () {
         return {
           filters: {
+            disabled: 0,
+            is_non_specific: 0,
             code_system: ["in", ["ICD-9", "ICD-10", "ICD-11"]],
           },
         };
@@ -136,6 +140,8 @@ frappe.ui.form.on("Patient Encounter", {
     frm.set_query("main_diagnosis_code", function () {
       return {
         filters: {
+          disabled: 0,
+          is_non_specific: 0,
           code_system: ["in", ["ICD-9", "ICD-10", "ICD-11"]],
         },
       };

--- a/hms_tz/nhif/api/patient_encounter.py
+++ b/hms_tz/nhif/api/patient_encounter.py
@@ -1513,10 +1513,10 @@ def get_previous_diagnosis_and_lrpmt_items_to_reuse(kwargs, caller):
 
             unique_codes.append(diag.get("item"))
 
-            is_diabled = frappe.get_cached_value(
-                "Code Value", diag.get("item"), "disabled"
+            diagnosis_info = frappe.get_cached_value(
+                "Code Value", diag.get("item"), ["disabled", "is_non_specific"], as_dict=True
             )
-            if is_diabled:
+            if diagnosis_info.get("disabled") or diagnosis_info.get("is_non_specific"):
                 continue
 
             data.append(diag)


### PR DESCRIPTION
- Add 'disabled: 0' and 'is_non_specific: 0' filters to the client-side set_query for codification_table (preliminary diagnosis), final_diagnosis, and main_diagnosis_code link fields to exclude disabled and non-specific Code Value entries from selection
- Update get_previous_diagnosis_and_lrpmt_items_to_reuse() to fetch both 'disabled' and 'is_non_specific' fields from Code Value and skip diagnosis entries where either flag is set, preventing reuse of non-specific or disabled diagnosis codes