### PR TITLE
style(report): fix prettier formatting in item_price_by_price_list.js

### DIFF
--- a/hms_tz/hms_tz/report/item_price_by_price_list/item_price_by_price_list.js
+++ b/hms_tz/hms_tz/report/item_price_by_price_list/item_price_by_price_list.js
@@ -15,6 +15,6 @@ frappe.query_reports["Item Price by Price List"] = {
       label: __("Item Code"),
       fieldtype: "Link",
       options: "Item",
-    }
+    },
   ],
 };


### PR DESCRIPTION
- Add trailing comma after last filter object to comply with es5 trailing-comma rule
- Add missing newline at end of file (POSIX compliance)

These formatting issues caused the pre-commit prettier hook to fail in CI, blocking all PRs targeting version-15-beta.