### PR TITLE
chore(ci): migrate deprecated pre-commit stage names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: "node_modules|.git"
-default_stages: [commit, push, manual]
+default_stages: [pre-commit, pre-push, manual]
 fail_fast: false
 
 repos:


### PR DESCRIPTION
- Replace deprecated 'commit' with 'pre-commit' in default_stages
- Replace deprecated 'push' with 'pre-push' in default_stages

The old stage names (commit, push) are deprecated and will be removed in a future version of pre-commit. This follows the recommendation from 'pre-commit migrate-config'.