### PR TITLE
chore: update pre-commit default_stages for v4.x compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: "node_modules|.git"
-default_stages: [pre-commit, pre-push, manual]
+default_stages: [commit, push, manual]
 fail_fast: false
 
 repos:


### PR DESCRIPTION
- Change default_stages from [pre-commit, pre-push, manual] to [commit, push, manual] to comply with pre-commit v4.x which dropped the 'pre-' prefix from stage names