### PR TITLE
fix: use 'definition' instead of 'description' for diagnosis in Healthcare Referral

### DIFF
--- a/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.py
+++ b/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.py
@@ -75,7 +75,7 @@ class HealthcareReferral(Document):
                 {
                     "status": "Final",
                     "disease_code": d.code,
-                    "description": d.description,
+                    "description": d.definition,
                 }
             )
             unique_diagnosis.append(d.code)
@@ -86,7 +86,7 @@ class HealthcareReferral(Document):
                     {
                         "status": "Provisional",
                         "disease_code": d.code,
-                        "description": d.description,
+                        "description": d.definition,
                     }
                 )
                 unique_diagnosis.append(d.code)


### PR DESCRIPTION
- Replace d.description with d.definition when populating the description field for both Final and Provisional diagnosis entries in the referral disease list, aligning with the correct Code Value field name