### PR TITLE
fix: remove fetch_if_empty property setter for coverage_plan_card_number in Patient Appointment

### DIFF
--- a/hms_tz/patches/custom_fields/custom_fields_json/04_patient_appointment.json
+++ b/hms_tz/patches/custom_fields/custom_fields_json/04_patient_appointment.json
@@ -1813,7 +1813,7 @@
         "hide_seconds": 0,
         "hide_days": 0,
         "sort_options": 0,
-        "fetch_if_empty": 1,
+        "fetch_if_empty": 0,
         "fetch_from": "insurance_subscription.coverage_plan_card_number",
         "collapsible": 0,
         "non_negative": 0,

--- a/hms_tz/patches/property_setter/properties_for_values_fetched_from_his.py
+++ b/hms_tz/patches/property_setter/properties_for_values_fetched_from_his.py
@@ -67,13 +67,6 @@ def execute():
         },
         {
             "doctype": "Patient Appointment",
-            "fieldname": "coverage_plan_card_number",
-            "property": "fetch_if_empty",
-            "property_type": "Check",
-            "value": 1,
-        },
-        {
-            "doctype": "Patient Appointment",
             "fieldname": "coverage_plan_name",
             "property": "fetch_if_empty",
             "value": 1,

--- a/hms_tz/patches/property_setter/property_setters_json/04_patient_appointment.json
+++ b/hms_tz/patches/property_setter/property_setters_json/04_patient_appointment.json
@@ -135,23 +135,6 @@
         "doctype": "Property Setter"
     },
     {
-        "name": "Patient Appointment-coverage_plan_card_number-fetch_if_empty",
-        "owner": "Administrator",
-        "creation": "2024-02-11 16:01:22.522226",
-        "modified": "2024-02-11 16:01:22.522226",
-        "modified_by": "Administrator",
-        "docstatus": 0,
-        "idx": 0,
-        "is_system_generated": 0,
-        "doctype_or_field": "DocField",
-        "doc_type": "Patient Appointment",
-        "field_name": "coverage_plan_card_number",
-        "property": "fetch_if_empty",
-        "property_type": "Check",
-        "value": "1",
-        "doctype": "Property Setter"
-    },
-    {
         "name": "Patient Appointment-main-image_field",
         "owner": "Administrator",
         "creation": "2024-02-11 16:01:13.289632",


### PR DESCRIPTION
- Set fetch_if_empty to 0 for coverage_plan_card_number custom field in 04_patient_appointment.json, so the field value is no longer auto-fetched from insurance_subscription.coverage_plan_card_number when empty
- Remove the coverage_plan_card_number fetch_if_empty entry from the property setter Python patch (properties_for_values_fetched_from_his.py)
- Remove the corresponding Property Setter JSON record from 04_patient_appointment.json property setters

This prevents the coverage_plan_card_number from being overwritten by the fetch_if_empty mechanism, allowing manual or programmatic control of the field value instead.