### PR TITLE
fix: use safe dict access for schemeID and schemeName in update_insurance_subscription

### DIFF
--- a/hms_tz/nhif/api/patient_appointment.py
+++ b/hms_tz/nhif/api/patient_appointment.py
@@ -400,8 +400,8 @@ def update_insurance_subscription(insurance_subscription, data):
         subscription_doc.healthcare_insurance_coverage_plan = plan.name
         subscription_doc.coverage_plan_name = plan.coverage_plan_name
 
-    subscription_doc.hms_tz_scheme_id = data["schemeID"]
-    subscription_doc.hms_tz_scheme_name = data["schemeName"]
+    subscription_doc.hms_tz_scheme_id = data.get("schemeID")
+    subscription_doc.hms_tz_scheme_name = data.get("schemeName")
 
     subscription_doc.save(ignore_permissions=True)
 


### PR DESCRIPTION

- Replace direct dict key access (data["schemeID"], data["schemeName"]) with data.get() calls in update_insurance_subscription function
- Prevents KeyError when the HIS response data does not include schemeID or schemeName keys, which can happen depending on the insurance provider or API response format
- Fields will default to None instead of raising an exception