### PR TITLE
fix(NHIFPatientClaim): correctly fetch diagnosis code and handle missing values

### DIFF
--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -192,8 +192,10 @@ class NHIFPatientClaim(Document):
         )
 
         # Set Main diagnosis code and convert the code of CDC to NHIF
-        diagnosis_code = frappe.get_cached_value("Code Value", encounter_list[-1].main_diagnosis_code, "code")
-        if diagnosis_code and len(diagnosis_code) > 3 and "." not in diagnosis_code:
+        diagnosis_code = frappe.get_cached_value("Code Value", encounter_list[-1].main_diagnosis_code, "code_value")
+        if not diagnosis_code:
+            self.main_diagnosis_code = ""
+        elif diagnosis_code and len(diagnosis_code) > 3 and "." not in diagnosis_code:
             self.main_diagnosis_code = diagnosis_code[:3] + "." + (diagnosis_code[3:4] or "0")
         elif diagnosis_code and len(diagnosis_code) <= 5 and "." in diagnosis_code:
             self.main_diagnosis_code = diagnosis_code


### PR DESCRIPTION
- Change the field retrieved via `frappe.get_cached_value` for the 'Code Value' doctype from 'code' to 'code_value'.

- Add fallback condition to set `self.main_diagnosis_code = ''` when `diagnosis_code` is falsy, preventing potential errors during string operations or validations.