### PR TITLE
fix(PatientAppointment): correct frappe.throw signature for holiday check

### DIFF
--- a/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.py
+++ b/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.py
@@ -366,7 +366,7 @@ def check_employee_wise_availability(date, practitioner_doc):
     if employee:
         # check holiday
         if is_holiday(employee, date):
-            frappe.throw(_(f"{date} is a holiday")(title=_("Not Available")))
+            frappe.throw(msg=_(f"{date} is a holiday"), title=_("Not Available"))
 
         # check leave status
         leave_record = frappe.db.sql(


### PR DESCRIPTION
- Fix a TypeError where the translated string was incorrectly being invoked as a function instead of passing keyword arguments to `frappe.throw`.

- Properly set `msg` and `title` parameters to correctly display the 'Not Available' holiday message.