### PR TITLE
feat(healthcare-practitioner): add custom fields for practitioner role differentiation

### DIFF
--- a/hms_tz/patches/custom_fields/custom_fields_json/28_healthcare_practitioner_nursing.json
+++ b/hms_tz/patches/custom_fields/custom_fields_json/28_healthcare_practitioner_nursing.json
@@ -1,0 +1,32 @@
+[
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "practitioner_role",
+        "fieldtype": "Select",
+        "label": "Practitioner Role",
+        "options": "Doctor\nNurse\nOther",
+        "insert_after": "healthcare_practitioner_type",
+        "reqd": 1,
+        "doctype": "Custom Field"
+    },
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "nursing_specialization",
+        "fieldtype": "Select",
+        "label": "Nursing Specialization",
+        "options": "\nGeneral Nursing\nCritical Care (ICU)\nSurgical/Theater\nMidwifery\nPediatric\nEmergency",
+        "depends_on": "eval:doc.practitioner_role==\"Nurse\"",
+        "insert_after": "practitioner_role",
+        "doctype": "Custom Field"
+    },
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "nursing_role",
+        "fieldtype": "Select",
+        "label": "Nursing Role",
+        "options": "\nStaff Nurse\nCharge Nurse\nNurse Manager",
+        "depends_on": "eval:doc.practitioner_role==\"Nurse\"",
+        "insert_after": "nursing_specialization",
+        "doctype": "Custom Field"
+    }
+]


### PR DESCRIPTION
## Summary

Add custom fields to the **Healthcare Practitioner** doctype to support distinguishing between Doctors, Nurses, and other practitioner types. This is a foundational change that enables role-based filtering and workflow separation across the healthcare modules.

## Changes

### New Custom Fields (`28_healthcare_practitioner_nursing.json`)

| Field | Type | Options | Visibility |
|-------|------|---------|------------|
| `practitioner_role` | Select | Doctor / Nurse / Other | Always visible, **required** |
| `nursing_specialization` | Select | General Nursing, Critical Care (ICU), Surgical/Theater, Midwifery, Pediatric, Emergency | Only when `practitioner_role == 'Nurse'` |
| `nursing_role` | Select | Staff Nurse, Charge Nurse, Nurse Manager | Only when `practitioner_role == 'Nurse'` |

### Design Decisions

- **New sequential JSON file**: Created `28_healthcare_practitioner_nursing.json` instead of modifying existing custom field patch files, following the established hms_tz pattern.
- **`practitioner_role` is required**: Ensures every practitioner must be explicitly categorized.
- **Conditional visibility**: `nursing_specialization` and `nursing_role` are only shown when the practitioner is a Nurse, keeping the form clean for Doctors and other roles.
- **`insert_after` ordering**: Fields are logically placed after `healthcare_practitioner_type` in the form layout.

## Testing

- [x] Verify custom fields appear on the Healthcare Practitioner form
- [x] Verify `practitioner_role` is required and defaults correctly
- [x] Verify `nursing_specialization` and `nursing_role` are hidden when `practitioner_role` is not 'Nurse'
- [x] Verify `nursing_specialization` and `nursing_role` become visible when `practitioner_role` is set to 'Nurse'

## Related

This is **Task 1** of the Nursing & OT module development initiative — laying the groundwork for subsequent practitioner role filtering and nurse-specific workflows.