### PR TITLE
feat(nurse-ot): implement healthcare practitioner role filtering and custom fields

### DIFF
--- a/hms_tz/hms_tz/doctype/episode_of_care/episode_of_care.js
+++ b/hms_tz/hms_tz/doctype/episode_of_care/episode_of_care.js
@@ -2,6 +2,12 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Episode of Care", {
-  // refresh: function(frm) {
-  // }
+  setup: function (frm) {
+    frm.set_query("initiated_by", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+    frm.set_query("primary_practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
 });

--- a/hms_tz/hms_tz/doctype/healthcare_nursing_task/healthcare_nursing_task.js
+++ b/hms_tz/hms_tz/doctype/healthcare_nursing_task/healthcare_nursing_task.js
@@ -2,6 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Healthcare Nursing Task", {
+  setup: function (frm) {
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     frm.set_query("service_unit", function () {
       return {

--- a/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.js
+++ b/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.js
@@ -4,6 +4,9 @@
 frappe.ui.form.on("Healthcare Referral", {
   setup: (frm) => {
     frm.get_field("diagnosis").grid.cannot_add_rows = true;
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
   },
   refresh: (frm) => {
     frm.get_field("diagnosis").grid.cannot_add_rows = true;

--- a/hms_tz/hms_tz/doctype/healthcare_service_order/healthcare_service_order.js
+++ b/hms_tz/hms_tz/doctype/healthcare_service_order/healthcare_service_order.js
@@ -2,6 +2,14 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Healthcare Service Order", {
+  setup: function (frm) {
+    frm.set_query("ordered_by", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+    frm.set_query("referring_practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     frm.set_query("insurance_subscription", function () {
       return {

--- a/hms_tz/hms_tz/doctype/healthcare_service_request/healthcare_service_request.js
+++ b/hms_tz/hms_tz/doctype/healthcare_service_request/healthcare_service_request.js
@@ -201,4 +201,12 @@ var set_filters = (frm) => {
       },
     };
   });
+
+  frm.set_query("practitioner", () => {
+    return {
+      filters: {
+        practitioner_role: "Doctor",
+      },
+    };
+  });
 };

--- a/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.js
+++ b/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.js
@@ -82,17 +82,26 @@ frappe.ui.form.on("Inpatient Record", {
       frm.set_df_property("btn_transfer", "hidden", 0);
     }
 
+    frm.set_query("primary_practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/hms_tz/doctype/lab_test/lab_test.js
+++ b/hms_tz/hms_tz/doctype/lab_test/lab_test.js
@@ -32,17 +32,26 @@ frappe.ui.form.on("Lab Test", {
   refresh: function (frm) {
     refresh_field("normal_test_items");
     refresh_field("descriptive_test_items");
+    frm.set_query("practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.js
+++ b/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.js
@@ -29,6 +29,7 @@ frappe.ui.form.on("Patient Appointment", {
       return {
         filters: {
           department: frm.doc.department,
+          practitioner_role: "Doctor",
         },
       };
     });
@@ -54,12 +55,14 @@ frappe.ui.form.on("Patient Appointment", {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/hms_tz/doctype/patient_encounter/patient_encounter.js
+++ b/hms_tz/hms_tz/doctype/patient_encounter/patient_encounter.js
@@ -145,17 +145,27 @@ frappe.ui.form.on("Patient Encounter", {
       };
     });
 
+    frm.set_query("practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
+
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }
@@ -805,6 +815,7 @@ var refer_practitioner = function (frm) {
         return {
           filters: {
             department: selected_department,
+            practitioner_role: "Doctor",
           },
         };
       };

--- a/hms_tz/hms_tz/doctype/patient_referral/patient_referral.js
+++ b/hms_tz/hms_tz/doctype/patient_referral/patient_referral.js
@@ -2,6 +2,14 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Patient Referral", {
+  setup: function (frm) {
+    frm.set_query("referred_to_practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     if (!frm.doc.__islocal) {
       if (frm.doc.status == "Pending" && frm.doc.docstatus == 1) {

--- a/hms_tz/hms_tz/doctype/practitioner_availability/practitioner_availability.js
+++ b/hms_tz/hms_tz/doctype/practitioner_availability/practitioner_availability.js
@@ -2,6 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Practitioner Availability", {
+  setup: function (frm) {
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     set_event_type_properties_to_event(frm);
     frm.set_query("service_unit", function () {

--- a/hms_tz/hms_tz/doctype/radiology_examination/radiology_examination.js
+++ b/hms_tz/hms_tz/doctype/radiology_examination/radiology_examination.js
@@ -219,17 +219,26 @@ frappe.ui.form.on("Radiology Examination", {
         },
       };
     });
+    frm.set_query("practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/hms_tz/doctype/therapy_session/therapy_session.js
+++ b/hms_tz/hms_tz/doctype/therapy_session/therapy_session.js
@@ -95,17 +95,26 @@ frappe.ui.form.on("Therapy Session", {
       );
     }
 
+    frm.set_query("practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/nhif/api/clinical_procedure.js
+++ b/hms_tz/nhif/api/clinical_procedure.js
@@ -1,4 +1,9 @@
 frappe.ui.form.on("Clinical Procedure", {
+  setup: function (frm) {
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     $('[data-label="Not%20Serviced"]').parent().hide();
     frm.remove_custom_button("Start");

--- a/hms_tz/nhif/api/patient_appointment.js
+++ b/hms_tz/nhif/api/patient_appointment.js
@@ -760,6 +760,7 @@ const check_and_set_availability = (frm) => {
               filters: {
                 status: "Active",
                 hms_tz_company: frm.doc.company,
+                practitioner_role: "Doctor",
               },
             };
           },

--- a/hms_tz/patches/custom_fields/custom_fields_json/28_healthcare_practitioner_nursing.json
+++ b/hms_tz/patches/custom_fields/custom_fields_json/28_healthcare_practitioner_nursing.json
@@ -1,0 +1,32 @@
+[
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "practitioner_role",
+        "fieldtype": "Select",
+        "label": "Practitioner Role",
+        "options": "Doctor\nNurse\nOther",
+        "insert_after": "healthcare_practitioner_type",
+        "reqd": 1,
+        "doctype": "Custom Field"
+    },
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "nursing_specialization",
+        "fieldtype": "Select",
+        "label": "Nursing Specialization",
+        "options": "\nGeneral Nursing\nCritical Care (ICU)\nSurgical/Theater\nMidwifery\nPediatric\nEmergency",
+        "depends_on": "eval:doc.practitioner_role==\"Nurse\"",
+        "insert_after": "practitioner_role",
+        "doctype": "Custom Field"
+    },
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "nursing_role",
+        "fieldtype": "Select",
+        "label": "Nursing Role",
+        "options": "\nStaff Nurse\nCharge Nurse\nNurse Manager",
+        "depends_on": "eval:doc.practitioner_role==\"Nurse\"",
+        "insert_after": "nursing_specialization",
+        "doctype": "Custom Field"
+    }
+]


### PR DESCRIPTION
This Pull Request implements the first two tasks of the Nursing & OT module implementation plan:

### Task 1: Healthcare Practitioner Enhancements
- Added custom fields to differentiate between Doctors and Nurses.
- New fields: `practitioner_role`, `nursing_specialization`, and `nursing_role`.
- Implemented via a new JSON patch: `28_healthcare_practitioner_nursing.json`.

### Task 2: Doctor-Only Role Filtering
- Enforced role-based filtering on `Healthcare Practitioner` link fields across 15+ doctypes.
- Ensuring only practitioners with the 'Doctor' role are selectable in doctor-specific fields (e.g., Primary Practitioner, Ordered By, Referring Practitioner).
- Modified Doctypes include: `Patient Appointment`, `Patient Encounter`, `Episode of Care`, `Inpatient Record`, `Lab Test`, `Radiology Examination`, `Healthcare Service Request`, etc.

Both tasks have been validated and are ready for review.