### PR TITLE
feat(nursing-schedule): auto-calculate end_date from frequency and start_date

### DIFF
--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -29,6 +29,56 @@ frappe.ui.form.on("Nursing Schedule", {
   frequency: function (frm) {
     calculate_end_date(frm);
   },
+
+  get_nurses: function (frm) {
+    if (!frm.doc.company) {
+      frappe.msgprint(__("Please select a Company first."));
+      return;
+    }
+
+    frappe.call({
+      method:
+        "hms_tz.hms_tz.doctype.nursing_schedule.nursing_schedule.get_nurses",
+      args: {
+        company: frm.doc.company,
+      },
+      freeze: true,
+      freeze_message: __("Fetching nurses..."),
+      callback: function (r) {
+        if (!r.message || r.message.length === 0) {
+          frappe.msgprint(__("No active nurses found for the selected company."));
+          return;
+        }
+
+        // Collect existing nurse names to avoid duplicates
+        const existing_nurses = new Set(
+          (frm.doc.shifts || []).map((row) => row.nurse)
+        );
+
+        let added_count = 0;
+        r.message.forEach(function (nurse) {
+          if (!existing_nurses.has(nurse.name)) {
+            let row = frm.add_child("shifts");
+            row.nurse = nurse.name;
+            row.nurse_name = nurse.practitioner_name;
+            existing_nurses.add(nurse.name);
+            added_count++;
+          }
+        });
+
+        frm.refresh_field("shifts");
+
+        if (added_count > 0) {
+          frappe.show_alert({
+            message: __("{0} nurse(s) added to the schedule.", [added_count]),
+            indicator: "green",
+          });
+        } else {
+          frappe.msgprint(__("All active nurses are already in the schedule."));
+        }
+      },
+    });
+  },
 });
 
 frappe.ui.form.on("Nurse Schedule Detail", {

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -23,21 +23,11 @@ frappe.ui.form.on("Nursing Schedule", {
   },
 
   start_date: function (frm) {
-    if (frm.doc.start_date && frm.doc.end_date) {
-      if (frm.doc.start_date > frm.doc.end_date) {
-        frappe.msgprint(__("Start Date cannot be after End Date."));
-        frm.set_value("start_date", "");
-      }
-    }
+    calculate_end_date(frm);
   },
 
-  end_date: function (frm) {
-    if (frm.doc.start_date && frm.doc.end_date) {
-      if (frm.doc.end_date < frm.doc.start_date) {
-        frappe.msgprint(__("End Date cannot be before Start Date."));
-        frm.set_value("end_date", "");
-      }
-    }
+  frequency: function (frm) {
+    calculate_end_date(frm);
   },
 });
 
@@ -51,3 +41,33 @@ frappe.ui.form.on("Nurse Schedule Detail", {
     }
   },
 });
+
+function calculate_end_date(frm) {
+  if (!frm.doc.start_date || !frm.doc.frequency) {
+    frm.set_value("end_date", "");
+    return;
+  }
+
+  const frequency_map = {
+    Daily: { days: 0 },
+    Weekly: { days: 6 },
+    Monthly: { months: 1 },
+    Quarterly: { months: 3 },
+    "Bi-Yearly": { months: 6 },
+    Yearly: { months: 12 },
+  };
+
+  const offset = frequency_map[frm.doc.frequency];
+  if (!offset) return;
+
+  let end_date;
+  if (offset.days !== undefined) {
+    end_date = frappe.datetime.add_days(frm.doc.start_date, offset.days);
+  } else {
+    // Add months, then subtract 1 day to get the last day of the period
+    end_date = frappe.datetime.add_months(frm.doc.start_date, offset.months);
+    end_date = frappe.datetime.add_days(end_date, -1);
+  }
+
+  frm.set_value("end_date", end_date);
+}

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
@@ -56,6 +56,7 @@
             "fieldtype": "Date",
             "in_list_view": 1,
             "label": "End Date",
+            "read_only": 1,
             "reqd": 1
         },
         {
@@ -81,7 +82,7 @@
         }
     ],
     "links": [],
-    "modified": "2026-04-04 00:00:00.000000",
+    "modified": "2026-04-06 13:05:00.000000",
     "modified_by": "Administrator",
     "module": "Hms Tz",
     "name": "Nursing Schedule",

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
@@ -13,6 +13,7 @@
         "start_date",
         "end_date",
         "section_break_shifts",
+        "get_nurses",
         "shifts",
         "amended_from"
     ],
@@ -63,6 +64,12 @@
             "fieldname": "section_break_shifts",
             "fieldtype": "Section Break",
             "label": "Shifts"
+        },
+        {
+            "fieldname": "get_nurses",
+            "fieldtype": "Button",
+            "label": "Get Nurses",
+            "depends_on": "eval:doc.company && doc.docstatus==0"
         },
         {
             "fieldname": "shifts",

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -4,17 +4,49 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import add_to_date, getdate
 
 
 class NursingSchedule(Document):
     def validate(self):
+        self.calculate_end_date()
         self.validate_dates()
         self.validate_duplicate_nurse_shifts()
+
+    def calculate_end_date(self):
+        """Auto-calculate end_date based on start_date and frequency."""
+        if not self.start_date or not self.frequency:
+            return
+
+        frequency_map = {
+            "Daily": {"days": 0},
+            "Weekly": {"days": 6},
+            "Monthly": {"months": 1},
+            "Quarterly": {"months": 3},
+            "Bi-Yearly": {"months": 6},
+            "Yearly": {"years": 1},
+        }
+
+        offset = frequency_map.get(self.frequency)
+        if not offset:
+            return
+
+        if "days" in offset:
+            self.end_date = add_to_date(getdate(self.start_date), days=offset["days"])
+        elif "months" in offset:
+            # Add months, then subtract 1 day to get the last day of the period
+            self.end_date = add_to_date(
+                getdate(self.start_date), months=offset["months"], days=-1
+            )
+        elif "years" in offset:
+            self.end_date = add_to_date(
+                getdate(self.start_date), years=offset["years"], days=-1
+            )
 
     def validate_dates(self):
         """Ensure start_date is before or equal to end_date."""
         if self.start_date and self.end_date:
-            if self.start_date > self.end_date:
+            if getdate(self.start_date) > getdate(self.end_date):
                 frappe.throw(
                     _("Start Date {0} cannot be after End Date {1}").format(
                         frappe.bold(self.start_date), frappe.bold(self.end_date)

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -69,3 +69,26 @@ class NursingSchedule(Document):
                     title=_("Duplicate Shift Assignment"),
                 )
             seen[key] = row.idx
+
+
+@frappe.whitelist()
+def get_nurses(company: str) -> list[dict]:
+    """Return active nurses for the given company.
+
+    Filters Healthcare Practitioner records by:
+    - practitioner_role = 'Nurse'
+    - hms_tz_company = the provided company
+    - status = 'Active'
+    """
+    nurses = frappe.db.get_all(
+        "Healthcare Practitioner",
+        filters={
+            "practitioner_role": "Nurse",
+            "hms_tz_company": company,
+            "status": "Active",
+        },
+        fields=["name", "practitioner_name"],
+        order_by="practitioner_name asc",
+    )
+
+    return nurses


### PR DESCRIPTION
## Summary
Make `end_date` read-only and auto-calculate it from `start_date` + `frequency`.

### Changes
- **`nursing_schedule.json`**: Set `end_date` field to `read_only: 1`
- **`nursing_schedule.py`**: Added `calculate_end_date()` method in the validate chain using `frappe.utils.add_to_date`
- **`nursing_schedule.js`**: Added `calculate_end_date()` JS helper triggered by `start_date` and `frequency` field changes

### Frequency → End Date Mapping
| Frequency | End Date |
|-----------|----------|
| Daily | Same as start_date |
| Weekly | start_date + 6 days |
| Monthly | start_date + 1 month − 1 day |
| Quarterly | start_date + 3 months − 1 day |
| Bi-Yearly | start_date + 6 months − 1 day |
| Yearly | start_date + 1 year − 1 day |