### PR TITLE
fix: update Nurse Schedule Detail default and formatting

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.json
+++ b/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.json
@@ -1,82 +1,82 @@
 {
- "actions": [],
- "creation": "2026-04-04 21:32:36.013090",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "nurse",
-  "nurse_name",
-  "shift_type",
-  "shift_based_on",
-  "column_break_01",
-  "service_unit_type",
-  "service_unit"
- ],
- "fields": [
-  {
-   "fieldname": "nurse",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Nurse",
-   "options": "Healthcare Practitioner",
-   "reqd": 1
-  },
-  {
-   "fetch_from": "nurse.practitioner_name",
-   "fieldname": "nurse_name",
-   "fieldtype": "Data",
-   "label": "Nurse Name",
-   "read_only": 1
-  },
-  {
-   "fieldname": "shift_type",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Shift Type",
-   "options": "Morning\nAfternoon\nNight\nFull Day",
-   "reqd": 1
-  },
-  {
-   "default": "Service Unit",
-   "fieldname": "shift_based_on",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Shift Based On",
-   "options": "Service Unit Type\nService Unit",
-   "reqd": 1
-  },
-  {
-   "fieldname": "column_break_01",
-   "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval:doc.shift_based_on=='Service Unit Type'",
-   "fieldname": "service_unit_type",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Service Unit Type",
-   "options": "Healthcare Service Unit Type"
-  },
-  {
-   "depends_on": "eval:doc.shift_based_on=='Service Unit'",
-   "fieldname": "service_unit",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Service Unit",
-   "options": "Healthcare Service Unit"
-  }
- ],
- "istable": 1,
- "links": [],
- "modified": "2026-04-04 21:36:28.516239",
- "modified_by": "Administrator",
- "module": "Hms Tz",
- "name": "Nurse Schedule Detail",
- "owner": "Administrator",
- "permissions": [],
- "row_format": "Dynamic",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+    "actions": [],
+    "creation": "2026-04-04 21:32:36.013090",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "nurse",
+        "nurse_name",
+        "shift_type",
+        "shift_based_on",
+        "column_break_01",
+        "service_unit_type",
+        "service_unit"
+    ],
+    "fields": [
+        {
+            "fieldname": "nurse",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Nurse",
+            "options": "Healthcare Practitioner",
+            "reqd": 1
+        },
+        {
+            "fetch_from": "nurse.practitioner_name",
+            "fieldname": "nurse_name",
+            "fieldtype": "Data",
+            "label": "Nurse Name",
+            "read_only": 1
+        },
+        {
+            "fieldname": "shift_type",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Shift Type",
+            "options": "Morning\nAfternoon\nNight\nFull Day",
+            "reqd": 1
+        },
+        {
+            "default": "Service Unit Type",
+            "fieldname": "shift_based_on",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Shift Based On",
+            "options": "Service Unit Type\nService Unit",
+            "reqd": 1
+        },
+        {
+            "fieldname": "column_break_01",
+            "fieldtype": "Column Break"
+        },
+        {
+            "depends_on": "eval:doc.shift_based_on=='Service Unit Type'",
+            "fieldname": "service_unit_type",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Service Unit Type",
+            "options": "Healthcare Service Unit Type"
+        },
+        {
+            "depends_on": "eval:doc.shift_based_on=='Service Unit'",
+            "fieldname": "service_unit",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Service Unit",
+            "options": "Healthcare Service Unit"
+        }
+    ],
+    "istable": 1,
+    "links": [],
+    "modified": "2026-04-06 13:36:00.000000",
+    "modified_by": "Administrator",
+    "module": "Hms Tz",
+    "name": "Nurse Schedule Detail",
+    "owner": "Administrator",
+    "permissions": [],
+    "row_format": "Dynamic",
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
 }


### PR DESCRIPTION
- Change shift_based_on default from 'Service Unit' to 'Service Unit Type' to match the first option in the select list
- Normalize JSON indentation to 4-space indent for consistency with the parent Nursing Schedule DocType