### PR TITLE
fix: resolve deprecated pre-commit stage name warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 exclude: "node_modules|.git"
-default_stages: [pre-commit, pre-push, manual]
+default_stages: [pre-commit, manual]
 fail_fast: false
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         files: "hms_tz.*"
@@ -26,7 +26,7 @@ repos:
         stages: [manual]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ["--profile", "black", "--line-length", "120"]


### PR DESCRIPTION
## Summary
Fix all deprecated pre-commit stage name warnings that appear when running `pre-commit run --all`.

### Changes
- **`default_stages`**: Changed from `[pre-commit, pre-push, manual]` to `[pre-commit, manual]` — removed unnecessary `pre-push` stage
- **`pre-commit-hooks`**: Updated from `v4.5.0` → `v5.0.0` — fixes internal deprecated stage names (`commit`, `push`)
- **`isort`**: Updated from `5.13.2` → `6.0.1` — fixes internal deprecated stage names (`commit`, `merge-commit`, `push`)

### Result
`pre-commit run --all` now runs cleanly with **zero warnings**.