### PR TITLE
feat: enforce employee as mandatory for Nurse practitioners

### DIFF
--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -10,7 +10,7 @@ frappe.ui.form.on("Nursing Schedule", {
     frm.set_query("nurse", "assignments", function () {
       return {
         filters: {
-          status: 'Active',
+          status: "Active",
           practitioner_role: "Nurse",
           hms_tz_company: frm.doc.company,
         },
@@ -69,9 +69,7 @@ frappe.ui.form.on("Nursing Schedule", {
 
         // Collect existing nurse names to avoid duplicates
         const existing_nurses = new Set(
-          (frm.doc.assignments || []).map(
-            (row) => row.nurse
-          )
+          (frm.doc.assignments || []).map((row) => row.nurse)
         );
 
         let added_count = 0;
@@ -92,10 +90,7 @@ frappe.ui.form.on("Nursing Schedule", {
 
         if (added_count > 0) {
           frappe.show_alert({
-            message: __(
-              "{0} nurse(s) added to the schedule.",
-              [added_count]
-            ),
+            message: __("{0} nurse(s) added to the schedule.", [added_count]),
             indicator: "green",
           });
         } else {
@@ -111,24 +106,14 @@ frappe.ui.form.on("Nursing Schedule", {
 frappe.ui.form.on("Nurse Schedule Detail", {
   assignments_add: function (frm, cdt, cdn) {
     if (frm.doc.frequency === "Daily" && frm.doc.end_date) {
-      frappe.model.set_value(
-        cdt,
-        cdn,
-        "assignment_date",
-        frm.doc.end_date
-      );
+      frappe.model.set_value(cdt, cdn, "assignment_date", frm.doc.end_date);
     }
   },
 
   assign_based_on: function (frm, cdt, cdn) {
     let row = locals[cdt][cdn];
     if (row.assign_based_on === "Service Unit") {
-      frappe.model.set_value(
-        cdt,
-        cdn,
-        "service_unit_type",
-        ""
-      );
+      frappe.model.set_value(cdt, cdn, "service_unit_type", "");
     } else {
       frappe.model.set_value(cdt, cdn, "service_unit", "");
     }
@@ -171,16 +156,10 @@ function calculate_end_date(frm) {
 
   let end_date;
   if (offset.days !== undefined) {
-    end_date = frappe.datetime.add_days(
-      frm.doc.start_date,
-      offset.days
-    );
+    end_date = frappe.datetime.add_days(frm.doc.start_date, offset.days);
   } else {
     // Add months, then subtract 1 day to get the last day of the period
-    end_date = frappe.datetime.add_months(
-      frm.doc.start_date,
-      offset.months
-    );
+    end_date = frappe.datetime.add_months(frm.doc.start_date, offset.months);
     end_date = frappe.datetime.add_days(end_date, -1);
   }
 

--- a/hms_tz/patches/property_setter/property_setters_json/27_healthcare_practitioner_nursing.json
+++ b/hms_tz/patches/property_setter/property_setters_json/27_healthcare_practitioner_nursing.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "Healthcare Practitioner-employee-mandatory_depends_on",
+        "owner": "Administrator",
+        "creation": "2026-04-06 17:30:00.000000",
+        "modified": "2026-04-06 17:30:00.000000",
+        "modified_by": "Administrator",
+        "docstatus": 0,
+        "idx": 0,
+        "is_system_generated": 0,
+        "doctype_or_field": "DocField",
+        "doc_type": "Healthcare Practitioner",
+        "field_name": "employee",
+        "property": "mandatory_depends_on",
+        "property_type": "Data",
+        "value": "eval:doc.practitioner_role=='Nurse'",
+        "doctype": "Property Setter"
+    }
+]


### PR DESCRIPTION
## Summary
Enforce that every Healthcare Practitioner with `practitioner_role == 'Nurse'` must have an `employee` link, ensuring integration with the HR Module for shift management.

### Changes

**New file:**
- `27_healthcare_practitioner_nursing.json` — Property setter that sets `mandatory_depends_on = eval:doc.practitioner_role=='Nurse'` on the `employee` field of Healthcare Practitioner

**Updated file:**
- `nursing_schedule.js` — Minor formatting cleanup (consistent double quotes, condensed single-line function calls)

### Why
Nurses need an Employee record to leverage HR features like Default Shift, Shift Assignment, and Shift Request. This property setter makes the field conditionally mandatory only for nurses, leaving doctors and other practitioners unaffected.