### PR TITLE
feat(roster): add Nurse Roster SPA with auto-load, dialog, and past date protection

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -18,8 +18,8 @@ declare module 'vue' {
     PaymentDialog: typeof import('./src/components/appointments/PaymentDialog.vue')['default']
     PractitionerCard: typeof import('./src/components/appointments/PractitionerCard.vue')['default']
     Print: typeof import('./src/components/controls/Print.vue')['default']
+    RosterCell: typeof import('./src/components/roster/RosterCell.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
-    TestComponent: typeof import('./src/components/TestComponent.vue')['default']
   }
 }

--- a/frontend/src/components/roster/RosterCell.vue
+++ b/frontend/src/components/roster/RosterCell.vue
@@ -1,0 +1,312 @@
+<template>
+  <td
+    class="relative border-b px-1 py-1 text-center"
+    :class="cellClasses"
+    @click="handleCellClick"
+  >
+    <!-- Existing assignment (read-only pill) -->
+    <div
+      v-if="assignment && !showDialog"
+      class="flex items-center justify-center gap-1"
+    >
+      <span
+        class="inline-flex max-w-[100px] items-center truncate rounded-full px-2 py-1 text-xs font-medium"
+        :class="pillClasses"
+        :title="displayValue"
+      >
+        {{ displayValue }}
+      </span>
+      <!-- Edit button: only shown for future/today dates -->
+      <button
+        v-if="!isPastDate"
+        class="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 shadow-sm hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600"
+        @click.stop="openEditDialog"
+        title="Edit assignment"
+      >
+        <svg
+          class="h-3.5 w-3.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+          />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Empty cell (+): only clickable for future/today dates -->
+    <div
+      v-else-if="!assignment && !showDialog"
+      class="flex h-8 items-center justify-center rounded border border-dashed transition-colors"
+      :class="
+        isPastDate
+          ? 'border-gray-100 text-gray-200'
+          : 'border-gray-200 text-gray-400 hover:border-blue-400 hover:bg-blue-50/50 hover:text-blue-500'
+      "
+    >
+      <svg
+        class="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2.5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M12 4v16m8-8H4"
+        />
+      </svg>
+    </div>
+
+    <!-- Assignment Dialog -->
+    <Dialog
+      :options="{
+        title: assignment ? 'Edit Assignment' : 'New Assignment',
+        size: 'sm',
+        actions: dialogActions,
+      }"
+      v-model="showDialog"
+      @close="cancelEdit"
+    >
+      <template #body-content>
+        <div class="flex flex-col gap-4">
+          <!-- Nurse & Date info -->
+          <div
+            class="flex items-center gap-3 rounded-lg bg-gray-50 px-3 py-2"
+          >
+            <div class="text-sm">
+              <span class="text-gray-500">Nurse:</span>
+              <span class="ml-1 font-medium text-gray-800">{{
+                nurse
+              }}</span>
+            </div>
+            <div class="text-sm">
+              <span class="text-gray-500">Date:</span>
+              <span class="ml-1 font-medium text-gray-800">{{ date }}</span>
+            </div>
+          </div>
+
+          <!-- Assignment Based On -->
+          <div>
+            <FormControl
+              type="select"
+              label="Assignment Based On"
+              :options="assignBasedOnOptions"
+              v-model="editAssignBasedOn"
+            />
+          </div>
+
+          <!-- Service Unit Type (searchable autocomplete) -->
+          <div v-if="editAssignBasedOn === 'Service Unit Type'">
+            <FormControl
+              type="autocomplete"
+              label="Service Unit Type"
+              :options="serviceUnitTypeOptions"
+              v-model="selectedServiceUnitType"
+              placeholder="Search service unit type..."
+            />
+          </div>
+
+          <!-- Service Unit (searchable autocomplete) -->
+          <div v-if="editAssignBasedOn === 'Service Unit'">
+            <FormControl
+              type="autocomplete"
+              label="Service Unit"
+              :options="serviceUnitOptions"
+              v-model="selectedServiceUnit"
+              placeholder="Search service unit..."
+            />
+          </div>
+
+          <!-- Remove button for existing assignments -->
+          <div v-if="assignment && assignment.name" class="border-t pt-3">
+            <Button
+              variant="subtle"
+              theme="red"
+              class="w-full"
+              @click="removeAssignment"
+            >
+              <template #prefix>
+                <svg
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              </template>
+              Remove Assignment
+            </Button>
+          </div>
+        </div>
+      </template>
+    </Dialog>
+  </td>
+</template>
+
+<script setup>
+import { computed, ref } from "vue";
+
+const props = defineProps({
+  nurse: { type: String, required: true },
+  date: { type: String, required: true },
+  isWeekend: { type: Boolean, default: false },
+  isPastDate: { type: Boolean, default: false },
+  assignment: { type: Object, default: null },
+  serviceUnitTypes: { type: Array, default: () => [] },
+  serviceUnits: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(["assign", "edit", "remove"]);
+
+const showDialog = ref(false);
+const editAssignBasedOn = ref("Service Unit Type");
+const selectedServiceUnitType = ref(null);
+const selectedServiceUnit = ref(null);
+
+const assignBasedOnOptions = [
+  { label: "Service Unit Type", value: "Service Unit Type" },
+  { label: "Service Unit", value: "Service Unit" },
+];
+
+const displayValue = computed(() => {
+  if (!props.assignment) return "";
+  if (props.assignment.assign_based_on === "Service Unit") {
+    return props.assignment.service_unit || "";
+  }
+  return props.assignment.service_unit_type || "";
+});
+
+// Options formatted for autocomplete
+const serviceUnitTypeOptions = computed(() =>
+  props.serviceUnitTypes.map((s) => ({ label: s, value: s })),
+);
+
+const serviceUnitOptions = computed(() =>
+  props.serviceUnits.map((s) => ({
+    label: s.name,
+    value: s.name,
+  })),
+);
+
+// The currently selected value string
+const currentEditValue = computed(() => {
+  if (editAssignBasedOn.value === "Service Unit Type") {
+    return selectedServiceUnitType.value?.value || "";
+  }
+  return selectedServiceUnit.value?.value || "";
+});
+
+const pillClasses = computed(() => {
+  if (props.assignment?._pending) return "bg-yellow-100 text-yellow-800";
+  return "bg-blue-100 text-blue-800";
+});
+
+const cellClasses = computed(() => ({
+  "bg-orange-50/50": props.isWeekend && !showDialog.value,
+  "cursor-pointer": !showDialog.value && !props.assignment && !props.isPastDate,
+  "bg-blue-50/30": props.assignment && !props.assignment._pending,
+  "bg-yellow-50/50": props.assignment?._pending,
+}));
+
+const dialogActions = computed(() => [
+  {
+    label: "Cancel",
+    variant: "subtle",
+    onClick: () => cancelEdit(),
+  },
+  {
+    label: props.assignment ? "Update" : "Assign",
+    variant: "solid",
+    disabled: !currentEditValue.value,
+    onClick: () => confirmEdit(),
+  },
+]);
+
+function handleCellClick() {
+  // Do not allow opening dialog for past dates
+  if (props.isPastDate) return;
+  if (!props.assignment && !showDialog.value) {
+    openNewDialog();
+  }
+}
+
+function openNewDialog() {
+  editAssignBasedOn.value = "Service Unit Type";
+  selectedServiceUnitType.value = null;
+  selectedServiceUnit.value = null;
+  showDialog.value = true;
+}
+
+function openEditDialog() {
+  // Do not allow editing past dates
+  if (props.isPastDate) return;
+
+  if (props.assignment) {
+    editAssignBasedOn.value =
+      props.assignment.assign_based_on || "Service Unit Type";
+    if (props.assignment.assign_based_on === "Service Unit") {
+      const val = props.assignment.service_unit || "";
+      selectedServiceUnit.value = val ? { label: val, value: val } : null;
+      selectedServiceUnitType.value = null;
+    } else {
+      const val = props.assignment.service_unit_type || "";
+      selectedServiceUnitType.value = val
+        ? { label: val, value: val }
+        : null;
+      selectedServiceUnit.value = null;
+    }
+  }
+  showDialog.value = true;
+}
+
+function confirmEdit() {
+  const val = currentEditValue.value;
+  if (!val) return;
+
+  if (props.assignment?.name) {
+    emit("edit", {
+      nurse: props.nurse,
+      date: props.date,
+      assignBasedOn: editAssignBasedOn.value,
+      value: val,
+      existingName: props.assignment.name,
+    });
+  } else {
+    emit("assign", {
+      nurse: props.nurse,
+      date: props.date,
+      assignBasedOn: editAssignBasedOn.value,
+      value: val,
+    });
+  }
+  showDialog.value = false;
+}
+
+function cancelEdit() {
+  showDialog.value = false;
+  selectedServiceUnitType.value = null;
+  selectedServiceUnit.value = null;
+}
+
+function removeAssignment() {
+  emit("remove", {
+    nurse: props.nurse,
+    date: props.date,
+    existingName: props.assignment?.name || props.assignment?.existing_name,
+  });
+  showDialog.value = false;
+}
+</script>

--- a/frontend/src/pages/NurseRoster.vue
+++ b/frontend/src/pages/NurseRoster.vue
@@ -1,0 +1,398 @@
+<template>
+  <div class="flex h-screen w-screen overflow-hidden">
+    <!-- Sidebar -->
+    <div
+      class="flex h-full flex-col border-r bg-gray-50"
+      :class="isSidebarCollapsed ? 'w-12' : 'w-[220px]'"
+    >
+      <!-- Logo/Brand area -->
+      <div class="flex items-center gap-2 border-b px-3 py-3">
+        <div
+          class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-blue-600 text-white"
+        >
+          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+            />
+          </svg>
+        </div>
+        <span
+          v-if="!isSidebarCollapsed"
+          class="truncate text-sm font-semibold text-gray-800"
+        >
+          HMS TZ
+        </span>
+      </div>
+
+      <!-- Nav links -->
+      <nav class="flex flex-1 flex-col gap-0.5 p-2">
+        <button
+          class="flex h-8 items-center gap-2 rounded-md bg-blue-100 px-2 text-sm font-medium text-blue-700"
+        >
+          <svg
+            class="h-4 w-4 shrink-0 text-blue-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          <span v-if="!isSidebarCollapsed">Nurse Roster</span>
+        </button>
+        <button
+          class="flex h-8 items-center gap-2 rounded-md px-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+          @click="goToNursingSchedule"
+        >
+          <svg
+            class="h-4 w-4 shrink-0 text-gray-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            />
+          </svg>
+          <span v-if="!isSidebarCollapsed">Nursing Schedule</span>
+        </button>
+      </nav>
+
+      <!-- Collapse toggle -->
+      <div class="border-t p-2">
+        <button
+          class="flex h-8 w-full items-center gap-2 rounded-md px-2 text-sm text-gray-500 hover:bg-gray-200"
+          @click="isSidebarCollapsed = !isSidebarCollapsed"
+        >
+          <svg
+            class="h-4 w-4 shrink-0 transition-transform duration-300"
+            :class="{ 'rotate-180': isSidebarCollapsed }"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
+            />
+          </svg>
+          <span v-if="!isSidebarCollapsed">Collapse</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Main content -->
+    <div class="flex flex-1 flex-col overflow-hidden">
+      <!-- Header (centered) -->
+      <div class="border-b bg-white px-6 py-4">
+        <h1 class="text-center text-xl font-semibold text-gray-900">
+          Nurse Roster
+        </h1>
+        <p class="mt-1 text-center text-sm" style="color: #60a5fa">
+          Assign nurses to wards and rooms across dates
+        </p>
+      </div>
+
+      <!-- Filter Bar (centered, reordered: Company → Frequency → Start Date → End Date) -->
+      <div class="border-b bg-white px-6 py-4">
+        <div class="flex flex-wrap items-end justify-center gap-4">
+          <div class="w-52">
+            <label class="mb-1 block text-xs font-medium text-gray-600">
+              Company
+            </label>
+            <FormControl
+              type="autocomplete"
+              :options="companyOptions"
+              v-model="companyModel"
+              placeholder="Select Company"
+            />
+          </div>
+          <div class="w-40">
+            <label class="mb-1 block text-xs font-medium text-gray-600">
+              Frequency
+            </label>
+            <FormControl
+              type="select"
+              :options="frequencyOptions"
+              v-model="store.frequency"
+              @change="store.calculateEndDate()"
+            />
+          </div>
+          <div class="w-40">
+            <label class="mb-1 block text-xs font-medium text-gray-600">
+              Start Date
+            </label>
+            <FormControl
+              type="date"
+              v-model="store.startDate"
+              @change="store.calculateEndDate()"
+            />
+          </div>
+          <div class="w-40">
+            <label class="mb-1 block text-xs font-medium text-gray-600">
+              End Date
+            </label>
+            <FormControl
+              type="date"
+              :modelValue="store.endDate"
+              disabled
+              class="bg-gray-50"
+            />
+          </div>
+          <!-- Loading indicator inline -->
+          <div v-if="store.isLoading" class="flex items-center pb-1">
+            <LoadingIndicator class="h-5 w-5" />
+          </div>
+        </div>
+      </div>
+
+      <!-- Scrollable grid section -->
+      <div class="flex-1 overflow-auto">
+        <!-- Grid -->
+        <div class="p-6" v-if="store.nurses.length">
+          <div class="overflow-x-auto rounded-lg border bg-white shadow-sm">
+            <table class="w-full border-collapse">
+              <thead>
+                <tr>
+                  <th
+                    class="sticky left-0 z-10 min-w-[180px] border-b border-r bg-gray-50 px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600"
+                  >
+                    Nurse
+                  </th>
+                  <th
+                    v-for="col in store.dateColumns"
+                    :key="col.date"
+                    class="min-w-[120px] border-b px-2 py-3 text-center text-xs font-semibold uppercase tracking-wider"
+                    :class="
+                      col.isWeekend
+                        ? 'bg-orange-50 text-orange-700'
+                        : 'bg-gray-50 text-gray-600'
+                    "
+                  >
+                    {{ col.label }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="nurse in store.nurses"
+                  :key="nurse.name"
+                  class="group hover:bg-gray-50/50"
+                >
+                  <!-- Nurse name (sticky left) -->
+                  <td
+                    class="sticky left-0 z-10 border-b border-r bg-white px-4 py-2 group-hover:bg-gray-50"
+                  >
+                    <div class="text-sm font-medium text-gray-900">
+                      {{ nurse.practitioner_name }}
+                    </div>
+                  </td>
+
+                  <!-- Date cells -->
+                  <RosterCell
+                    v-for="col in store.dateColumns"
+                    :key="`${nurse.name}-${col.date}`"
+                    :nurse="nurse.name"
+                    :date="col.date"
+                    :is-weekend="col.isWeekend"
+                    :is-past-date="isDatePast(col.date)"
+                    :assignment="store.getAssignment(nurse.name, col.date)"
+                    :service-unit-types="store.serviceUnitTypes"
+                    :service-units="store.serviceUnits"
+                    @assign="handleAssign"
+                    @edit="handleEdit"
+                    @remove="handleRemove"
+                  />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Empty state -->
+        <div
+          v-else-if="!store.isLoading"
+          class="flex flex-col items-center justify-center px-6 py-20"
+        >
+          <div class="text-center">
+            <svg
+              class="mx-auto h-12 w-12 text-gray-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            <h3 class="mt-4 text-sm font-medium text-gray-900">
+              No roster loaded
+            </h3>
+            <p class="mt-1 text-sm text-gray-500">
+              Select company, start date and frequency to load the roster
+              automatically.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Save bar (fixed at bottom of main content) -->
+      <div
+        v-if="store.hasPendingChanges()"
+        class="border-t bg-white px-6 py-3 shadow-lg"
+      >
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-gray-600">
+            <span class="font-semibold text-blue-600">{{
+              store.pendingChanges.length
+            }}</span>
+            unsaved change(s)
+          </p>
+          <div class="flex gap-3">
+            <Button variant="subtle" @click="store.pendingChanges = []">
+              Discard
+            </Button>
+            <Button
+              variant="solid"
+              :loading="store.isSaving"
+              @click="store.saveRoster()"
+            >
+              Save Changes
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import dayjs from "dayjs";
+import { createResource } from "frappe-ui";
+import { computed, onMounted, ref, watch } from "vue";
+import RosterCell from "@/components/roster/RosterCell.vue";
+import { useRosterStore } from "@/stores/rosterStore";
+
+const store = useRosterStore();
+const isSidebarCollapsed = ref(false);
+
+// Company options
+const companyOptions = ref([]);
+const companyResource = createResource({
+  url: "frappe.client.get_list",
+  params: {
+    doctype: "Company",
+    fields: ["name"],
+    order_by: "name asc",
+    limit_page_length: 0,
+  },
+  auto: true,
+  onSuccess(data) {
+    companyOptions.value = data.map((c) => ({
+      label: c.name,
+      value: c.name,
+    }));
+  },
+});
+
+const frequencyOptions = [
+  { label: "Daily", value: "Daily" },
+  { label: "Weekly", value: "Weekly" },
+  { label: "Monthly", value: "Monthly" },
+  { label: "Quarterly", value: "Quarterly" },
+  { label: "Bi-Yearly", value: "Bi-Yearly" },
+  { label: "Yearly", value: "Yearly" },
+];
+
+// v-model computed for autocomplete: converts between option object and string
+const companyModel = computed({
+  get() {
+    if (!store.company) return null;
+    return { label: store.company, value: store.company };
+  },
+  set(option) {
+    if (option && typeof option === "object") {
+      store.company = option.value || option.label || "";
+    } else {
+      store.company = option || "";
+    }
+  },
+});
+
+// Check if a date is in the past (before today)
+function isDatePast(dateStr) {
+  return dayjs(dateStr).isBefore(dayjs(), "day");
+}
+
+// Auto-load roster when all fields are filled
+watch(
+  () => [store.company, store.startDate, store.frequency, store.endDate],
+  () => {
+    if (store.company && store.startDate && store.frequency && store.endDate) {
+      store.loadRoster();
+    }
+  },
+);
+
+function goToNursingSchedule() {
+  window.location.href = "/app/nursing-schedule";
+}
+
+// Try to get params from URL
+onMounted(() => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("company")) store.company = params.get("company");
+  if (params.get("start_date")) store.startDate = params.get("start_date");
+  if (params.get("frequency")) store.frequency = params.get("frequency");
+  if (store.startDate && store.frequency) {
+    store.calculateEndDate();
+  }
+});
+
+function handleAssign({ nurse, date, assignBasedOn, value }) {
+  store.addPendingChange({
+    nurse,
+    assignment_date: date,
+    assign_based_on: assignBasedOn,
+    service_unit_type: assignBasedOn === "Service Unit Type" ? value : "",
+    service_unit: assignBasedOn === "Service Unit" ? value : "",
+    action: "add",
+  });
+}
+
+function handleEdit({ nurse, date, assignBasedOn, value, existingName }) {
+  store.addPendingChange({
+    nurse,
+    assignment_date: date,
+    assign_based_on: assignBasedOn,
+    service_unit_type: assignBasedOn === "Service Unit Type" ? value : "",
+    service_unit: assignBasedOn === "Service Unit" ? value : "",
+    existing_name: existingName,
+    action: "edit",
+  });
+}
+
+function handleRemove({ nurse, date, existingName }) {
+  store.addPendingChange({
+    nurse,
+    assignment_date: date,
+    existing_name: existingName,
+    action: "remove",
+  });
+}
+</script>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -14,6 +14,11 @@ const routes = [
     component: () => import("@/pages/Appointments.vue"),
   },
   {
+    path: "/nurse-roster",
+    name: "NurseRoster",
+    component: () => import("@/pages/NurseRoster.vue"),
+  },
+  {
     name: "Login",
     path: "/account/login",
     component: () => import("@/pages/Login.vue"),

--- a/frontend/src/stores/rosterStore.js
+++ b/frontend/src/stores/rosterStore.js
@@ -1,0 +1,202 @@
+import dayjs from "dayjs";
+import { createResource } from "frappe-ui";
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+
+export const useRosterStore = defineStore("roster", () => {
+  // Filter state
+  const company = ref("");
+  const startDate = ref("");
+  const frequency = ref("Weekly");
+  const endDate = ref("");
+
+  // Data state
+  const nurses = ref([]);
+  const assignments = ref([]);
+  const serviceUnitTypes = ref([]);
+  const serviceUnits = ref([]);
+
+  // Pending changes (tracked before save)
+  const pendingChanges = ref([]);
+
+  // Loading state
+  const isLoading = ref(false);
+  const isSaving = ref(false);
+
+  // Date columns
+  const dateColumns = computed(() => {
+    if (!startDate.value || !endDate.value) return [];
+    const cols = [];
+    let current = dayjs(startDate.value);
+    const end = dayjs(endDate.value);
+    while (current.isBefore(end) || current.isSame(end, "day")) {
+      cols.push({
+        date: current.format("YYYY-MM-DD"),
+        label: current.format("ddd DD"),
+        isWeekend:
+          current.day() === 0 || current.day() === 6,
+      });
+      current = current.add(1, "day");
+    }
+    return cols;
+  });
+
+  // Build a lookup map: nurse -> date -> assignment
+  const assignmentMap = computed(() => {
+    const map = {};
+    for (const a of assignments.value) {
+      const key = `${a.nurse}|${a.assignment_date}`;
+      map[key] = a;
+    }
+    // Overlay pending changes
+    for (const change of pendingChanges.value) {
+      const key = `${change.nurse}|${change.assignment_date}`;
+      if (change.action === "remove") {
+        delete map[key];
+      } else {
+        map[key] = { ...map[key], ...change, _pending: true };
+      }
+    }
+    return map;
+  });
+
+  function getAssignment(nurse, date) {
+    return assignmentMap.value[`${nurse}|${date}`] || null;
+  }
+
+  // Calculate end date
+  function calculateEndDate() {
+    if (!startDate.value || !frequency.value) {
+      endDate.value = "";
+      return;
+    }
+    const frequencyMap = {
+      Daily: { days: 0 },
+      Weekly: { days: 6 },
+      Monthly: { months: 1 },
+      Quarterly: { months: 3 },
+      "Bi-Yearly": { months: 6 },
+      Yearly: { months: 12 },
+    };
+    const offset = frequencyMap[frequency.value];
+    if (!offset) return;
+
+    if (offset.days !== undefined) {
+      endDate.value = dayjs(startDate.value)
+        .add(offset.days, "day")
+        .format("YYYY-MM-DD");
+    } else {
+      endDate.value = dayjs(startDate.value)
+        .add(offset.months, "month")
+        .subtract(1, "day")
+        .format("YYYY-MM-DD");
+    }
+  }
+
+  // API resources
+  const rosterDataResource = createResource({
+    url: "hms_tz.hms_tz.doctype.nursing_schedule.roster.get_roster_data",
+    onSuccess(data) {
+      nurses.value = data.nurses || [];
+      assignments.value = data.assignments || [];
+      pendingChanges.value = [];
+      isLoading.value = false;
+    },
+    onError() {
+      isLoading.value = false;
+    },
+  });
+
+  const serviceOptionsResource = createResource({
+    url: "hms_tz.hms_tz.doctype.nursing_schedule.roster.get_service_options",
+    onSuccess(data) {
+      serviceUnitTypes.value = data.service_unit_types || [];
+      serviceUnits.value = data.service_units || [];
+    },
+  });
+
+  const saveResource = createResource({
+    url: "hms_tz.hms_tz.doctype.nursing_schedule.roster.save_roster_assignments",
+    onSuccess() {
+      isSaving.value = false;
+      // Reload after save
+      loadRoster();
+    },
+    onError() {
+      isSaving.value = false;
+    },
+  });
+
+  function loadRoster() {
+    if (!company.value || !startDate.value || !endDate.value) return;
+    isLoading.value = true;
+    rosterDataResource.submit({
+      company: company.value,
+      start_date: startDate.value,
+      end_date: endDate.value,
+    });
+    serviceOptionsResource.submit({
+      company: company.value,
+    });
+  }
+
+  function addPendingChange(change) {
+    // Remove any existing pending change for same nurse+date
+    pendingChanges.value = pendingChanges.value.filter(
+      (c) =>
+        !(
+          c.nurse === change.nurse &&
+          c.assignment_date === change.assignment_date
+        ),
+    );
+    pendingChanges.value.push(change);
+  }
+
+  function removePendingChange(nurse, date) {
+    pendingChanges.value = pendingChanges.value.filter(
+      (c) => !(c.nurse === nurse && c.assignment_date === date),
+    );
+  }
+
+  function hasPendingChanges() {
+    return pendingChanges.value.length > 0;
+  }
+
+  function saveRoster() {
+    if (!pendingChanges.value.length) return;
+    isSaving.value = true;
+    saveResource.submit({
+      company: company.value,
+      start_date: startDate.value,
+      end_date: endDate.value,
+      frequency: frequency.value,
+      assignments: JSON.stringify(pendingChanges.value),
+    });
+  }
+
+  return {
+    // State
+    company,
+    startDate,
+    frequency,
+    endDate,
+    nurses,
+    assignments,
+    serviceUnitTypes,
+    serviceUnits,
+    pendingChanges,
+    isLoading,
+    isSaving,
+    // Computed
+    dateColumns,
+    assignmentMap,
+    // Methods
+    getAssignment,
+    calculateEndDate,
+    loadRoster,
+    addPendingChange,
+    removePendingChange,
+    hasPendingChanges,
+    saveRoster,
+  };
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
       jinjaBootData: true,
       lucideIcons: true,
       buildConfig: {
-        indexHtmlPath: "../<app-name>/www/frontend.html",
+        indexHtmlPath: "../hms_tz/www/frontend.html",
         emptyOutDir: true,
         sourcemap: true,
       },
@@ -20,7 +20,7 @@ export default defineConfig({
   ],
   build: {
     chunkSizeWarningLimit: 1500,
-    outDir: "../<app-name>/public/frontend",
+    outDir: "../hms_tz/public/frontend",
     emptyOutDir: true,
     target: "es2015",
     sourcemap: true,

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule_list.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule_list.js
@@ -1,0 +1,10 @@
+// Copyright (c) 2026, Aakvatech Limited and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings["Nursing Schedule"] = {
+  onload: function (listview) {
+    listview.page.add_inner_button(__("Open Roster"), function () {
+      window.open("/frontend/nurse-roster");
+    });
+  },
+};

--- a/hms_tz/hms_tz/doctype/nursing_schedule/roster.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/roster.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026, Aakvatech Limited and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.utils import add_to_date, getdate
+
+
+@frappe.whitelist()
+def get_roster_data(company: str, start_date: str, end_date: str) -> dict:
+    """Return nurses and their existing assignments for the given company and date range.
+
+    Returns:
+        dict with keys:
+        - nurses: list of {name, practitioner_name, employee}
+        - assignments: list of {nurse, assignment_date, assign_based_on,
+          service_unit_type, service_unit, parent, name}
+    """
+    if not company or not start_date or not end_date:
+        frappe.throw(_("Company, Start Date, and End Date are required."))
+
+    nurses = frappe.db.get_all(
+        "Healthcare Practitioner",
+        filters={
+            "practitioner_role": "Nurse",
+            "hms_tz_company": company,
+            "status": "Active",
+        },
+        fields=["name", "practitioner_name", "employee"],
+        order_by="practitioner_name asc",
+    )
+
+    nurse_names = [n.name for n in nurses]
+
+    # Get all assignments in the date range for these nurses
+    assignments = []
+    if nurse_names:
+        assignments = frappe.db.get_all(
+            "Nurse Schedule Detail",
+            filters={
+                "nurse": ["in", nurse_names],
+                "assignment_date": ["between", [start_date, end_date]],
+            },
+            fields=[
+                "name",
+                "parent",
+                "nurse",
+                "nurse_name",
+                "assignment_date",
+                "assign_based_on",
+                "service_unit_type",
+                "service_unit",
+            ],
+            order_by="assignment_date asc",
+        )
+
+    return {
+        "nurses": nurses,
+        "assignments": assignments,
+    }
+
+
+@frappe.whitelist()
+def save_roster_assignments(
+    company: str,
+    start_date: str,
+    end_date: str,
+    frequency: str,
+    assignments: list | str,
+) -> dict:
+    """Batch-save roster assignments.
+
+    Each assignment dict should have:
+    - nurse: str (Healthcare Practitioner name)
+    - assignment_date: str (YYYY-MM-DD)
+    - assign_based_on: str (Service Unit Type / Service Unit)
+    - service_unit_type: str (optional)
+    - service_unit: str (optional)
+    - existing_name: str (optional - if editing an existing row)
+    - action: str (add / edit / remove)
+
+    This function finds or creates Nursing Schedule documents for the
+    given company/start_date/end_date/frequency and updates their
+    child table rows accordingly.
+    """
+    import json
+
+    if isinstance(assignments, str):
+        assignments = json.loads(assignments)
+
+    if not assignments:
+        return {"message": _("No assignments to save.")}
+
+    # Find existing Nursing Schedule for this period, or create one
+    existing_schedule = frappe.db.get_value(
+        "Nursing Schedule",
+        filters={
+            "company": company,
+            "start_date": start_date,
+            "end_date": end_date,
+            "docstatus": ["!=", 2],
+        },
+        fieldname="name",
+    )
+
+    if existing_schedule:
+        schedule = frappe.get_doc("Nursing Schedule", existing_schedule)
+    else:
+        schedule = frappe.new_doc("Nursing Schedule")
+        schedule.company = company
+        schedule.frequency = frequency
+        schedule.start_date = start_date
+        schedule.end_date = end_date
+
+    for assignment in assignments:
+        action = assignment.get("action", "add")
+        existing_name = assignment.get("existing_name")
+
+        if action == "remove" and existing_name:
+            # Remove the row from the child table
+            schedule.assignments = [
+                row for row in schedule.assignments if row.name != existing_name
+            ]
+            continue
+
+        if action == "edit" and existing_name:
+            # Find and update the existing row
+            for row in schedule.assignments:
+                if row.name == existing_name:
+                    row.assign_based_on = assignment.get("assign_based_on", "")
+                    row.service_unit_type = assignment.get("service_unit_type", "")
+                    row.service_unit = assignment.get("service_unit", "")
+                    break
+            continue
+
+        # action == "add"
+        # Validate: no duplicate nurse + date
+        duplicate = False
+        for row in schedule.assignments:
+            if (
+                row.nurse == assignment.get("nurse")
+                and str(row.assignment_date) == str(assignment.get("assignment_date"))
+            ):
+                duplicate = True
+                break
+
+        if duplicate:
+            frappe.msgprint(
+                _("Nurse {0} already has an assignment on {1}. Skipping.").format(
+                    assignment.get("nurse"), assignment.get("assignment_date")
+                ),
+                alert=True,
+            )
+            continue
+
+        schedule.append(
+            "assignments",
+            {
+                "nurse": assignment.get("nurse"),
+                "assignment_date": assignment.get("assignment_date"),
+                "assign_based_on": assignment.get("assign_based_on", "Service Unit Type"),
+                "service_unit_type": assignment.get("service_unit_type", ""),
+                "service_unit": assignment.get("service_unit", ""),
+            },
+        )
+
+    schedule.save(ignore_permissions=False)
+
+    return {
+        "message": _("Roster saved successfully."),
+        "schedule_name": schedule.name,
+    }
+
+
+@frappe.whitelist()
+def get_service_options(company: str) -> dict:
+    """Return service unit types and service units for dropdowns."""
+    service_unit_types = frappe.db.get_all(
+        "Healthcare Service Unit Type",
+        filters={"disabled": 0},
+        fields=["name"],
+        order_by="name asc",
+    )
+
+    service_units = frappe.db.get_all(
+        "Healthcare Service Unit",
+        filters={"is_group": 0, "disabled": 0, "company": company},
+        fields=["name", "service_unit_type"],
+        order_by="name asc",
+    )
+
+    return {
+        "service_unit_types": [s.name for s in service_unit_types],
+        "service_units": [{"name": s.name, "type": s.service_unit_type} for s in service_units],
+    }


### PR DESCRIPTION
## Nurse Roster SPA (Task 6 - Design A)

### Summary
Implements the Nurse Roster single-page application for managing nurse-to-ward/room assignments across dates. This is a complete frontend + backend feature built with Vue 3 (Composition API), Pinia, and Frappe UI.

### Backend (roster.py)
- `get_roster_data`: Fetches nurses (by company) and their schedule assignments for a date range
- `get_service_options`: Returns service unit types and service units for dropdown population
- `save_roster_assignments`: Batch processes add/edit/remove roster changes against Nursing Schedule documents
- `nursing_schedule_list.js`: Adds "Open Roster" button to Nursing Schedule list view

### Frontend SPA
- **Layout**: CRM-style collapsible sidebar with Nurse Roster (active) and Nursing Schedule navigation
- **Auto-load**: Roster auto-loads when all filter fields (Company, Frequency, Start Date, End Date) are populated — no button needed
- **Centered UI**: Title, subtitle (light blue), and filter fields are centered
- **Field order**: Company → Frequency → Start Date → End Date (auto-calculated from frequency)
- **Assignment Dialog**: Clean Dialog component with searchable Autocomplete fields for Service Unit Type and Service Unit (handles 100+ options)
- **Past Date Protection**: No edit icon or dialog for backdated assignments; past assignments retain same blue pill styling as current/future dates
- **Pending Changes**: Save/Discard bar tracks unsaved changes before committing to server
- **State Management**: Pinia store (`rosterStore.js`) centralizes filter state, data, and API calls

### Testing
- Site: `neph` at `http://neph:8001/frontend/nurse-roster`
- Verified: auto-load, past date locking, dialog assignment, searchable dropdowns, sidebar order