### PR TITLE
feat(nurse-record): add Nurse Record parent DocType with controller and client script

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/__init__.py
+++ b/hms_tz/hms_tz/doctype/nurse_record/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt

--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
@@ -1,0 +1,321 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Nurse Record", {
+  setup: (frm) => {
+    render_age(frm);
+    render_vital_signs(frm);
+  },
+
+  refresh: (frm) => {
+    set_queries(frm);
+    render_consumables_placeholder(frm);
+    setup_vital_signs_button(frm);
+  },
+
+  onload: (frm) => {
+    render_age(frm);
+    render_vital_signs(frm);
+  },
+
+  appointment: (frm) => {
+    if (frm.doc.appointment) {
+      render_vital_signs(frm);
+      render_age(frm);
+    }
+  },
+
+  record_vital_signs: (frm) => {
+    if (frm.is_new() || frm.doc.docstatus === 2) return;
+
+    show_vital_signs_dialog(frm);
+  },
+});
+
+function set_queries(frm) {
+  frm.set_query("nurse", () => {
+    return {
+      filters: {
+        status: "Active",
+        practitioner_role: "Nurse",
+        hms_tz_company: frm.doc.company,
+      },
+    };
+  });
+
+  frm.set_query("acknowledged_by", () => {
+    return {
+      filters: {
+        status: "Active",
+        practitioner_role: "Nurse",
+        hms_tz_company: frm.doc.company,
+      },
+    };
+  });
+  frm.set_query("service_unit", () => {
+    return {
+      filters: {
+        disabled: 0,
+        is_group: 0,
+        company: frm.doc.company,
+      },
+    };
+  });
+
+  frm.set_query("service_unit_type", () => {
+    return {
+      filters: {
+        disabled: 0,
+      },
+    };
+  });
+}
+
+function render_vital_signs(frm) {
+  frappe.call({
+    method: "hms_tz.hms_tz.doctype.nurse_record.nurse_record.get_vital_signs",
+    args: {
+      patient: frm.doc.patient,
+      appointment: frm.doc.appointment || "",
+    },
+    callback: function (r) {
+      if (r.message && r.message.length > 0) {
+        render_vitals_chart_and_table(frm, r.message);
+      } else {
+        frm.fields_dict.vital_signs_html.$wrapper.html(
+          '<div class="text-muted text-center p-4">' +
+            __("No vital signs recorded for this patient episode.") +
+            "</div>"
+        );
+      }
+    },
+  });
+}
+
+function render_vitals_chart_and_table(frm, vitals) {
+  let $wrapper = frm.fields_dict.vital_signs_html.$wrapper;
+  $wrapper.empty();
+
+  // --- Chart Section ---
+  let chart_id = "vitals-chart-" + frm.doc.name;
+  $wrapper.append('<div class="mb-4"><div id="' + chart_id + '"></div></div>');
+
+  let labels = vitals.map(function (v) {
+    return v.signs_date;
+  });
+  let temp_data = vitals.map(function (v) {
+    return parseFloat(v.temperature) || 0;
+  });
+  let pulse_data = vitals.map(function (v) {
+    return parseFloat(v.pulse) || 0;
+  });
+  let rr_data = vitals.map(function (v) {
+    return parseFloat(v.respiratory_rate) || 0;
+  });
+  let bp_sys_data = vitals.map(function (v) {
+    return parseFloat(v.bp_systolic) || 0;
+  });
+  let bp_dia_data = vitals.map(function (v) {
+    return parseFloat(v.bp_diastolic) || 0;
+  });
+
+  new frappe.Chart("#" + chart_id, {
+    title: __("Vital Signs Trend"),
+    data: {
+      labels: labels,
+      datasets: [
+        { name: __("Temperature (°C)"), values: temp_data },
+        { name: __("Pulse (bpm)"), values: pulse_data },
+        { name: __("Respiratory Rate"), values: rr_data },
+        { name: __("BP Systolic"), values: bp_sys_data },
+        { name: __("BP Diastolic"), values: bp_dia_data },
+      ],
+    },
+    type: "line",
+    height: 280,
+    colors: ["#ff6384", "#36a2eb", "#4bc0c0", "#ff9f40", "#9966ff"],
+    lineOptions: {
+      regionFill: 0,
+      hideDots: 0,
+    },
+  });
+
+  // --- Table Section ---
+  let table_html = '<table class="table table-bordered table-sm mt-3">';
+  table_html += "<thead><tr>";
+  table_html += "<th>" + __("Date") + "</th>";
+  table_html += "<th>" + __("Time") + "</th>";
+  table_html += "<th>" + __("Temp (°C)") + "</th>";
+  table_html += "<th>" + __("Pulse") + "</th>";
+  table_html += "<th>" + __("RR") + "</th>";
+  table_html += "<th>" + __("BP") + "</th>";
+  table_html += "<th>" + __("Weight") + "</th>";
+  table_html += "<th>" + __("BMI") + "</th>";
+  table_html += "<th>" + __("Notes") + "</th>";
+  table_html += "</tr></thead><tbody>";
+
+  vitals.forEach(function (v) {
+    let bp_display = v.bp || v.bp_systolic + "/" + v.bp_diastolic;
+    table_html += "<tr>";
+    table_html += "<td>" + (v.signs_date || "") + "</td>";
+    table_html += "<td>" + (v.signs_time || "") + "</td>";
+    table_html += "<td>" + (v.temperature || "") + "</td>";
+    table_html += "<td>" + (v.pulse || "") + "</td>";
+    table_html += "<td>" + (v.respiratory_rate || "") + "</td>";
+    table_html += "<td>" + bp_display + "</td>";
+    table_html += "<td>" + (v.weight || "") + "</td>";
+    table_html += "<td>" + (v.bmi || "") + "</td>";
+    table_html += "<td>" + (v.vital_signs_note || "") + "</td>";
+    table_html += "</tr>";
+  });
+
+  table_html += "</tbody></table>";
+  $wrapper.append(table_html);
+}
+
+function show_vital_signs_dialog(frm) {
+  let d = new frappe.ui.Dialog({
+    title: __("Record Vital Signs"),
+    fields: [
+      {
+        fieldname: "temperature",
+        fieldtype: "Data",
+        label: __("Temperature (°C)"),
+      },
+      {
+        fieldname: "pulse",
+        fieldtype: "Data",
+        label: __("Pulse (bpm)"),
+      },
+      {
+        fieldname: "respiratory_rate",
+        fieldtype: "Data",
+        label: __("Respiratory Rate"),
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "bp_systolic",
+        fieldtype: "Data",
+        label: __("BP Systolic"),
+      },
+      {
+        fieldname: "bp_diastolic",
+        fieldtype: "Data",
+        label: __("BP Diastolic"),
+      },
+      { fieldtype: "Section Break" },
+      {
+        fieldname: "weight",
+        fieldtype: "Float",
+        label: __("Weight (kg)"),
+      },
+      {
+        fieldname: "height",
+        fieldtype: "Float",
+        label: __("Height (cm)"),
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "tongue",
+        fieldtype: "Select",
+        label: __("Tongue"),
+        options: "\nCoated\nVery Coated\nNormal\nFurry\nCuts",
+      },
+      {
+        fieldname: "abdomen",
+        fieldtype: "Select",
+        label: __("Abdomen"),
+        options: "\nNormal\nBloated\nFull\nFluid\nConstipated",
+      },
+      {
+        fieldname: "reflexes",
+        fieldtype: "Select",
+        label: __("Reflexes"),
+        options: "\nNormal\nHyper\nVery Hyper\nOne Sided",
+      },
+      { fieldtype: "Section Break" },
+      {
+        fieldname: "vital_signs_note",
+        fieldtype: "Small Text",
+        label: __("Notes"),
+      },
+    ],
+    primary_action_label: __("Save"),
+    primary_action(values) {
+      frappe.call({
+        method:
+          "hms_tz.hms_tz.doctype.nurse_record.nurse_record.create_vital_signs",
+        args: {
+          patient: frm.doc.patient,
+          nurse_record: frm.doc.name,
+          ...values,
+        },
+        callback: function (r) {
+          if (r.message) {
+            frappe.show_alert({
+              message: __("Vital Signs {0} created and submitted", [
+                r.message,
+              ]),
+              indicator: "green",
+            });
+            d.hide();
+            render_vital_signs(frm);
+          }
+        },
+      });
+    },
+  });
+
+  d.show();
+}
+
+function render_consumables_placeholder(frm) {
+  if (!frm.fields_dict.consumables_html) return;
+
+  frm.fields_dict.consumables_html.$wrapper.html(
+    '<div class="text-muted text-center p-4">' +
+      __(
+        "Consumables tracking will be available after the Consumable Record module is implemented."
+      ) +
+      "</div>"
+  );
+}
+
+function render_age(frm) {
+  if (!frm.fields_dict.age || !frm.fields_dict.age.$wrapper) return;
+
+  if (!frm.doc.patient) {
+    frm.fields_dict.age.$wrapper.html("");
+    return;
+  }
+
+  frappe.call({
+    method: "frappe.client.get_value",
+    args: {
+      doctype: "Patient",
+      filters: { name: frm.doc.patient },
+      fieldname: "dob",
+    },
+    callback: (r) => {
+      if (r.message && r.message.dob) {
+        const age_str = get_age(r.message.dob);
+        frm.fields_dict.age.$wrapper.html(
+          `<div class="clearfix"><span class="text-muted">${__(
+            "AGE"
+          )} : ${age_str}</span></div>`
+        );
+      } else {
+        frm.fields_dict.age.$wrapper.html("");
+      }
+    },
+  });
+}
+
+const get_age = function (birth) {
+  let birth_moment = moment(birth);
+  let current_moment = moment(Date());
+  let diff = moment.duration(current_moment.diff(birth_moment));
+  return `${diff.years()} ${__("Year(s)")} ${diff.months()} ${__(
+    "Month(s)"
+  )} ${diff.days()} ${__("Day(s)")}`;
+};

--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
@@ -1,0 +1,413 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-04-07 00:00:00",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_header",
+  "appointment",
+  "patient",
+  "patient_name",
+  "inpatient_record",
+  "column_break_header",
+  "company",
+  "gender",
+  "age",
+  "column_break_kgkv",
+  "status",
+  "posting_date",
+  "posting_time",
+  "section_break_hsu",
+  "service_unit",
+  "service_unit_type",
+  "naming_series",
+  "column_break_references",
+  "nurse",
+  "nurse_name",
+  "amended_from",
+  "tab_care_plans",
+  "care_plans",
+  "tab_nursing_notes",
+  "nursing_notes",
+  "previous_notes",
+  "tab_vital_signs",
+  "column_break_hrhg",
+  "column_break_chqn",
+  "record_vital_signs",
+  "section_break_fgmh",
+  "vital_signs_html",
+  "tab_medications",
+  "medications",
+  "tab_observations",
+  "observations",
+  "tab_progress",
+  "progress_notes",
+  "tab_consumables",
+  "consumables_html",
+  "tab_handover",
+  "section_break_handover_notes",
+  "outgoing_notes",
+  "pending_tasks",
+  "critical_alerts",
+  "section_break_handover_ack",
+  "handover_acknowledged",
+  "column_break_handover_ack",
+  "acknowledged_by"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_header",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "NR-.YYYY.-",
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Series",
+   "options": "NR-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "appointment",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Appointment",
+   "options": "Patient Appointment",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fetch_from": "appointment.patient",
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fetch_from": "appointment.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "nurse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Nurse",
+   "options": "Healthcare Practitioner",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "nurse.practitioner_name",
+   "fieldname": "nurse_name",
+   "fieldtype": "Data",
+   "label": "Nurse Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_header",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "appointment.company",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company",
+   "read_only": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Posting Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "posting_time",
+   "fieldtype": "Time",
+   "label": "Posting Time"
+  },
+  {
+   "default": "Open",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Open\nIn Progress\nCompleted",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "service_unit",
+   "fieldtype": "Link",
+   "label": "Service Unit",
+   "options": "Healthcare Service Unit"
+  },
+  {
+   "fieldname": "service_unit_type",
+   "fieldtype": "Link",
+   "label": "Service Unit Type",
+   "options": "Healthcare Service Unit Type"
+  },
+  {
+   "fieldname": "column_break_references",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "appointment.inpatient_record",
+   "fieldname": "inpatient_record",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Inpatient Record",
+   "options": "Inpatient Record",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Nurse Record",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "tab_care_plans",
+   "fieldtype": "Tab Break",
+   "label": "Care Plans"
+  },
+  {
+   "fieldname": "care_plans",
+   "fieldtype": "Table",
+   "label": "Care Plans",
+   "options": "Nurse Care Plan"
+  },
+  {
+   "fieldname": "tab_nursing_notes",
+   "fieldtype": "Tab Break",
+   "label": "Nursing Notes"
+  },
+  {
+   "fieldname": "nursing_notes",
+   "fieldtype": "Text Editor",
+   "label": "Nursing Notes"
+  },
+  {
+   "fieldname": "previous_notes",
+   "fieldtype": "Text Editor",
+   "label": "Previous Notes",
+   "read_only": 1
+  },
+  {
+   "fieldname": "tab_vital_signs",
+   "fieldtype": "Tab Break",
+   "label": "Vital Signs"
+  },
+  {
+   "bold": 1,
+   "fieldname": "vital_signs_html",
+   "fieldtype": "HTML",
+   "label": "Vital Signs"
+  },
+  {
+   "fieldname": "tab_medications",
+   "fieldtype": "Tab Break",
+   "label": "Medication Administration"
+  },
+  {
+   "fieldname": "medications",
+   "fieldtype": "Table",
+   "label": "Medications",
+   "options": "Nurse Medication Administration"
+  },
+  {
+   "fieldname": "tab_observations",
+   "fieldtype": "Tab Break",
+   "label": "Observations"
+  },
+  {
+   "fieldname": "observations",
+   "fieldtype": "Table",
+   "label": "Observations",
+   "options": "Nurse Observation"
+  },
+  {
+   "fieldname": "tab_progress",
+   "fieldtype": "Tab Break",
+   "label": "Patient Progress"
+  },
+  {
+   "fieldname": "progress_notes",
+   "fieldtype": "Table",
+   "label": "Progress Notes",
+   "options": "Nurse Progress Note"
+  },
+  {
+   "fieldname": "tab_consumables",
+   "fieldtype": "Tab Break",
+   "label": "Consumables"
+  },
+  {
+   "fieldname": "consumables_html",
+   "fieldtype": "HTML",
+   "label": "Consumables"
+  },
+  {
+   "fieldname": "tab_handover",
+   "fieldtype": "Tab Break",
+   "label": "Handover"
+  },
+  {
+   "fieldname": "section_break_handover_notes",
+   "fieldtype": "Section Break",
+   "label": "Handover Notes"
+  },
+  {
+   "fieldname": "outgoing_notes",
+   "fieldtype": "Text Editor",
+   "label": "Outgoing Notes"
+  },
+  {
+   "fieldname": "pending_tasks",
+   "fieldtype": "Text Editor",
+   "label": "Pending Tasks"
+  },
+  {
+   "fieldname": "critical_alerts",
+   "fieldtype": "Text Editor",
+   "label": "Critical Alerts"
+  },
+  {
+   "fieldname": "section_break_handover_ack",
+   "fieldtype": "Section Break",
+   "label": "Acknowledgement"
+  },
+  {
+   "default": "0",
+   "fieldname": "handover_acknowledged",
+   "fieldtype": "Check",
+   "label": "Handover Acknowledged"
+  },
+  {
+   "depends_on": "eval:doc.handover_acknowledged",
+   "fieldname": "column_break_handover_ack",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.handover_acknowledged",
+   "fieldname": "acknowledged_by",
+   "fieldtype": "Link",
+   "label": "Acknowledged By",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_hsu",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fetch_from": "patient.sex",
+   "fieldname": "gender",
+   "fieldtype": "Link",
+   "label": "Gender",
+   "options": "Gender",
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_kgkv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "age",
+   "fieldtype": "HTML",
+   "label": "Age"
+  },
+  {
+   "fieldname": "record_vital_signs",
+   "fieldtype": "Button",
+   "label": "Record Vital Signs"
+  },
+  {
+   "fieldname": "column_break_hrhg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_chqn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_fgmh",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2026-04-08 13:39:53.996510",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Nurse Record",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Healthcare Administrator",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nursing User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Physician"
+  }
+ ],
+ "restrict_to_domain": "Healthcare",
+ "row_format": "Dynamic",
+ "search_fields": "patient,nurse,posting_date",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "patient_name",
+ "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
@@ -1,0 +1,346 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import nowdate, nowtime
+
+
+class NurseRecord(Document):
+    def before_save(self):
+        self.set_inpatient_record()
+        self.validate_posting_date()
+        self.validate_no_duplicate()
+        self.validate_service_unit_fields()
+        self.set_status_on_save()
+        self.set_previous_notes()
+
+    def set_inpatient_record(self):
+        """Auto-set inpatient_record from the patient if not already set."""
+        if self.patient and not self.inpatient_record:
+            self.inpatient_record = frappe.db.get_value(
+                "Patient",
+                self.patient,
+                "inpatient_record",
+            )
+
+    def validate_posting_date(self):
+        if not self.posting_date:
+            self.posting_date = nowdate()
+            self.posting_time = nowtime()
+
+    def validate_no_duplicate(self):
+        """Prevent duplicate nurse records for the same patient + nurse + date."""
+        filters = {
+            "patient": self.patient,
+            "nurse": self.nurse,
+            "posting_date": self.posting_date,
+            "docstatus": ["!=", 2],
+        }
+        if not self.is_new():
+            filters["name"] = ["!=", self.name]
+
+        existing = frappe.db.exists("Nurse Record", filters)
+        if existing:
+            frappe.throw(
+                _(
+                    "A Nurse Record already exists for patient {0} with nurse"
+                    " {1} on {2}: {3}"
+                ).format(self.patient, self.nurse, self.posting_date, existing)
+            )
+
+    def validate_service_unit_fields(self):
+        """Validate service unit fields.
+
+        Rules:
+        - If service_unit is set but service_unit_type is missing: OK
+        - If service_unit_type is set but service_unit is missing: OK
+        - If BOTH are missing: throw validation error
+        """
+        if not self.service_unit and not self.service_unit_type:
+            frappe.throw(
+                _(
+                    "Please set at least one of Service Unit or Service Unit"
+                    " Type."
+                )
+            )
+
+    def set_status_on_save(self):
+        """Auto-update status based on content."""
+        if self.status == "Open" and (
+            self.care_plans or self.nursing_notes or self.observations
+        ):
+            self.status = "In Progress"
+
+    def set_previous_notes(self):
+        """Copy nursing_notes from the most recent previous Nurse Record for this patient."""
+
+        if not self.is_new() or not self.patient:
+            return
+
+        nurse_details = frappe.db.get_value(
+            "Nurse Record",
+            filters={
+                "patient": self.patient,
+                "docstatus": ["!=", 2],
+                "name": ["!=", self.name or ""],
+            },
+            fieldname=["nursing_notes", "previous_notes", "posting_date", "posting_time"],
+            order_by="posting_date desc, creation desc",
+            as_dict=True
+        )
+
+        if not nurse_details:
+            return
+
+        nurse_info = ""
+        if nurse_details.nursing_notes:
+            nurse_info = f"""
+            Nurse: <b>{nurse_details.nurse}</b>: Date: <b>{nurse_details.posting_date + ' ' + nurse_details.posting_time}</b><br>{nurse_details.nursing_notes}
+            """
+        self.previous_notes = nurse_info + "\n\n" + (nurse_details.previous_notes or "")
+
+
+@frappe.whitelist()
+def get_vital_signs(patient, appointment=None):
+    """Fetch vital signs for a patient's episode (from appointment to current).
+
+    Returns vital signs data for rendering charts and table in the Nurse Record.
+    """
+    filters = {
+        "patient": patient,
+        "docstatus": 1,
+    }
+    if appointment:
+        filters["appointment"] = appointment
+
+    vitals = frappe.db.get_all(
+        "Vital Signs",
+        filters=filters,
+        fields=[
+            "name",
+            "signs_date",
+            "signs_time",
+            "temperature",
+            "pulse",
+            "respiratory_rate",
+            "bp_systolic",
+            "bp_diastolic",
+            "bp",
+            "weight",
+            "height",
+            "bmi",
+            "vital_signs_note",
+        ],
+        order_by="signs_date asc, signs_time asc",
+        limit_page_length=0,
+    )
+
+    return vitals
+
+
+@frappe.whitelist()
+def create_vital_signs(patient, nurse_record, **kwargs):
+    """Create a Vital Signs record from the Nurse Record dialog.
+
+    Args:
+        patient: Patient ID
+        nurse_record: Nurse Record name for linking
+        **kwargs: Vital signs field values (temperature, pulse, bp_systolic, etc.)
+    """
+    nr = frappe.get_doc("Nurse Record", nurse_record)
+    vs = frappe.new_doc("Vital Signs")
+    vs.patient = patient
+    vs.appointment = nr.appointment
+    vs.inpatient_record = nr.inpatient_record
+    vs.company = nr.company
+    vs.signs_date = nowdate()
+
+    # Set vital sign values from kwargs
+    vital_fields = [
+        "temperature",
+        "pulse",
+        "respiratory_rate",
+        "bp_systolic",
+        "bp_diastolic",
+        "weight",
+        "height",
+        "tongue",
+        "abdomen",
+        "reflexes",
+        "vital_signs_note",
+    ]
+    for field in vital_fields:
+        if kwargs.get(field):
+            vs.set(field, kwargs[field])
+
+    vs.insert(ignore_permissions=True)
+    vs.submit()
+
+    return vs.name
+
+
+def create_nurse_records_for_admitted_patients():
+    """Background job (every 4 hours): auto-create Nurse Records for admitted patients.
+
+    Logic:
+    1. Get all Nursing Schedule records for today that haven't yet generated
+       a Nurse Record (nurse_record_created == 0).
+    2. Get all Inpatient Records with status 'Admitted'.
+    3. For each admitted patient, get the last service unit from the
+       inpatient_occupancies child table.
+    4. Match nursing schedules by comparing:
+       - schedule.service_unit == last occupancy service_unit, OR
+       - schedule.service_unit_type == service_unit_type of the last
+         occupancy's service unit
+    5. Create a Nurse Record for each match if one doesn't already exist.
+    6. Mark the Nursing Schedule's nurse_record_created checkbox.
+    """
+    today = nowdate()
+
+    # Get today's nursing schedules that haven't generated records
+    schedules = frappe.db.get_all(
+        "Nursing Schedule",
+        filters={
+            "assignment_date": today,
+            "docstatus": 1,
+            "nurse_record_created": 0,
+        },
+        fields=[
+            "name",
+            "nurse",
+            "nurse_name",
+            "company",
+            "assign_based_on",
+            "service_unit",
+            "service_unit_type",
+        ],
+    )
+
+    if not schedules:
+        return
+
+    # Get all admitted inpatient records
+    admitted_records = frappe.db.get_all(
+        "Inpatient Record",
+        filters={"status": "Admitted"},
+        fields=["name", "patient", "company", "patient_appointment"],
+    )
+
+    if not admitted_records:
+        return
+
+    for ip in admitted_records:
+        # Get the last service unit from inpatient occupancies
+        last_occupancy = frappe.db.get_value(
+            "Inpatient Occupancy",
+            filters={
+                "parent": ip.name,
+                "parenttype": "Inpatient Record",
+                "left": 0,
+            },
+            fieldname="service_unit",
+            order_by="check_in desc",
+        )
+
+        if not last_occupancy:
+            continue
+
+        # Get the service unit type of the last occupancy's service unit
+        last_su_type = frappe.db.get_value(
+            "Healthcare Service Unit",
+            last_occupancy,
+            "service_unit_type",
+        )
+
+        for schedule in schedules:
+            # Only match schedules in the same company
+            if schedule.company != ip.company:
+                continue
+
+            # Match by service_unit or service_unit_type
+            matched = False
+            if (
+                schedule.assign_based_on == "Service Unit"
+                and schedule.service_unit
+            ):
+                matched = schedule.service_unit == last_occupancy
+            elif (
+                schedule.assign_based_on == "Service Unit Type"
+                and schedule.service_unit_type
+            ):
+                matched = schedule.service_unit_type == last_su_type
+
+            if not matched:
+                continue
+
+            #Check if a record already exists
+            existing = frappe.db.exists(
+                "Nurse Record",
+                {
+                    "patient": ip.patient,
+                    "nurse": schedule.nurse,
+                    "posting_date": today,
+                    "docstatus": ["!=", 2],
+                    "nurse": schedule.nurse,
+                },
+            )
+            if existing:
+                # Still mark the schedule as processed
+                frappe.db.set_value(
+                    "Nursing Schedule",
+                    schedule.name,
+                    "nurse_record_created",
+                    1,
+                    update_modified=False,
+                )
+                continue
+
+
+            try:
+                nr = frappe.new_doc("Nurse Record")
+                nr.appointment = ip.patient_appointment
+                nr.patient = ip.patient
+                nr.nurse = schedule.nurse
+                nr.posting_date = today
+                nr.company = ip.company
+                nr.inpatient_record = ip.name
+                nr.service_unit = (
+                    last_occupancy
+                    if schedule.assign_based_on == "Service Unit"
+                    else None
+                )
+                nr.service_unit_type = (
+                    last_su_type
+                    if schedule.assign_based_on == "Service Unit Type"
+                    else None
+                )
+                nr.flags.ignore_validate = True
+                nr.insert(ignore_permissions=True)
+
+                # Mark the nursing schedule
+                frappe.db.set_value(
+                    "Nursing Schedule",
+                    schedule.name,
+                    "nurse_record_created",
+                    1,
+                    update_modified=False,
+                )
+
+            except Exception:
+                frappe.log_error(
+                    title="Nurse Record Auto-Creation Error",
+                    message=(
+                        f"Failed to create Nurse Record for patient"
+                        f" {ip.patient}, nurse {schedule.nurse},"
+                        f" schedule {schedule.name}"
+                    ),
+                    reference_doctype="Nursing Schedule",
+                    reference_name=schedule.name,
+                )
+                frappe.db.rollback()
+
+
+
+

--- a/hms_tz/hms_tz/doctype/nurse_record/test_nurse_record.py
+++ b/hms_tz/hms_tz/doctype/nurse_record/test_nurse_record.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestNurseRecord(FrappeTestCase):
+	pass


### PR DESCRIPTION
Task 7 - Nurse Record parent DocType implementation:

DocType Schema (nurse_record.json):
- Submittable DocType (is_submittable=1) with naming series NR-.YYYY.-
- Primary field: appointment (Link: Patient Appointment, mandatory)
- Auto-fetched fields via fetch_from: patient, patient_name, company, inpatient_record (all read_only, derived from appointment)
- Gender (fetch_from patient.sex) and Age (HTML, calculated via moment.js)
- Nurse (Link: Healthcare Practitioner), service_unit, service_unit_type
- Status: Open / In Progress / Completed
- 8 tabs: Care Plans, Nursing Notes, Vital Signs, Medication Administration, Observations, Patient Progress, Consumables, Handover
- Nursing Notes tab uses Text Editor fields (nursing_notes + previous_notes) instead of a child table for simpler documentation workflow
- Vital Signs tab: HTML chart area + "Record Vital Signs" button
- Handover tab: outgoing_notes, pending_tasks, critical_alerts, handover_acknowledged (Check), acknowledged_by (Link: Healthcare Practitioner)
- Permissions: Healthcare Administrator (full), Nursing User (full), Physician (read)

Controller (nurse_record.py):
- before_save hook with: set_inpatient_record (auto-fetch from patient), set_previous_notes (copy nursing_notes from most recent previous record), validate_posting_date, validate_no_duplicate (patient+nurse+date), validate_service_unit_fields (fails only if BOTH are empty), set_status_on_save (auto-transition Open→In Progress)
- get_vital_signs() whitelisted API: fetches Vital Signs by patient/appointment for chart and table rendering
- create_vital_signs() whitelisted API: creates and submits Vital Signs from dialog data
- create_nurse_records_for_admitted_patients() background job: matches Nursing Schedule assignments against Inpatient Record occupancy service units, creates Nurse Records for admitted patients, marks schedule as processed

Client Script (nurse_record.js):
- set_query filters: nurse/acknowledged_by (Active + Nurse role + company), service_unit (enabled, non-group, by company), service_unit_type (enabled)
- Vital Signs chart (frappe.Chart line chart with 5 series: temp, pulse, RR, BP systolic, BP diastolic) and HTML data table
- Dialog-based vital signs creation with all standard fields
- Age calculation using moment.js (same pattern as Patient DocType)
- Consumables placeholder for future Task 8 implementation