### PR TITLE
feat(nursing-schedule): add nurse_record_created tracking field

### DIFF
--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
@@ -18,6 +18,7 @@
   "assign_based_on",
   "service_unit_type",
   "service_unit",
+  "nurse_record_created",
   "amended_from"
  ],
  "fields": [
@@ -98,6 +99,15 @@
    "options": "Healthcare Service Unit"
   },
   {
+   "default": "0",
+   "fieldname": "nurse_record_created",
+   "fieldtype": "Check",
+   "label": "Nurse Record Created",
+   "read_only": 1,
+   "no_copy": 1,
+   "allow_on_submit": 1
+  },
+  {
    "fieldname": "amended_from",
    "fieldtype": "Link",
    "label": "Amended From",
@@ -108,7 +118,7 @@
   }
  ],
  "links": [],
- "modified": "2026-04-08 00:00:00.000000",
+ "modified": "2026-04-08 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "Nursing Schedule",

--- a/hms_tz/hms_tz/doctype/nursing_schedule/test_nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/test_nursing_schedule.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestNursingSchedule(FrappeTestCase):
+	pass


### PR DESCRIPTION
Add a checkbox field to Nursing Schedule DocType to track whether a Nurse Record has already been auto-created from this schedule entry.

Changes to nursing_schedule.json:
- New field: nurse_record_created (Check, default 0, read_only, no_copy, allow_on_submit) - prevents the background job from creating duplicate Nurse Records for the same schedule assignment
- This field is set to 1 by the create_nurse_records_for_admitted_patients background job in nurse_record.py after successful record creation

Also adds test_nursing_schedule.py stub for future test coverage.