### PR TITLE
feat(hooks): register 4-hourly cron job for auto-creating Nurse Records

### DIFF
--- a/hms_tz/hooks.py
+++ b/hms_tz/hooks.py
@@ -251,6 +251,10 @@ scheduler_events = {
     "hourly": ["hms_tz.nhif.api.healthcare_utils.set_uninvoiced_so_closed"],
     "daily": ["hms_tz.nhif.api.inpatient_record.daily_update_inpatient_occupancies"],
     "cron": {
+        # Routine for every 4 hours: auto-create Nurse Records for admitted patients
+        "0 */4 * * *": [
+            "hms_tz.hms_tz.doctype.nurse_record.nurse_record.create_nurse_records_for_admitted_patients"
+        ],
         # Routine for every day 00:01 am at night
         "1 0 * * *": ["hms_tz.nhif.api.healthcare_utils.auto_submit_nhif_patient_claim"],
         # Routine for every day 01:30am at night


### PR DESCRIPTION
Add scheduler cron entry to hooks.py for automatic Nurse Record creation for admitted patients.

Changes to hooks.py:
- New cron job at '0 */4 * * *' (every 4 hours at minute 0)
- Calls: hms_tz.hms_tz.doctype.nurse_record.nurse_record .create_nurse_records_for_admitted_patients
- The job matches active Nursing Schedule assignments against admitted Inpatient Records by comparing service_unit or service_unit_type, then auto-creates Nurse Records and marks schedules as processed via the nurse_record_created checkbox