### PR TITLE
refactor(custom-fields): rename nursing patch file and add IMO Entry traceability fields

### DIFF
--- a/hms_tz/patches/custom_fields/custom_fields_json/28_nursing_ot_fields.json
+++ b/hms_tz/patches/custom_fields/custom_fields_json/28_nursing_ot_fields.json
@@ -28,5 +28,25 @@
         "depends_on": "eval:doc.practitioner_role==\"Nurse\"",
         "insert_after": "nursing_specialization",
         "doctype": "Custom Field"
+    },
+    {
+        "dt": "Inpatient Medication Order Entry",
+        "fieldname": "ref_doctype",
+        "fieldtype": "Data",
+        "label": "Reference DocType",
+        "insert_after": "instructions",
+        "read_only": 1,
+        "no_copy": 1,
+        "doctype": "Custom Field"
+    },
+    {
+        "dt": "Inpatient Medication Order Entry",
+        "fieldname": "ref_docname",
+        "fieldtype": "Data",
+        "label": "Reference Name",
+        "insert_after": "ref_doctype",
+        "read_only": 1,
+        "no_copy": 1,
+        "doctype": "Custom Field"
     }
 ]


### PR DESCRIPTION
Rename 28_healthcare_practitioner_nursing.json → 28_nursing_ot_fields.json to consolidate all nursing and OT-related custom fields into a single fixture file with a clearer name.

Custom Field Additions (Inpatient Medication Order Entry):
- ref_doctype (Data, read_only): Stores the reference DocType (e.g. "Drug Prescription") for tracing the origin of each medication order entry back to the original prescription.
- ref_docname (Data, read_only): Stores the specific reference name (e.g. the Drug Prescription name) for full audit traceability.

Existing Fields Retained (Healthcare Practitioner):
- practitioner_role (Select: Doctor/Nurse/Other)
- nursing_specialization (Select, depends_on: Nurse)
- nursing_role (Select, depends_on: Nurse)

These traceability fields support the new automated workflow where Delivery Note submission auto-creates Inpatient Medication Orders, enabling the system to trace each IMO entry back to its originating Drug Prescription.