### PR TITLE
refactor(nurse-medication-administration): restructure child table to support direct IMO-based administration

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_medication_administration/nurse_medication_administration.json
+++ b/hms_tz/hms_tz/doctype/nurse_medication_administration/nurse_medication_administration.json
@@ -4,7 +4,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "drug_prescription",
+  "drug",
   "drug_name",
   "dosage",
   "column_break_01",
@@ -14,19 +14,23 @@
   "column_break_02",
   "status",
   "administered_by",
+  "section_break_refs",
+  "imo_entry",
+  "ref_doctype",
+  "column_break_refs2",
+  "ref_docname",
   "section_break_notes",
   "notes"
  ],
  "fields": [
   {
-   "fieldname": "drug_prescription",
+   "fieldname": "drug",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Drug Prescription",
-   "options": "Drug Prescription"
+   "label": "Drug",
+   "options": "Medication"
   },
   {
-   "fetch_from": "drug_prescription.drug_name",
    "fieldname": "drug_name",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -80,6 +84,34 @@
    "options": "User"
   },
   {
+   "collapsible": 1,
+   "fieldname": "section_break_refs",
+   "fieldtype": "Section Break",
+   "label": "References"
+  },
+  {
+   "fieldname": "imo_entry",
+   "fieldtype": "Data",
+   "label": "IMO Entry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "ref_doctype",
+   "fieldtype": "Data",
+   "label": "Reference DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_refs2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "ref_docname",
+   "fieldtype": "Data",
+   "label": "Reference Name",
+   "read_only": 1
+  },
+  {
    "fieldname": "section_break_notes",
    "fieldtype": "Section Break"
   },
@@ -91,7 +123,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-04-07 00:00:00.000000",
+ "modified": "2026-04-08 22:00:00.000000",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "Nurse Medication Administration",


### PR DESCRIPTION
Refactored the Nurse Medication Administration child table to bypass the standard Inpatient Medication Entry (IME) DocType. Nurses now mark medications as administered directly within the Nurse Record form.

Field Changes:
- REMOVED: drug_prescription (Link → Drug Prescription) Replaced with a direct link to the Medication DocType, decoupling the child table from Drug Prescription references.

- ADDED: drug (Link → Medication) Direct link to the healthcare Medication DocType for cleaner data lookup and medication identification.

- ADDED: imo_entry (Data, read_only) Links each row back to the specific Inpatient Medication Order Entry it represents, enabling server-side status updates when a dose is marked as administered.

- ADDED: ref_doctype (Data, read_only) Stores the originating reference DocType (e.g. "Drug Prescription") for full prescription-to-administration audit trail.

- ADDED: ref_docname (Data, read_only) Stores the specific reference document name for traceability.

- ADDED: section_break_refs + column_break_refs2 Collapsible "References" section grouping the traceability fields to keep the main form view clean for nurses.

- REMOVED: fetch_from on drug_name Previously fetched from drug_prescription.drug_name; now populated by the server-side populate_pending_medications() logic.

Existing fields retained: drug_name, dosage, route, scheduled_time, administered_time, status, administered_by, notes.