### PR TITLE
feat(nurse-record): add medication progress chart and completed history fields to schema

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
@@ -38,7 +38,11 @@
   "section_break_fgmh",
   "vital_signs_html",
   "tab_medications",
+  "medication_progress_html",
+  "section_break_pending_meds",
   "medications",
+  "section_break_completed_meds",
+  "completed_medications_html",
   "tab_observations",
   "observations",
   "tab_progress",
@@ -229,10 +233,31 @@
    "label": "Medication Administration"
   },
   {
+   "fieldname": "medication_progress_html",
+   "fieldtype": "HTML",
+   "label": "Medication Progress"
+  },
+  {
+   "fieldname": "section_break_pending_meds",
+   "fieldtype": "Section Break",
+   "label": "Pending Medications"
+  },
+  {
    "fieldname": "medications",
    "fieldtype": "Table",
    "label": "Medications",
    "options": "Nurse Medication Administration"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_completed_meds",
+   "fieldtype": "Section Break",
+   "label": "Completed Medications"
+  },
+  {
+   "fieldname": "completed_medications_html",
+   "fieldtype": "HTML",
+   "label": "Completed Medications"
   },
   {
    "fieldname": "tab_observations",
@@ -356,7 +381,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-08 13:39:53.996510",
+ "modified": "2026-04-09 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "Nurse Record",


### PR DESCRIPTION
Extended the Nurse Record DocType schema with HTML and Section Break fields to support medication administration visualization within the Medication Administration tab.

Field Additions:
- medication_progress_html (HTML): Renders a stacked bar chart (frappe.Chart) showing Administered vs Pending counts per drug, along with a summary table with color-coded badges. Placed at the top of the Medication Administration tab for immediate visibility.

- section_break_pending_meds (Section Break, label: "Pending Medications"): Organizes the existing medications child table under a clear heading, separating it from the progress chart above.

- section_break_completed_meds (Section Break, collapsible, label: "Completed Medications"): Collapsible section below the pending table, keeping the form clean by default while allowing nurses to expand and review history.

- completed_medications_html (HTML): Renders a table of all completed IMO entries (drug, dosage, form, date, time) fetched from the server, limited to the 50 most recent entries.

Layout (Medication Administration tab, top to bottom):
  1. Medication Progress chart + summary table
  2. Pending Medications child table
  3. Completed Medications history (collapsible)