### PR TITLE
feat(nurse-record): implement medication administration frontend UI

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
@@ -10,7 +10,9 @@ frappe.ui.form.on("Nurse Record", {
   refresh: (frm) => {
     set_queries(frm);
     render_consumables_placeholder(frm);
-    setup_vital_signs_button(frm);
+    render_medication_progress(frm);
+    render_completed_medications(frm);
+    check_upcoming_medications(frm);
   },
 
   onload: (frm) => {
@@ -29,6 +31,52 @@ frappe.ui.form.on("Nurse Record", {
     if (frm.is_new() || frm.doc.docstatus === 2) return;
 
     show_vital_signs_dialog(frm);
+  },
+});
+
+frappe.ui.form.on("Nurse Medication Administration", {
+  status: (frm, cdt, cdn) => {
+    let row = locals[cdt][cdn];
+    if (row.status === "Administered" && row.imo_entry) {
+      if (!row.administered_time) {
+        frappe.model.set_value(
+          cdt,
+          cdn,
+          "administered_time",
+          frappe.datetime.now_time()
+        );
+      }
+      if (!row.administered_by) {
+        frappe.model.set_value(
+          cdt,
+          cdn,
+          "administered_by",
+          frappe.session.user
+        );
+      }
+
+      frappe.call({
+        method:
+          "hms_tz.hms_tz.doctype.nurse_record.nurse_record.mark_medication_administered",
+        args: {
+          imo_entry_name: row.imo_entry,
+          administered_time:
+            row.administered_time || frappe.datetime.now_time(),
+          nurse_record: frm.doc.name,
+        },
+        callback: (r) => {
+          if (r.message && r.message.status === "success") {
+            frappe.show_alert({
+              message: __("Medication marked as administered"),
+              indicator: "green",
+            });
+            // Refresh the medication progress chart
+            render_medication_progress(frm);
+            render_completed_medications(frm);
+          }
+        },
+      });
+    }
   },
 });
 
@@ -267,6 +315,281 @@ function show_vital_signs_dialog(frm) {
   });
 
   d.show();
+}
+
+function render_medication_progress(frm) {
+  if (!frm.fields_dict.medication_progress_html) return;
+  if (!frm.doc.patient || !frm.doc.inpatient_record) {
+    frm.fields_dict.medication_progress_html.$wrapper.html(
+      '<div class="text-muted text-center p-4">' +
+        __("Medication progress will appear once medications are ordered.") +
+        "</div>"
+    );
+    return;
+  }
+
+  frappe.call({
+    method:
+      "hms_tz.hms_tz.doctype.nurse_record.nurse_record.get_medication_progress",
+    args: {
+      patient: frm.doc.patient,
+      inpatient_record: frm.doc.inpatient_record,
+    },
+    callback: (r) => {
+      if (r.message && r.message.length > 0) {
+        render_med_progress_chart(frm, r.message);
+      } else {
+        frm.fields_dict.medication_progress_html.$wrapper.html(
+          '<div class="text-muted text-center p-4">' +
+            __("No medication orders found for this patient.") +
+            "</div>"
+        );
+      }
+    },
+  });
+}
+
+function render_med_progress_chart(frm, data) {
+  let $wrapper = frm.fields_dict.medication_progress_html.$wrapper;
+  $wrapper.empty();
+
+  let chart_id = "med-progress-chart-" + frm.doc.name;
+  $wrapper.append('<div class="mb-3"><div id="' + chart_id + '"></div></div>');
+
+  let labels = data.map((d) => d.drug_name);
+  let completed_values = data.map((d) => d.completed);
+  let pending_values = data.map((d) => d.pending);
+
+  new frappe.Chart("#" + chart_id, {
+    title: __("Medication Administration Progress"),
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          name: __("Administered"),
+          values: completed_values,
+          chartType: "bar",
+        },
+        {
+          name: __("Pending"),
+          values: pending_values,
+          chartType: "bar",
+        },
+      ],
+    },
+    type: "bar",
+    height: 250,
+    colors: ["#36a2eb", "#ff6384"],
+    barOptions: {
+      stacked: 1,
+      spaceRatio: 0.4,
+    },
+  });
+
+  // Summary table below chart
+  let summary_html =
+    '<table class="table table-sm table-bordered mt-2">' +
+    "<thead><tr>" +
+    "<th>" +
+    __("Drug") +
+    "</th>" +
+    "<th class='text-center'>" +
+    __("Total") +
+    "</th>" +
+    "<th class='text-center'>" +
+    __("Administered") +
+    "</th>" +
+    "<th class='text-center'>" +
+    __("Pending") +
+    "</th>" +
+    "</tr></thead><tbody>";
+
+  data.forEach((d) => {
+    let pct = d.total > 0 ? Math.round((d.completed / d.total) * 100) : 0;
+    let badge_class =
+      pct === 100
+        ? "badge-success"
+        : pct > 50
+        ? "badge-warning"
+        : "badge-danger";
+
+    summary_html +=
+      "<tr>" +
+      "<td>" +
+      d.drug_name +
+      "</td>" +
+      '<td class="text-center">' +
+      d.total +
+      "</td>" +
+      '<td class="text-center">' +
+      d.completed +
+      "</td>" +
+      '<td class="text-center">' +
+      '<span class="badge ' +
+      badge_class +
+      '">' +
+      d.pending +
+      "</span>" +
+      "</td></tr>";
+  });
+
+  summary_html += "</tbody></table>";
+  $wrapper.append(summary_html);
+}
+
+function render_completed_medications(frm) {
+  if (!frm.fields_dict.completed_medications_html) return;
+  if (!frm.doc.patient || !frm.doc.inpatient_record) {
+    frm.fields_dict.completed_medications_html.$wrapper.html("");
+    return;
+  }
+
+  frappe.call({
+    method:
+      "hms_tz.hms_tz.doctype.nurse_record.nurse_record.get_completed_medications",
+    args: {
+      patient: frm.doc.patient,
+      inpatient_record: frm.doc.inpatient_record,
+    },
+    callback: (r) => {
+      if (r.message && r.message.length > 0) {
+        render_completed_meds_table(frm, r.message);
+      } else {
+        frm.fields_dict.completed_medications_html.$wrapper.html(
+          '<div class="text-muted text-center p-3">' +
+            __("No completed medications yet.") +
+            "</div>"
+        );
+      }
+    },
+  });
+}
+
+function render_completed_meds_table(frm, entries) {
+  let $wrapper = frm.fields_dict.completed_medications_html.$wrapper;
+  $wrapper.empty();
+
+  let html =
+    '<table class="table table-sm table-bordered">' +
+    "<thead><tr>" +
+    "<th>" +
+    __("Drug") +
+    "</th>" +
+    "<th>" +
+    __("Dosage") +
+    "</th>" +
+    "<th>" +
+    __("Form") +
+    "</th>" +
+    "<th>" +
+    __("Date") +
+    "</th>" +
+    "<th>" +
+    __("Time") +
+    "</th>" +
+    "</tr></thead><tbody>";
+
+  entries.forEach((e) => {
+    html +=
+      "<tr>" +
+      "<td>" +
+      (e.drug_name || e.drug) +
+      "</td>" +
+      "<td>" +
+      (e.dosage || "") +
+      "</td>" +
+      "<td>" +
+      (e.dosage_form || "") +
+      "</td>" +
+      "<td>" +
+      (e.date || "") +
+      "</td>" +
+      "<td>" +
+      (e.time || "") +
+      "</td>" +
+      "</tr>";
+  });
+
+  html += "</tbody></table>";
+  $wrapper.append(html);
+}
+
+function check_upcoming_medications(frm) {
+  if (!frm.doc.nurse || frm.is_new()) return;
+
+  frappe.call({
+    method:
+      "hms_tz.hms_tz.doctype.nurse_record.nurse_record.get_upcoming_medications",
+    args: {
+      nurse: frm.doc.nurse,
+      within_minutes: 30,
+    },
+    callback: (r) => {
+      if (r.message && r.message.length > 0) {
+        show_medication_alert_banner(frm, r.message);
+      }
+    },
+  });
+}
+
+function show_medication_alert_banner(frm, medications) {
+  // Group medications by patient
+  let patients = {};
+  medications.forEach((med) => {
+    if (!patients[med.patient]) {
+      patients[med.patient] = {
+        patient_name: med.patient_name,
+        nurse_record_name: med.nurse_record_name,
+        meds: [],
+      };
+    }
+    patients[med.patient].meds.push(med);
+  });
+
+  // Build the alert message
+  let total_count = medications.length;
+  let patient_links = [];
+
+  Object.keys(patients).forEach((patient_id) => {
+    let p = patients[patient_id];
+    let med_count = p.meds.length;
+    let url = frappe.utils.get_form_link("Nurse Record", p.nurse_record_name);
+    patient_links.push(
+      '<a href="' +
+        url +
+        '" class="alert-link font-weight-bold">' +
+        p.patient_name +
+        "</a> (" +
+        med_count +
+        " medication" +
+        (med_count > 1 ? "s" : "") +
+        ")"
+    );
+  });
+
+  let alert_html =
+    '<div class="alert alert-warning alert-dismissible fade show d-flex align-items-start" ' +
+    'role="alert" style="margin-bottom: 0; border-radius: 0;">' +
+    '<span class="mr-2" style="font-size: 1.2em;">⚠️</span>' +
+    "<div>" +
+    "<strong>" +
+    total_count +
+    " medication(s) due within the next hour</strong><br>" +
+    patient_links.join(" &bull; ") +
+    "</div>" +
+    '<button type="button" class="close ml-auto" data-dismiss="alert" aria-label="Close">' +
+    '<span aria-hidden="true">&times;</span>' +
+    "</button>" +
+    "</div>";
+
+  // Insert above the form
+  frm.$wrapper
+    .find(".form-message, .medication-alert-banner")
+    .filter(".medication-alert-banner")
+    .remove();
+  $(alert_html)
+    .addClass("medication-alert-banner")
+    .prependTo(frm.$wrapper.find(".form-page"));
 }
 
 function render_consumables_placeholder(frm) {


### PR DESCRIPTION
Added client-side logic for medication administration visualization, real-time administration marking, and multi-patient dashboard alerts to the Nurse Record form.

Nurse Medication Administration child table events:
- When status changes to Administered, auto-sets administered_time to current time and administered_by to current session user
- Calls mark_medication_administered server API to update IMO entry status and trigger time recalculation when needed
- Refreshes progress chart and completed history after administration

Medication Progress Chart - render_medication_progress:
- Calls get_medication_progress API to fetch aggregated data
- Renders a frappe.Chart stacked bar chart showing Administered vs Pending counts per drug with blue/red color coding
- Displays summary table below the chart with total, administered, and pending columns with color-coded badges: green = 100% complete, yellow = over 50%, red = under 50%

Completed Medications History - render_completed_medications:
- Calls get_completed_medications API to fetch up to 50 entries
- Renders a table showing drug name, dosage, form, date, and time
- Displayed inside the collapsible Completed Medications section

Dashboard Alert Banner - check_upcoming_medications:
- Calls get_upcoming_medications API on form refresh
- Scans ALL patients assigned to the current nurse
- Groups results by patient and renders a warning alert banner prepended to the top of the form page
- Each patient_name is a clickable anchor link that opens the corresponding Nurse Record form using frappe.utils.get_form_link
- Shows total medication count and per-patient breakdown
- Banner is dismissible via close button

Existing features retained:
- Age calculation from patient DOB
- Vital signs chart and table rendering with frappe.Chart line chart
- Vital signs recording dialog
- Link field queries for nurse, service_unit, service_unit_type
- Consumables placeholder