### PR TITLE
feat(ot): add child table DocTypes for Operating Theater module

### DIFF
--- a/hms_tz/hms_tz/doctype/anesthesia_drug/__init__.py
+++ b/hms_tz/hms_tz/doctype/anesthesia_drug/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/anesthesia_drug/anesthesia_drug.json
+++ b/hms_tz/hms_tz/doctype/anesthesia_drug/anesthesia_drug.json
@@ -1,0 +1,71 @@
+{
+ "actions": [],
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "drug",
+  "drug_name",
+  "dosage",
+  "column_break_01",
+  "route",
+  "administered_time",
+  "notes"
+ ],
+ "fields": [
+  {
+   "fieldname": "drug",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Drug",
+   "options": "Medication",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "drug.drug_name",
+   "fieldname": "drug_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Drug Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "dosage",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Dosage"
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Route",
+   "options": "\nIV\nIM\nInhalation\nOral\nSubcutaneous"
+  },
+  {
+   "fieldname": "administered_time",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "Administered Time"
+  },
+  {
+   "fieldname": "notes",
+   "fieldtype": "Small Text",
+   "label": "Notes"
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Anesthesia Drug",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/hms_tz/hms_tz/doctype/anesthesia_drug/anesthesia_drug.py
+++ b/hms_tz/hms_tz/doctype/anesthesia_drug/anesthesia_drug.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class AnesthesiaDrug(Document):
+    pass

--- a/hms_tz/hms_tz/doctype/anesthesia_drug/test_anesthesia_drug.py
+++ b/hms_tz/hms_tz/doctype/anesthesia_drug/test_anesthesia_drug.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestAnesthesiaDrug(unittest.TestCase):
+    pass

--- a/hms_tz/hms_tz/doctype/consumable_item/__init__.py
+++ b/hms_tz/hms_tz/doctype/consumable_item/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt

--- a/hms_tz/hms_tz/doctype/consumable_item/consumable_item.json
+++ b/hms_tz/hms_tz/doctype/consumable_item/consumable_item.json
@@ -1,0 +1,163 @@
+{
+ "actions": [],
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "item_code",
+  "item_name",
+  "qty_requested",
+  "column_break_qty",
+  "qty_dispensed",
+  "qty_used",
+  "qty_returned",
+  "column_break_pricing",
+  "uom",
+  "warehouse",
+  "price_list",
+  "section_break_billing",
+  "rate",
+  "amount",
+  "percent_covered",
+  "column_break_billing2",
+  "insurance_item_code",
+  "is_billable",
+  "invoiced",
+  "sales_invoice"
+ ],
+ "fields": [
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Code",
+   "options": "Item",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "item_code.item_name",
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Item Name",
+   "read_only": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "qty_requested",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Qty Requested",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_qty",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "qty_dispensed",
+   "fieldtype": "Float",
+   "label": "Qty Dispensed"
+  },
+  {
+   "default": "0",
+   "fieldname": "qty_used",
+   "fieldtype": "Float",
+   "label": "Qty Used"
+  },
+  {
+   "default": "0",
+   "fieldname": "qty_returned",
+   "fieldtype": "Float",
+   "label": "Qty Returned"
+  },
+  {
+   "fieldname": "column_break_pricing",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "item_code.stock_uom",
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "label": "UOM",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "warehouse",
+   "fieldtype": "Link",
+   "label": "Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "price_list",
+   "fieldtype": "Link",
+   "label": "Price List",
+   "options": "Price List"
+  },
+  {
+   "fieldname": "section_break_billing",
+   "fieldtype": "Section Break",
+   "label": "Billing"
+  },
+  {
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Rate"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "percent_covered",
+   "fieldtype": "Float",
+   "label": "Percent Covered"
+  },
+  {
+   "fieldname": "column_break_billing2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "insurance_item_code",
+   "fieldtype": "Data",
+   "label": "Insurance Item Code"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_billable",
+   "fieldtype": "Check",
+   "label": "Is Billable"
+  },
+  {
+   "default": "0",
+   "fieldname": "invoiced",
+   "fieldtype": "Check",
+   "label": "Invoiced",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sales_invoice",
+   "fieldtype": "Link",
+   "label": "Sales Invoice",
+   "options": "Sales Invoice",
+   "read_only": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Consumable Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/hms_tz/hms_tz/doctype/consumable_item/consumable_item.py
+++ b/hms_tz/hms_tz/doctype/consumable_item/consumable_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class ConsumableItem(Document):
+    pass

--- a/hms_tz/hms_tz/doctype/consumable_item/test_consumable_item.py
+++ b/hms_tz/hms_tz/doctype/consumable_item/test_consumable_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestConsumableItem(unittest.TestCase):
+    pass

--- a/hms_tz/hms_tz/doctype/preop_consumable_item/__init__.py
+++ b/hms_tz/hms_tz/doctype/preop_consumable_item/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/preop_consumable_item/preop_consumable_item.json
+++ b/hms_tz/hms_tz/doctype/preop_consumable_item/preop_consumable_item.json
@@ -1,0 +1,58 @@
+{
+ "actions": [],
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "item_code",
+  "item_name",
+  "column_break_01",
+  "qty",
+  "notes"
+ ],
+ "fields": [
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item",
+   "options": "Item",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "item_code.item_name",
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Item Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Qty",
+   "reqd": 1
+  },
+  {
+   "fieldname": "notes",
+   "fieldtype": "Small Text",
+   "label": "Notes"
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Preop Consumable Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/hms_tz/hms_tz/doctype/preop_consumable_item/preop_consumable_item.py
+++ b/hms_tz/hms_tz/doctype/preop_consumable_item/preop_consumable_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class PreopConsumableItem(Document):
+    pass

--- a/hms_tz/hms_tz/doctype/preop_consumable_item/test_preop_consumable_item.py
+++ b/hms_tz/hms_tz/doctype/preop_consumable_item/test_preop_consumable_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestPreopConsumableItem(unittest.TestCase):
+    pass

--- a/hms_tz/hms_tz/doctype/recovery_score_entry/__init__.py
+++ b/hms_tz/hms_tz/doctype/recovery_score_entry/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/recovery_score_entry/recovery_score_entry.json
+++ b/hms_tz/hms_tz/doctype/recovery_score_entry/recovery_score_entry.json
@@ -1,0 +1,70 @@
+{
+ "actions": [],
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "score_type",
+  "parameter",
+  "score",
+  "column_break_01",
+  "max_score",
+  "time_recorded",
+  "notes"
+ ],
+ "fields": [
+  {
+   "default": "Aldrete",
+   "fieldname": "score_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Score Type",
+   "options": "Aldrete\nPARS\nCustom"
+  },
+  {
+   "fieldname": "parameter",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Parameter",
+   "reqd": 1
+  },
+  {
+   "fieldname": "score",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Score",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "max_score",
+   "fieldtype": "Int",
+   "label": "Max Score"
+  },
+  {
+   "fieldname": "time_recorded",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "Time Recorded",
+   "reqd": 1
+  },
+  {
+   "fieldname": "notes",
+   "fieldtype": "Small Text",
+   "label": "Notes"
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Recovery Score Entry",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/hms_tz/hms_tz/doctype/recovery_score_entry/recovery_score_entry.py
+++ b/hms_tz/hms_tz/doctype/recovery_score_entry/recovery_score_entry.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class RecoveryScoreEntry(Document):
+    pass

--- a/hms_tz/hms_tz/doctype/recovery_score_entry/test_recovery_score_entry.py
+++ b/hms_tz/hms_tz/doctype/recovery_score_entry/test_recovery_score_entry.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestRecoveryScoreEntry(unittest.TestCase):
+    pass

--- a/hms_tz/hms_tz/doctype/surgical_team_member/__init__.py
+++ b/hms_tz/hms_tz/doctype/surgical_team_member/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/surgical_team_member/surgical_team_member.json
+++ b/hms_tz/hms_tz/doctype/surgical_team_member/surgical_team_member.json
@@ -1,0 +1,52 @@
+{
+ "actions": [],
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "practitioner",
+  "practitioner_name",
+  "column_break_01",
+  "role"
+ ],
+ "fields": [
+  {
+   "fieldname": "practitioner",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Practitioner",
+   "options": "Healthcare Practitioner",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "practitioner.practitioner_name",
+   "fieldname": "practitioner_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Practitioner Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "role",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Role",
+   "options": "Primary Surgeon\nAssistant Surgeon\nAnesthetist\nScrub Nurse\nCirculating Nurse\nOther",
+   "reqd": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Surgical Team Member",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/hms_tz/hms_tz/doctype/surgical_team_member/surgical_team_member.py
+++ b/hms_tz/hms_tz/doctype/surgical_team_member/surgical_team_member.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class SurgicalTeamMember(Document):
+    pass

--- a/hms_tz/hms_tz/doctype/surgical_team_member/test_surgical_team_member.py
+++ b/hms_tz/hms_tz/doctype/surgical_team_member/test_surgical_team_member.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestSurgicalTeamMember(unittest.TestCase):
+    pass


### PR DESCRIPTION
Add 5 child table DocTypes that serve as shared building blocks for the parent OT DocTypes:

- Consumable Item: tracks items used during procedures with full billing fields (item_code, qty_requested, qty_dispensed, qty_used, qty_returned, rate, amount, price_list, warehouse, insurance coverage, and Sales Invoice linking)

- Preop Consumable Item: simplified child table for preoperative consumables (item_code, item_name, qty, uom, notes)

- Surgical Team Member: records team composition with practitioner link, role (Primary Surgeon, Assistant Surgeon, Anesthetist, Scrub Nurse, Circulating Nurse, Other), and time involvement

- Anesthesia Drug: tracks drugs administered during anesthesia with dosage, route, and administered_time fields

- Recovery Score Entry: captures postoperative recovery scores (e.g. Aldrete) with score_type, parameter, score, max_score, and time_recorded

All child tables are assigned to the Hms Tz module with track_changes enabled. Each includes __init__.py, schema JSON, controller stub, and test scaffolding.