### PR TITLE
feat(ot): add Consumable Record DocType for surgical consumable tracking

### DIFF
--- a/hms_tz/hms_tz/doctype/consumable_record/__init__.py
+++ b/hms_tz/hms_tz/doctype/consumable_record/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/consumable_record/consumable_record.js
+++ b/hms_tz/hms_tz/doctype/consumable_record/consumable_record.js
@@ -1,0 +1,104 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Consumable Record", {
+  setup(frm) {
+    frm.set_query("prescribed_by", () => ({
+      filters: { practitioner_role: "Doctor" },
+    }));
+    frm.set_query("patient", () => ({
+      filters: { status: "Active" },
+    }));
+  },
+
+  refresh(frm) {
+    if (frm.doc.docstatus === 1 && frm.doc.status === "Dispensed") {
+      frm.add_custom_button(
+        __("Finalize"),
+        () => {
+          frappe.confirm(
+            __("Mark all items as used and finalize this record?"),
+            () => {
+              frm.call("update_status", { status: "Finalized" }).then(() => {
+                frm.reload_doc();
+              });
+            }
+          );
+        },
+        __("Actions")
+      );
+    }
+  },
+
+  patient(frm) {
+    if (frm.doc.patient) {
+      frappe.db.get_value(
+        "Patient",
+        frm.doc.patient,
+        "inpatient_record",
+        (r) => {
+          if (r && r.inpatient_record) {
+            frm.set_value("inpatient_record", r.inpatient_record);
+          }
+        }
+      );
+    }
+  },
+});
+
+frappe.ui.form.on("Consumable Item", {
+  item_code(frm, cdt, cdn) {
+    let row = frappe.get_doc(cdt, cdn);
+    if (row.item_code && frm.doc.company) {
+      frappe.call({
+        method: "frappe.client.get_value",
+        args: {
+          doctype: "Item Price",
+          filters: {
+            item_code: row.item_code,
+            price_list: row.price_list || "Standard Selling",
+            selling: 1,
+          },
+          fieldname: "price_list_rate",
+        },
+        callback(r) {
+          if (r.message && r.message.price_list_rate) {
+            frappe.model.set_value(
+              cdt,
+              cdn,
+              "rate",
+              r.message.price_list_rate
+            );
+          }
+        },
+      });
+    }
+  },
+
+  qty_requested(frm, cdt, cdn) {
+    calculate_row_amount(frm, cdt, cdn);
+  },
+
+  rate(frm, cdt, cdn) {
+    calculate_row_amount(frm, cdt, cdn);
+  },
+
+  qty_used(frm, cdt, cdn) {
+    calculate_row_amount(frm, cdt, cdn);
+  },
+});
+
+function calculate_row_amount(frm, cdt, cdn) {
+  let row = frappe.get_doc(cdt, cdn);
+  let qty = row.qty_used || row.qty_dispensed || row.qty_requested || 0;
+  frappe.model.set_value(cdt, cdn, "amount", flt(qty) * flt(row.rate));
+  calculate_total(frm);
+}
+
+function calculate_total(frm) {
+  let total = 0;
+  (frm.doc.items || []).forEach((row) => {
+    total += flt(row.amount);
+  });
+  frm.set_value("total_amount", total);
+}

--- a/hms_tz/hms_tz/doctype/consumable_record/consumable_record.json
+++ b/hms_tz/hms_tz/doctype/consumable_record/consumable_record.json
@@ -1,0 +1,258 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "patient",
+  "patient_name",
+  "encounter",
+  "appointment",
+  "column_break_01",
+  "company",
+  "posting_date",
+  "posting_time",
+  "status",
+  "section_break_refs",
+  "inpatient_record",
+  "prescribed_by",
+  "column_break_refs2",
+  "ref_doctype",
+  "ref_docname",
+  "source_doctype",
+  "source_docname",
+  "section_break_insurance",
+  "insurance_subscription",
+  "insurance_company",
+  "column_break_insurance2",
+  "insurance_coverage_plan",
+  "section_break_items",
+  "items",
+  "section_break_totals",
+  "total_amount",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "CR-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "encounter",
+   "fieldtype": "Link",
+   "label": "Patient Encounter",
+   "options": "Patient Encounter"
+  },
+  {
+   "fieldname": "appointment",
+   "fieldtype": "Link",
+   "label": "Appointment",
+   "options": "Patient Appointment"
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "posting_time",
+   "fieldtype": "Time",
+   "label": "Posting Time"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Draft\nDispensed\nFinalized\nBilled",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_refs",
+   "fieldtype": "Section Break",
+   "label": "References"
+  },
+  {
+   "fetch_from": "patient.inpatient_record",
+   "fieldname": "inpatient_record",
+   "fieldtype": "Link",
+   "label": "Inpatient Record",
+   "options": "Inpatient Record",
+   "read_only": 1
+  },
+  {
+   "fieldname": "prescribed_by",
+   "fieldtype": "Link",
+   "label": "Prescribed By",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "column_break_refs2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "ref_doctype",
+   "fieldtype": "Link",
+   "label": "Ref DocType",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "ref_docname",
+   "fieldtype": "Dynamic Link",
+   "label": "Ref DocName",
+   "options": "ref_doctype"
+  },
+  {
+   "fieldname": "source_doctype",
+   "fieldtype": "Link",
+   "label": "Source DocType",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "source_docname",
+   "fieldtype": "Dynamic Link",
+   "label": "Source DocName",
+   "options": "source_doctype"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_insurance",
+   "fieldtype": "Section Break",
+   "label": "Insurance Details"
+  },
+  {
+   "fieldname": "insurance_subscription",
+   "fieldtype": "Link",
+   "label": "Insurance Subscription",
+   "options": "Healthcare Insurance Subscription"
+  },
+  {
+   "fetch_from": "insurance_subscription.insurance_company",
+   "fieldname": "insurance_company",
+   "fieldtype": "Link",
+   "label": "Insurance Company",
+   "options": "Healthcare Insurance Company",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_insurance2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "insurance_coverage_plan",
+   "fieldtype": "Link",
+   "label": "Insurance Coverage Plan",
+   "options": "Healthcare Insurance Coverage Plan"
+  },
+  {
+   "fieldname": "section_break_items",
+   "fieldtype": "Section Break",
+   "label": "Consumable Items"
+  },
+  {
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "options": "Consumable Item",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_totals",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "total_amount",
+   "fieldtype": "Currency",
+   "label": "Total Amount",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Consumable Record",
+   "print_hide": 1,
+   "read_only": 1
+  }
+ ],
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Consumable Record",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nursing User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Physician",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/consumable_record/consumable_record.py
+++ b/hms_tz/hms_tz/doctype/consumable_record/consumable_record.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import flt
+
+
+class ConsumableRecord(Document):
+    def before_save(self):
+        self.set_inpatient_record()
+        self.calculate_totals()
+
+    def on_submit(self):
+        self.update_status("Dispensed")
+
+    def set_inpatient_record(self):
+        """Auto-set inpatient_record if patient has an active admission."""
+        if not self.inpatient_record and self.patient:
+            inpatient_record = frappe.db.get_value(
+                "Patient", self.patient, "inpatient_record"
+            )
+            if inpatient_record:
+                self.inpatient_record = inpatient_record
+
+    def calculate_totals(self):
+        """Calculate amount per item and total amount."""
+        total = 0
+        for item in self.items:
+            qty = flt(item.qty_used) or flt(item.qty_dispensed) or flt(item.qty_requested)
+            item.amount = flt(qty * flt(item.rate))
+            total += flt(item.amount)
+        self.total_amount = total
+
+    def update_status(self, status: str):
+        self.db_set("status", status)
+
+    def validate_quantities(self):
+        """Ensure qty_returned does not exceed qty_dispensed."""
+        for item in self.items:
+            if flt(item.qty_returned) > flt(item.qty_dispensed):
+                frappe.throw(
+                    _("Row {0}: Qty Returned ({1}) cannot exceed Qty Dispensed ({2})").format(
+                        item.idx, item.qty_returned, item.qty_dispensed
+                    )
+                )
+            if flt(item.qty_used) > flt(item.qty_dispensed):
+                frappe.throw(
+                    _("Row {0}: Qty Used ({1}) cannot exceed Qty Dispensed ({2})").format(
+                        item.idx, item.qty_used, item.qty_dispensed
+                    )
+                )

--- a/hms_tz/hms_tz/doctype/consumable_record/test_consumable_record.py
+++ b/hms_tz/hms_tz/doctype/consumable_record/test_consumable_record.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestConsumableRecord(unittest.TestCase):
+    pass


### PR DESCRIPTION
Add the Consumable Record parent DocType to manage consumable items used during clinical procedures, surgeries, and inpatient care.

Schema (consumable_record.json):
- Links to Patient, Patient Encounter, and Clinical Procedure
- Reference fields (ref_doctype/ref_docname) for tracing the prescription source (Drug Prescription, Lab Prescription, etc.)
- Source fields (source_doctype/source_docname) for the originating document (Lab Test, Clinical Procedure, Therapy Session, etc.)
- Auto-detection of Inpatient Record from patient
- Appointment and Insurance Company fields for billing integration
- Status workflow: Draft → Dispensed → Finalized
- Child table: Consumable Item (items with billing fields)

Controller (consumable_record.py):
- before_save: auto-sets inpatient_record from active patient admission, calculates per-item amounts and total_amount
- on_submit: updates status to "Dispensed"
- Validates qty_returned and qty_used do not exceed qty_dispensed

Client script (consumable_record.js):
- Filters prescribed_by to practitioners with role "Doctor"
- Auto-fetches item price from Item Price on item_code selection
- Live calculation of row amounts and record total
- "Finalize" action button on submitted records

Permissions: Nursing User, Physician (full CRUD)