### PR TITLE
feat(ot): add OT Schedule DocType for theater scheduling

### DIFF
--- a/hms_tz/hms_tz/doctype/ot_schedule/__init__.py
+++ b/hms_tz/hms_tz/doctype/ot_schedule/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/ot_schedule/ot_schedule.js
+++ b/hms_tz/hms_tz/doctype/ot_schedule/ot_schedule.js
@@ -1,0 +1,94 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("OT Schedule", {
+  setup(frm) {
+    // Filter surgeons to doctors only
+    for (let field of [
+      "primary_surgeon",
+      "assistant_surgeon",
+      "anesthetist",
+    ]) {
+      frm.set_query(field, () => ({
+        filters: { practitioner_role: "Doctor" },
+      }));
+    }
+    // Filter nurses
+    for (let field of ["scrub_nurse", "circulating_nurse"]) {
+      frm.set_query(field, () => ({
+        filters: { practitioner_role: "Nurse" },
+      }));
+    }
+    frm.set_query("patient", () => ({
+      filters: { status: "Active" },
+    }));
+    frm.set_query("theater_room", () => ({
+      filters: { disabled: 0 },
+    }));
+  },
+
+  refresh(frm) {
+    if (!frm.is_new() && frm.doc.status === "Scheduled") {
+      frm.add_custom_button(
+        __("Start Procedure"),
+        () => {
+          frm.set_value("status", "In Progress");
+          frm.save();
+        },
+        __("Actions")
+      );
+
+      frm.add_custom_button(
+        __("Cancel Schedule"),
+        () => {
+          frappe.confirm(
+            __("Are you sure you want to cancel this schedule?"),
+            () => {
+              frm.set_value("status", "Cancelled");
+              frm.save();
+            }
+          );
+        },
+        __("Actions")
+      );
+    }
+
+    if (frm.doc.status === "In Progress") {
+      frm.add_custom_button(
+        __("Complete"),
+        () => {
+          frm.set_value("status", "Completed");
+          frm.set_value("end_time", frappe.datetime.now_time());
+          frm.save();
+        },
+        __("Actions")
+      );
+    }
+
+    // Create linked documents
+    if (!frm.is_new() && frm.doc.status !== "Cancelled") {
+      frm.add_custom_button(
+        __("Preoperative Assessment"),
+        () => {
+          frappe.new_doc("Preoperative Assessment", {
+            patient: frm.doc.patient,
+            ot_schedule: frm.doc.name,
+            company: frm.doc.company,
+          });
+        },
+        __("Create")
+      );
+
+      frm.add_custom_button(
+        __("Surgical Handover"),
+        () => {
+          frappe.new_doc("Surgical Handover", {
+            patient: frm.doc.patient,
+            company: frm.doc.company,
+          });
+        },
+        __("Create")
+      );
+    }
+  },
+});

--- a/hms_tz/hms_tz/doctype/ot_schedule/ot_schedule.json
+++ b/hms_tz/hms_tz/doctype/ot_schedule/ot_schedule.json
@@ -1,0 +1,227 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "patient",
+  "patient_name",
+  "procedure_template",
+  "clinical_procedure",
+  "column_break_01",
+  "company",
+  "date",
+  "priority",
+  "status",
+  "section_break_location",
+  "theater_room",
+  "start_time",
+  "estimated_duration",
+  "column_break_time",
+  "end_time",
+  "section_break_team",
+  "primary_surgeon",
+  "assistant_surgeon",
+  "anesthetist",
+  "column_break_team2",
+  "scrub_nurse",
+  "circulating_nurse",
+  "section_break_notes",
+  "notes"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "OTS-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "procedure_template",
+   "fieldtype": "Link",
+   "label": "Procedure Template",
+   "options": "Clinical Procedure Template"
+  },
+  {
+   "fieldname": "clinical_procedure",
+   "fieldtype": "Link",
+   "label": "Clinical Procedure",
+   "options": "Clinical Procedure"
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Date",
+   "reqd": 1
+  },
+  {
+   "default": "Elective",
+   "fieldname": "priority",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Priority",
+   "options": "Elective\nUrgent\nEmergency"
+  },
+  {
+   "default": "Scheduled",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Scheduled\nIn Progress\nCompleted\nCancelled\nPostponed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_location",
+   "fieldtype": "Section Break",
+   "label": "Schedule Details"
+  },
+  {
+   "fieldname": "theater_room",
+   "fieldtype": "Link",
+   "label": "Theater Room",
+   "options": "Healthcare Service Unit"
+  },
+  {
+   "fieldname": "start_time",
+   "fieldtype": "Time",
+   "label": "Start Time",
+   "reqd": 1
+  },
+  {
+   "fieldname": "estimated_duration",
+   "fieldtype": "Duration",
+   "label": "Estimated Duration"
+  },
+  {
+   "fieldname": "column_break_time",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "end_time",
+   "fieldtype": "Time",
+   "label": "Actual End Time"
+  },
+  {
+   "fieldname": "section_break_team",
+   "fieldtype": "Section Break",
+   "label": "Surgical Team"
+  },
+  {
+   "fieldname": "primary_surgeon",
+   "fieldtype": "Link",
+   "label": "Primary Surgeon",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "assistant_surgeon",
+   "fieldtype": "Link",
+   "label": "Assistant Surgeon",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "anesthetist",
+   "fieldtype": "Link",
+   "label": "Anesthetist",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "column_break_team2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "scrub_nurse",
+   "fieldtype": "Link",
+   "label": "Scrub Nurse",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "circulating_nurse",
+   "fieldtype": "Link",
+   "label": "Circulating Nurse",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "section_break_notes",
+   "fieldtype": "Section Break",
+   "label": "Notes"
+  },
+  {
+   "fieldname": "notes",
+   "fieldtype": "Text",
+   "label": "Notes"
+  }
+ ],
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "OT Schedule",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nursing User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Physician",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/ot_schedule/ot_schedule.py
+++ b/hms_tz/hms_tz/doctype/ot_schedule/ot_schedule.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class OTSchedule(Document):
+    def before_save(self):
+        self.validate_schedule_conflict()
+
+    def validate_schedule_conflict(self):
+        """Check for time conflicts in the same theater room on the same date."""
+        if not self.theater_room or not self.date or not self.start_time:
+            return
+
+        filters = {
+            "theater_room": self.theater_room,
+            "date": self.date,
+            "status": ["not in", ["Cancelled", "Postponed"]],
+            "name": ["!=", self.name],
+        }
+
+        existing = frappe.get_all(
+            "OT Schedule",
+            filters=filters,
+            fields=["name", "start_time", "end_time", "estimated_duration", "patient_name"],
+        )
+
+        for schedule in existing:
+            if self._has_time_overlap(schedule):
+                frappe.throw(
+                    _(
+                        "Time conflict with {0} (Patient: {1}) in {2} on {3}. "
+                        "Please choose a different time or theater."
+                    ).format(
+                        schedule.name,
+                        schedule.patient_name,
+                        self.theater_room,
+                        self.date,
+                    )
+                )
+
+    def _has_time_overlap(self, other) -> bool:
+        """Check if this schedule overlaps with another."""
+        from datetime import timedelta
+
+        # Estimate end time from duration if not set
+        my_start = self.start_time
+        other_start = other.start_time
+
+        # Use estimated duration (in seconds) or default 2 hours
+        my_duration = self.estimated_duration or 7200
+        other_duration = other.estimated_duration or 7200
+
+        if isinstance(my_duration, str):
+            # Duration field stores as seconds
+            my_duration = int(my_duration) if my_duration.isdigit() else 7200
+
+        if isinstance(other_duration, str):
+            other_duration = int(other_duration) if other_duration.isdigit() else 7200
+
+        from datetime import datetime, timedelta
+
+        from frappe.utils import get_time
+
+        my_start_dt = datetime.combine(datetime.today(), get_time(my_start))
+        my_end_dt = my_start_dt + timedelta(seconds=my_duration)
+
+        other_start_dt = datetime.combine(datetime.today(), get_time(other_start))
+        other_end_dt = other_start_dt + timedelta(seconds=other_duration)
+
+        return my_start_dt < other_end_dt and other_start_dt < my_end_dt

--- a/hms_tz/hms_tz/doctype/ot_schedule/test_ot_schedule.py
+++ b/hms_tz/hms_tz/doctype/ot_schedule/test_ot_schedule.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestOtSchedule(unittest.TestCase):
+    pass


### PR DESCRIPTION
Add the OT Schedule parent DocType to manage operating theater scheduling, surgical team assignments, and time slot management.

Schema (ot_schedule.json):
- Patient, Clinical Procedure, and Company links
- Theater room assignment (Healthcare Service Unit)
- Date, start_time, end_time, and estimated_duration fields
- Surgical team links: primary_surgeon, assistant_surgeon, anesthetist, scrub_nurse, circulating_nurse
- Surgical Team child table for additional team members
- Status workflow: Scheduled → In Progress → Completed/Cancelled
- Priority levels: Routine, Urgent, Emergency
- Urgency classification and surgical notes

Controller (ot_schedule.py):
- before_save: validates time conflicts in the same theater room on the same date, preventing double-booking across overlapping time ranges using estimated_duration calculations

Client script (ot_schedule.js):
- Filters surgeons/anesthetist to "Doctor" practitioner role
- Filters scrub_nurse/circulating_nurse to "Nurse" role
- Status action buttons: Start Procedure, Complete, Cancel
- "Create" menu to generate linked Preoperative Assessment and Surgical Handover documents from the schedule

Permissions: Nursing User, Physician (full CRUD)