### PR TITLE
feat(ot): add Anesthesia Record DocType for anesthesia management

### DIFF
--- a/hms_tz/hms_tz/doctype/anesthesia_record/__init__.py
+++ b/hms_tz/hms_tz/doctype/anesthesia_record/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/anesthesia_record/anesthesia_record.js
+++ b/hms_tz/hms_tz/doctype/anesthesia_record/anesthesia_record.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Anesthesia Record", {
+  setup(frm) {
+    frm.set_query("anesthetist", () => ({
+      filters: { practitioner_role: "Doctor" },
+    }));
+    frm.set_query("patient", () => ({
+      filters: { status: "Active" },
+    }));
+  },
+
+  refresh(frm) {
+    if (!frm.is_new() && frm.doc.clinical_procedure) {
+      frm.add_custom_button(__("Open Procedure"), () => {
+        frappe.set_route(
+          "Form",
+          "Clinical Procedure",
+          frm.doc.clinical_procedure
+        );
+      });
+    }
+  },
+
+  clinical_procedure(frm) {
+    if (frm.doc.clinical_procedure) {
+      frappe.db.get_value(
+        "Clinical Procedure",
+        frm.doc.clinical_procedure,
+        ["patient", "company", "practitioner"],
+        (r) => {
+          if (r) {
+            frm.set_value("patient", r.patient);
+            frm.set_value("company", r.company);
+          }
+        }
+      );
+    }
+  },
+});

--- a/hms_tz/hms_tz/doctype/anesthesia_record/anesthesia_record.json
+++ b/hms_tz/hms_tz/doctype/anesthesia_record/anesthesia_record.json
@@ -1,0 +1,204 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "patient",
+  "patient_name",
+  "clinical_procedure",
+  "ot_schedule",
+  "column_break_01",
+  "company",
+  "anesthetist",
+  "anesthesia_type",
+  "airway_approach",
+  "asa_grade",
+  "section_break_timing",
+  "start_time",
+  "end_time",
+  "section_break_vitals",
+  "pre_induction_vitals",
+  "column_break_vitals",
+  "post_induction_vitals",
+  "section_break_drugs",
+  "drugs_administered",
+  "section_break_notes",
+  "complications",
+  "notes"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "ANES-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "clinical_procedure",
+   "fieldtype": "Link",
+   "label": "Clinical Procedure",
+   "options": "Clinical Procedure"
+  },
+  {
+   "fieldname": "ot_schedule",
+   "fieldtype": "Link",
+   "label": "OT Schedule",
+   "options": "OT Schedule"
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fieldname": "anesthetist",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Anesthetist",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "anesthesia_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Anesthesia Type",
+   "options": "\nGeneral\nRegional\nLocal\nSpinal\nEpidural\nSedation"
+  },
+  {
+   "fieldname": "airway_approach",
+   "fieldtype": "Select",
+   "label": "Airway Approach",
+   "options": "\nIntubation\nLMA\nMask\nNatural"
+  },
+  {
+   "fieldname": "asa_grade",
+   "fieldtype": "Select",
+   "label": "ASA Grade",
+   "options": "\nASA I\nASA II\nASA III\nASA IV\nASA V\nASA VI"
+  },
+  {
+   "fieldname": "section_break_timing",
+   "fieldtype": "Section Break",
+   "label": "Timing"
+  },
+  {
+   "fieldname": "start_time",
+   "fieldtype": "Time",
+   "label": "Start Time"
+  },
+  {
+   "fieldname": "end_time",
+   "fieldtype": "Time",
+   "label": "End Time"
+  },
+  {
+   "fieldname": "section_break_vitals",
+   "fieldtype": "Section Break",
+   "label": "Vitals"
+  },
+  {
+   "fieldname": "pre_induction_vitals",
+   "fieldtype": "Small Text",
+   "label": "Pre-Induction Vitals"
+  },
+  {
+   "fieldname": "column_break_vitals",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "post_induction_vitals",
+   "fieldtype": "Small Text",
+   "label": "Post-Induction Vitals"
+  },
+  {
+   "fieldname": "section_break_drugs",
+   "fieldtype": "Section Break",
+   "label": "Drugs Administered"
+  },
+  {
+   "fieldname": "drugs_administered",
+   "fieldtype": "Table",
+   "label": "Drugs Administered",
+   "options": "Anesthesia Drug"
+  },
+  {
+   "fieldname": "section_break_notes",
+   "fieldtype": "Section Break",
+   "label": "Notes"
+  },
+  {
+   "fieldname": "complications",
+   "fieldtype": "Small Text",
+   "label": "Complications"
+  },
+  {
+   "fieldname": "notes",
+   "fieldtype": "Text",
+   "label": "Notes"
+  }
+ ],
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Anesthesia Record",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nursing User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Physician",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/anesthesia_record/anesthesia_record.py
+++ b/hms_tz/hms_tz/doctype/anesthesia_record/anesthesia_record.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class AnesthesiaRecord(Document):
+    def before_save(self):
+        self.validate_timing()
+
+    def validate_timing(self):
+        """Ensure end_time is after start_time if both are set."""
+        if self.start_time and self.end_time:
+            from frappe.utils import get_time
+
+            if get_time(self.end_time) < get_time(self.start_time):
+                frappe.throw(
+                    _("End Time cannot be before Start Time")
+                )

--- a/hms_tz/hms_tz/doctype/anesthesia_record/test_anesthesia_record.py
+++ b/hms_tz/hms_tz/doctype/anesthesia_record/test_anesthesia_record.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestAnesthesiaRecord(unittest.TestCase):
+    pass


### PR DESCRIPTION
Add the Anesthesia Record parent DocType to document anesthesia administration during surgical procedures.

Schema (anesthesia_record.json):
- Patient, Clinical Procedure, and Company links
- Anesthetist link (Healthcare Practitioner)
- Anesthesia type selection: General, Regional, Local, Spinal, Epidural, Sedation
- Timing fields: start_time, end_time for duration tracking
- Vital signs: heart_rate, blood_pressure, spo2, temperature
- Intubation details: intubation_type, airway_grade, tube_size
- Anesthesia Drug child table for tracking administered drugs with dosage, route, and administered_time
- Complications and clinical notes text fields

Controller (anesthesia_record.py):
- before_save: validates that end_time is not before start_time

Client script (anesthesia_record.js):
- Filters anesthetist to "Doctor" practitioner role
- "Open Procedure" button to navigate to linked Clinical Procedure
- Auto-populates patient and company from Clinical Procedure link

Permissions: Nursing User, Physician (full CRUD)