### PR TITLE
feat(ot): add Surgical Specimen and Implant Registry DocTypes

### DIFF
--- a/hms_tz/hms_tz/doctype/implant_registry/__init__.py
+++ b/hms_tz/hms_tz/doctype/implant_registry/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/implant_registry/implant_registry.js
+++ b/hms_tz/hms_tz/doctype/implant_registry/implant_registry.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Implant Registry", {
+  setup(frm) {
+    frm.set_query("implanted_by", () => ({
+      filters: { practitioner_role: "Doctor" },
+    }));
+    frm.set_query("patient", () => ({
+      filters: { status: "Active" },
+    }));
+  },
+
+  refresh(frm) {
+    if (!frm.is_new()) {
+      if (frm.doc.status === "Planned") {
+        frm.add_custom_button(
+          __("Mark Implanted"),
+          () => {
+            frm.set_value("status", "Implanted");
+            if (!frm.doc.implant_date) {
+              frm.set_value("implant_date", frappe.datetime.get_today());
+            }
+            frm.save();
+          },
+          __("Actions")
+        );
+      }
+
+      if (frm.doc.status === "Implanted") {
+        frm.add_custom_button(
+          __("Mark Removed"),
+          () => {
+            frm.set_value("status", "Removed");
+            frm.save();
+          },
+          __("Actions")
+        );
+      }
+
+      // Expiry warning
+      if (frm.doc.expiry_date) {
+        let expiry = frappe.datetime.str_to_obj(frm.doc.expiry_date);
+        let today = frappe.datetime.str_to_obj(frappe.datetime.get_today());
+        if (expiry < today) {
+          frm.dashboard.add_indicator(__("EXPIRED"), "red");
+        } else {
+          let days_left = frappe.datetime.get_diff(
+            frm.doc.expiry_date,
+            frappe.datetime.get_today()
+          );
+          if (days_left <= 30) {
+            frm.dashboard.add_indicator(
+              __("Expires in {0} days", [days_left]),
+              "orange"
+            );
+          }
+        }
+      }
+    }
+  },
+});

--- a/hms_tz/hms_tz/doctype/implant_registry/implant_registry.json
+++ b/hms_tz/hms_tz/doctype/implant_registry/implant_registry.json
@@ -1,0 +1,194 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "patient",
+  "patient_name",
+  "clinical_procedure",
+  "preoperative_assessment",
+  "column_break_01",
+  "company",
+  "status",
+  "barcode",
+  "section_break_details",
+  "implant_type",
+  "manufacturer",
+  "lot_number",
+  "serial_number",
+  "column_break_details",
+  "expiry_date",
+  "anatomical_location",
+  "implanted_by",
+  "implant_date",
+  "section_break_notes",
+  "notes"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "IMP-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "clinical_procedure",
+   "fieldtype": "Link",
+   "label": "Clinical Procedure",
+   "options": "Clinical Procedure"
+  },
+  {
+   "fieldname": "preoperative_assessment",
+   "fieldtype": "Link",
+   "label": "Preoperative Assessment",
+   "options": "Preoperative Assessment"
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "default": "Planned",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Planned\nImplanted\nRemoved\nReplaced"
+  },
+  {
+   "fieldname": "barcode",
+   "fieldtype": "Barcode",
+   "label": "Barcode",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_details",
+   "fieldtype": "Section Break",
+   "label": "Implant Details"
+  },
+  {
+   "fieldname": "implant_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Implant Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "manufacturer",
+   "fieldtype": "Data",
+   "label": "Manufacturer"
+  },
+  {
+   "fieldname": "lot_number",
+   "fieldtype": "Data",
+   "label": "Lot Number"
+  },
+  {
+   "fieldname": "serial_number",
+   "fieldtype": "Data",
+   "label": "Serial Number"
+  },
+  {
+   "fieldname": "column_break_details",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "expiry_date",
+   "fieldtype": "Date",
+   "label": "Expiry Date"
+  },
+  {
+   "fieldname": "anatomical_location",
+   "fieldtype": "Data",
+   "label": "Anatomical Location"
+  },
+  {
+   "fieldname": "implanted_by",
+   "fieldtype": "Link",
+   "label": "Implanted By",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "default": "Today",
+   "fieldname": "implant_date",
+   "fieldtype": "Date",
+   "label": "Implant Date"
+  },
+  {
+   "fieldname": "section_break_notes",
+   "fieldtype": "Section Break",
+   "label": "Notes"
+  },
+  {
+   "fieldname": "notes",
+   "fieldtype": "Text",
+   "label": "Notes"
+  }
+ ],
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Implant Registry",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nursing User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Physician",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/implant_registry/implant_registry.py
+++ b/hms_tz/hms_tz/doctype/implant_registry/implant_registry.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import random_string
+
+
+class ImplantRegistry(Document):
+    def before_insert(self):
+        self.generate_barcode()
+
+    def before_save(self):
+        self.validate_expiry()
+
+    def generate_barcode(self):
+        """Auto-generate a unique barcode for the implant."""
+        if not self.barcode:
+            self.barcode = f"IMP-{random_string(10).upper()}"
+
+    def validate_expiry(self):
+        """Warn if the implant is expired."""
+        if self.expiry_date and self.implant_date:
+            from frappe.utils import getdate
+
+            if getdate(self.expiry_date) < getdate(self.implant_date):
+                frappe.throw(
+                    _("Implant has expired (Expiry Date: {0}). Cannot proceed with implantation.").format(
+                        self.expiry_date
+                    )
+                )

--- a/hms_tz/hms_tz/doctype/implant_registry/test_implant_registry.py
+++ b/hms_tz/hms_tz/doctype/implant_registry/test_implant_registry.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestImplantRegistry(unittest.TestCase):
+    pass

--- a/hms_tz/hms_tz/doctype/surgical_specimen/__init__.py
+++ b/hms_tz/hms_tz/doctype/surgical_specimen/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/surgical_specimen/surgical_specimen.js
+++ b/hms_tz/hms_tz/doctype/surgical_specimen/surgical_specimen.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Surgical Specimen", {
+  setup(frm) {
+    frm.set_query("collected_by", () => ({
+      filters: { status: "Active" },
+    }));
+    frm.set_query("patient", () => ({
+      filters: { status: "Active" },
+    }));
+  },
+
+  refresh(frm) {
+    if (!frm.is_new()) {
+      // Status transitions
+      if (frm.doc.status === "Collected") {
+        frm.add_custom_button(
+          __("Send to Lab"),
+          () => {
+            frm.set_value("status", "Sent to Lab");
+            frm.save();
+          },
+          __("Actions")
+        );
+      }
+
+      if (frm.doc.status === "Sent to Lab") {
+        frm.add_custom_button(
+          __("Results Received"),
+          () => {
+            frm.set_value("status", "Results Received");
+            frm.save();
+          },
+          __("Actions")
+        );
+      }
+
+      // Create Lab Test from specimen
+      if (frm.doc.status === "Collected" && !frm.doc.lab_test) {
+        frm.add_custom_button(
+          __("Lab Test"),
+          () => {
+            frappe.new_doc("Lab Test", {
+              patient: frm.doc.patient,
+              company: frm.doc.company,
+            });
+          },
+          __("Create")
+        );
+      }
+    }
+  },
+});

--- a/hms_tz/hms_tz/doctype/surgical_specimen/surgical_specimen.json
+++ b/hms_tz/hms_tz/doctype/surgical_specimen/surgical_specimen.json
@@ -1,0 +1,169 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "patient",
+  "patient_name",
+  "clinical_procedure",
+  "column_break_01",
+  "company",
+  "status",
+  "barcode",
+  "section_break_details",
+  "specimen_type",
+  "anatomical_site",
+  "column_break_details",
+  "collection_time",
+  "collected_by",
+  "section_break_lab",
+  "lab_test",
+  "pathology_notes"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "SPEC-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "clinical_procedure",
+   "fieldtype": "Link",
+   "label": "Clinical Procedure",
+   "options": "Clinical Procedure"
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "default": "Collected",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Collected\nSent to Lab\nResults Received\nArchived"
+  },
+  {
+   "fieldname": "barcode",
+   "fieldtype": "Barcode",
+   "label": "Barcode",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_details",
+   "fieldtype": "Section Break",
+   "label": "Specimen Details"
+  },
+  {
+   "fieldname": "specimen_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Specimen Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "anatomical_site",
+   "fieldtype": "Data",
+   "label": "Anatomical Site"
+  },
+  {
+   "fieldname": "column_break_details",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "collection_time",
+   "fieldtype": "Datetime",
+   "label": "Collection Time"
+  },
+  {
+   "fieldname": "collected_by",
+   "fieldtype": "Link",
+   "label": "Collected By",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "section_break_lab",
+   "fieldtype": "Section Break",
+   "label": "Lab & Pathology"
+  },
+  {
+   "fieldname": "lab_test",
+   "fieldtype": "Link",
+   "label": "Lab Test",
+   "options": "Lab Test"
+  },
+  {
+   "fieldname": "pathology_notes",
+   "fieldtype": "Text",
+   "label": "Pathology Notes"
+  }
+ ],
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Surgical Specimen",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nursing User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Physician",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/surgical_specimen/surgical_specimen.py
+++ b/hms_tz/hms_tz/doctype/surgical_specimen/surgical_specimen.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+from frappe.utils import random_string
+
+
+class SurgicalSpecimen(Document):
+    def before_insert(self):
+        self.generate_barcode()
+
+    def generate_barcode(self):
+        """Auto-generate a unique barcode for the specimen."""
+        if not self.barcode:
+            self.barcode = f"SPEC-{random_string(10).upper()}"

--- a/hms_tz/hms_tz/doctype/surgical_specimen/test_surgical_specimen.py
+++ b/hms_tz/hms_tz/doctype/surgical_specimen/test_surgical_specimen.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestSurgicalSpecimen(unittest.TestCase):
+    pass


### PR DESCRIPTION
Add two DocTypes for tracking surgical materials: specimens collected during procedures and implants placed in patients.

Surgical Specimen:
- Schema: Patient, Clinical Procedure, Company links; specimen_type, collection_time, collected_by (practitioner), preservation_method, anatomical_site, and clinical_notes fields
- Auto-generated barcode on creation for lab tracking
- Status workflow: Collected → Sent to Lab → Results Available
- Controller: before_insert generates unique barcode
- Client script: status transition buttons and "Create Lab Test" action to generate a linked Lab Test from the specimen

Implant Registry:
- Schema: Patient, Clinical Procedure, Company links; implant_name, manufacturer, model_number, serial_number, lot_number, implant_site, implanted_by (practitioner), implant_date
- Expiry tracking: expiry_date with auto-validation
- Auto-generated barcode on creation for inventory tracking
- Status workflow: Available → Implanted → Removed / Recalled
- Controller: before_insert generates barcode; before_save validates expiry_date is not in the past
- Client script: status transitions, expiry warning indicator when implant is within 90 days of expiration

Permissions: Nursing User, Physician (full CRUD)