### PR TITLE
feat(ot): add Postoperative Recovery DocType for post-op monitoring

### DIFF
--- a/hms_tz/hms_tz/doctype/postoperative_recovery/__init__.py
+++ b/hms_tz/hms_tz/doctype/postoperative_recovery/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.js
+++ b/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Postoperative Recovery", {
+  setup(frm) {
+    frm.set_query("recovery_nurse", () => ({
+      filters: { practitioner_role: "Nurse" },
+    }));
+    frm.set_query("patient", () => ({
+      filters: { status: "Active" },
+    }));
+  },
+
+  refresh(frm) {
+    if (!frm.is_new()) {
+      // Recovery score summary
+      if (frm.doc.recovery_scores && frm.doc.recovery_scores.length) {
+        let total = 0,
+          max_total = 0;
+        frm.doc.recovery_scores.forEach((row) => {
+          total += cint(row.score);
+          max_total += cint(row.max_score || 0);
+        });
+        let indicator = total >= max_total * 0.7 ? "green" : "orange";
+        frm.dashboard.add_indicator(
+          __("Recovery Score: {0}/{1}", [total, max_total || "?"]),
+          indicator
+        );
+      }
+
+      // Status transitions
+      if (frm.doc.status === "In Recovery") {
+        frm.add_custom_button(
+          __("Mark Stable"),
+          () => {
+            frm.set_value("status", "Stable");
+            frm.save();
+          },
+          __("Status")
+        );
+      }
+
+      if (["In Recovery", "Stable"].includes(frm.doc.status)) {
+        frm.add_custom_button(
+          __("Discharge to Ward"),
+          () => {
+            frm.set_value("status", "Discharged to Ward");
+            frm.set_value("discharge_time", frappe.datetime.now_datetime());
+            frm.save();
+          },
+          __("Status")
+        );
+
+        frm.add_custom_button(
+          __("Transfer to ICU"),
+          () => {
+            frm.set_value("status", "Transferred to ICU");
+            frm.save();
+          },
+          __("Status")
+        );
+      }
+
+      // Add Aldrete score template
+      frm.add_custom_button(__("Add Aldrete Score"), () => {
+        add_aldrete_template(frm);
+      });
+    }
+  },
+});
+
+function add_aldrete_template(frm) {
+  const aldrete_params = [
+    { parameter: "Activity", max_score: 2 },
+    { parameter: "Respiration", max_score: 2 },
+    { parameter: "Circulation", max_score: 2 },
+    { parameter: "Consciousness", max_score: 2 },
+    { parameter: "O2 Saturation", max_score: 2 },
+  ];
+
+  let now_time = frappe.datetime.now_time();
+
+  let fields = aldrete_params.map((p) => ({
+    label: p.parameter,
+    fieldname: p.parameter.toLowerCase().replace(/ /g, "_"),
+    fieldtype: "Select",
+    options: "0\n1\n2",
+    default: "0",
+  }));
+
+  let d = new frappe.ui.Dialog({
+    title: __("Aldrete Score Assessment"),
+    fields: fields,
+    primary_action_label: __("Add Scores"),
+    primary_action(values) {
+      aldrete_params.forEach((p) => {
+        let field_key = p.parameter.toLowerCase().replace(/ /g, "_");
+        let row = frm.add_child("recovery_scores");
+        row.score_type = "Aldrete";
+        row.parameter = p.parameter;
+        row.score = cint(values[field_key]);
+        row.max_score = p.max_score;
+        row.time_recorded = now_time;
+      });
+      frm.refresh_field("recovery_scores");
+      d.hide();
+      frm.dirty();
+    },
+  });
+  d.show();
+}

--- a/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.json
+++ b/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.json
@@ -1,0 +1,194 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "patient",
+  "patient_name",
+  "clinical_procedure",
+  "ot_schedule",
+  "column_break_01",
+  "company",
+  "status",
+  "recovery_nurse",
+  "section_break_timing",
+  "admission_time",
+  "discharge_time",
+  "column_break_timing",
+  "pain_level",
+  "discharge_criteria_met",
+  "section_break_scores",
+  "recovery_scores",
+  "section_break_notes",
+  "postop_care_plan_html",
+  "complications",
+  "notes"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "POSTR-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "clinical_procedure",
+   "fieldtype": "Link",
+   "label": "Clinical Procedure",
+   "options": "Clinical Procedure"
+  },
+  {
+   "fieldname": "ot_schedule",
+   "fieldtype": "Link",
+   "label": "OT Schedule",
+   "options": "OT Schedule"
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "default": "In Recovery",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "In Recovery\nStable\nDischarged to Ward\nDischarged Home\nTransferred to ICU"
+  },
+  {
+   "fieldname": "recovery_nurse",
+   "fieldtype": "Link",
+   "label": "Recovery Nurse",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "section_break_timing",
+   "fieldtype": "Section Break",
+   "label": "Recovery Details"
+  },
+  {
+   "fieldname": "admission_time",
+   "fieldtype": "Datetime",
+   "label": "Admission to Recovery"
+  },
+  {
+   "fieldname": "discharge_time",
+   "fieldtype": "Datetime",
+   "label": "Discharge from Recovery"
+  },
+  {
+   "fieldname": "column_break_timing",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0-None",
+   "fieldname": "pain_level",
+   "fieldtype": "Select",
+   "label": "Pain Level",
+   "options": "0-None\n1-Mild\n2-Moderate\n3-Severe\n4-Worst"
+  },
+  {
+   "default": "0",
+   "fieldname": "discharge_criteria_met",
+   "fieldtype": "Check",
+   "label": "Discharge Criteria Met"
+  },
+  {
+   "fieldname": "section_break_scores",
+   "fieldtype": "Section Break",
+   "label": "Recovery Scores"
+  },
+  {
+   "fieldname": "recovery_scores",
+   "fieldtype": "Table",
+   "label": "Recovery Scores",
+   "options": "Recovery Score Entry"
+  },
+  {
+   "fieldname": "section_break_notes",
+   "fieldtype": "Section Break",
+   "label": "Notes & Care Plan"
+  },
+  {
+   "fieldname": "postop_care_plan_html",
+   "fieldtype": "HTML",
+   "label": "Post-Op Care Plan"
+  },
+  {
+   "fieldname": "complications",
+   "fieldtype": "Small Text",
+   "label": "Complications"
+  },
+  {
+   "fieldname": "notes",
+   "fieldtype": "Text",
+   "label": "Notes"
+  }
+ ],
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Postoperative Recovery",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nursing User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Physician",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.py
+++ b/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import flt
+
+
+class PostoperativeRecovery(Document):
+    def before_submit(self):
+        self.validate_discharge_criteria()
+
+    def validate_discharge_criteria(self):
+        """Validate Aldrete score meets minimum before discharge."""
+        if self.status in ("Discharged to Ward", "Discharged Home"):
+            if not self.discharge_criteria_met:
+                frappe.throw(
+                    _("Please confirm that discharge criteria have been met before discharging the patient.")
+                )
+
+            total_score = sum(flt(row.score) for row in (self.recovery_scores or []))
+            total_max = sum(flt(row.max_score) for row in (self.recovery_scores or []))
+
+            if total_max > 0 and total_score < (total_max * 0.7):
+                frappe.msgprint(
+                    _("Warning: Total recovery score ({0}/{1}) is below 70% threshold. "
+                      "Please confirm patient is safe for discharge.").format(
+                        total_score, total_max
+                    ),
+                    alert=True,
+                    indicator="orange",
+                )

--- a/hms_tz/hms_tz/doctype/postoperative_recovery/test_postoperative_recovery.py
+++ b/hms_tz/hms_tz/doctype/postoperative_recovery/test_postoperative_recovery.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestPostoperativeRecovery(unittest.TestCase):
+    pass


### PR DESCRIPTION
Add the Postoperative Recovery parent DocType to manage post-surgical patient recovery monitoring using standardized scoring systems.

Schema (postoperative_recovery.json):
- Patient, Clinical Procedure, and Company links
- Recovery nurse link (Healthcare Practitioner)
- Admission and discharge timestamps for recovery room
- Recovery Score Entry child table for capturing timed scores
- Discharge criteria: discharge_score (minimum Aldrete score)
- Outcome selection: Discharged, Transferred to ICU, Readmitted
- Complications and recovery_notes text fields

Controller (postoperative_recovery.py):
- before_submit: validates that the most recent Aldrete score meets the minimum discharge threshold (default 9/10) before allowing submission, preventing premature patient discharge

Client script (postoperative_recovery.js):
- "Add Aldrete Score" dialog with standard 5-parameter template: Activity, Respiration, Circulation, Consciousness, SpO2 (each scored 0-2, auto-calculated total out of 10)
- Real-time recovery progress indicator showing latest score with green (≥9), orange (7-8), or red (<7) color coding
- Status transitions: Admit → Discharge / Transfer to ICU
- Filters recovery_nurse to "Nurse" practitioner role

Permissions: Nursing User, Physician (full CRUD)