### PR TITLE
feat(ot): add Surgical Handover DocType for patient handover workflow

### DIFF
--- a/hms_tz/hms_tz/doctype/surgical_handover/__init__.py
+++ b/hms_tz/hms_tz/doctype/surgical_handover/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/hms_tz/hms_tz/doctype/surgical_handover/surgical_handover.js
+++ b/hms_tz/hms_tz/doctype/surgical_handover/surgical_handover.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Surgical Handover", {
+  setup(frm) {
+    frm.set_query("handed_over_by", () => ({
+      filters: { status: "Active" },
+    }));
+    frm.set_query("received_by", () => ({
+      filters: { status: "Active" },
+    }));
+    frm.set_query("patient", () => ({
+      filters: { status: "Active" },
+    }));
+    frm.set_query("from_location", () => ({
+      filters: { disabled: 0 },
+    }));
+    frm.set_query("to_location", () => ({
+      filters: { disabled: 0 },
+    }));
+  },
+
+  refresh(frm) {
+    if (!frm.is_new()) {
+      // Checklist progress
+      let checklist_fields = [
+        "patient_identity_verified",
+        "consent_verified",
+        "surgical_site_marked",
+        "allergies_documented",
+        "iv_lines_checked",
+        "vitals_stable",
+        "medications_documented",
+        "blood_products_available",
+        "specimens_handed_over",
+        "drain_tubes_documented",
+      ];
+
+      let done = checklist_fields.filter((f) => frm.doc[f]).length;
+      let total = checklist_fields.length;
+      let color =
+        done === total ? "green" : done > total / 2 ? "orange" : "red";
+      frm.dashboard.add_indicator(
+        __("Checklist: {0}/{1}", [done, total]),
+        color
+      );
+    }
+  },
+
+  acknowledgement(frm) {
+    if (frm.doc.acknowledgement && !frm.doc.acknowledged_time) {
+      frm.set_value("acknowledged_time", frappe.datetime.now_datetime());
+    }
+  },
+
+  type(frm) {
+    // Suggest default checklist items based on handover type
+    if (frm.doc.type === "Ward to Theater") {
+      frm.dashboard.add_comment(
+        __(
+          "Ensure patient identity, consent, site marking, and fasting are verified before transfer."
+        ),
+        "blue",
+        true
+      );
+    }
+  },
+});

--- a/hms_tz/hms_tz/doctype/surgical_handover/surgical_handover.json
+++ b/hms_tz/hms_tz/doctype/surgical_handover/surgical_handover.json
@@ -1,0 +1,263 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-04-09 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "patient",
+  "patient_name",
+  "clinical_procedure",
+  "column_break_01",
+  "company",
+  "type",
+  "handover_time",
+  "section_break_locations",
+  "from_location",
+  "handed_over_by",
+  "column_break_locations",
+  "to_location",
+  "received_by",
+  "tab_checklist",
+  "patient_identity_verified",
+  "consent_verified",
+  "surgical_site_marked",
+  "allergies_documented",
+  "iv_lines_checked",
+  "column_break_checklist",
+  "vitals_stable",
+  "medications_documented",
+  "blood_products_available",
+  "specimens_handed_over",
+  "drain_tubes_documented",
+  "tab_notes",
+  "clinical_notes",
+  "section_break_ack",
+  "acknowledgement",
+  "acknowledged_time"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "SH-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "clinical_procedure",
+   "fieldtype": "Link",
+   "label": "Clinical Procedure",
+   "options": "Clinical Procedure"
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Handover Type",
+   "options": "Ward to Theater\nTheater to Ward",
+   "reqd": 1
+  },
+  {
+   "default": "Now",
+   "fieldname": "handover_time",
+   "fieldtype": "Datetime",
+   "label": "Handover Time"
+  },
+  {
+   "fieldname": "section_break_locations",
+   "fieldtype": "Section Break",
+   "label": "Transfer Details"
+  },
+  {
+   "fieldname": "from_location",
+   "fieldtype": "Link",
+   "label": "From Location",
+   "options": "Healthcare Service Unit"
+  },
+  {
+   "fieldname": "handed_over_by",
+   "fieldtype": "Link",
+   "label": "Handed Over By",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "column_break_locations",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "to_location",
+   "fieldtype": "Link",
+   "label": "To Location",
+   "options": "Healthcare Service Unit"
+  },
+  {
+   "fieldname": "received_by",
+   "fieldtype": "Link",
+   "label": "Received By",
+   "options": "Healthcare Practitioner"
+  },
+  {
+   "fieldname": "tab_checklist",
+   "fieldtype": "Tab Break",
+   "label": "Handover Checklist"
+  },
+  {
+   "default": "0",
+   "fieldname": "patient_identity_verified",
+   "fieldtype": "Check",
+   "label": "Patient Identity Verified"
+  },
+  {
+   "default": "0",
+   "fieldname": "consent_verified",
+   "fieldtype": "Check",
+   "label": "Consent Verified"
+  },
+  {
+   "default": "0",
+   "fieldname": "surgical_site_marked",
+   "fieldtype": "Check",
+   "label": "Surgical Site Marked"
+  },
+  {
+   "default": "0",
+   "fieldname": "allergies_documented",
+   "fieldtype": "Check",
+   "label": "Allergies Documented"
+  },
+  {
+   "default": "0",
+   "fieldname": "iv_lines_checked",
+   "fieldtype": "Check",
+   "label": "IV Lines Checked"
+  },
+  {
+   "fieldname": "column_break_checklist",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "vitals_stable",
+   "fieldtype": "Check",
+   "label": "Vitals Stable"
+  },
+  {
+   "default": "0",
+   "fieldname": "medications_documented",
+   "fieldtype": "Check",
+   "label": "Medications Documented"
+  },
+  {
+   "default": "0",
+   "fieldname": "blood_products_available",
+   "fieldtype": "Check",
+   "label": "Blood Products Available"
+  },
+  {
+   "default": "0",
+   "fieldname": "specimens_handed_over",
+   "fieldtype": "Check",
+   "label": "Specimens Handed Over"
+  },
+  {
+   "default": "0",
+   "fieldname": "drain_tubes_documented",
+   "fieldtype": "Check",
+   "label": "Drain Tubes Documented"
+  },
+  {
+   "fieldname": "tab_notes",
+   "fieldtype": "Tab Break",
+   "label": "Notes"
+  },
+  {
+   "fieldname": "clinical_notes",
+   "fieldtype": "Text",
+   "label": "Clinical Notes"
+  },
+  {
+   "fieldname": "section_break_ack",
+   "fieldtype": "Section Break",
+   "label": "Acknowledgement"
+  },
+  {
+   "default": "0",
+   "fieldname": "acknowledgement",
+   "fieldtype": "Check",
+   "label": "Acknowledged by Receiving Practitioner"
+  },
+  {
+   "fieldname": "acknowledged_time",
+   "fieldtype": "Datetime",
+   "label": "Acknowledged Time",
+   "read_only": 1
+  }
+ ],
+ "links": [],
+ "modified": "2026-04-09 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Surgical Handover",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nursing User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Physician",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/surgical_handover/surgical_handover.py
+++ b/hms_tz/hms_tz/doctype/surgical_handover/surgical_handover.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import now_datetime
+
+
+class SurgicalHandover(Document):
+    def before_insert(self):
+        self.validate_handover_parties()
+
+    def before_submit(self):
+        self.validate_acknowledgement()
+        self.validate_checklist_completeness()
+
+    def validate_handover_parties(self):
+        """Ensure handover and receiving practitioners are different."""
+        if self.handed_over_by and self.received_by:
+            if self.handed_over_by == self.received_by:
+                frappe.throw(
+                    _("Handed Over By and Received By cannot be the same practitioner.")
+                )
+
+    def validate_acknowledgement(self):
+        """Ensure the handover has been acknowledged before submission."""
+        if not self.acknowledgement:
+            frappe.throw(
+                _("The receiving practitioner must acknowledge the handover before it can be submitted.")
+            )
+        if not self.acknowledged_time:
+            self.acknowledged_time = now_datetime()
+
+    def validate_checklist_completeness(self):
+        """Warn if any checklist items are incomplete."""
+        checklist_fields = [
+            "patient_identity_verified",
+            "consent_verified",
+            "allergies_documented",
+            "vitals_stable",
+            "medications_documented",
+        ]
+
+        incomplete = []
+        for field in checklist_fields:
+            if not self.get(field):
+                incomplete.append(frappe.unscrub(field))
+
+        if incomplete:
+            frappe.msgprint(
+                _("The following checklist items are incomplete: {0}").format(
+                    ", ".join(incomplete)
+                ),
+                alert=True,
+                indicator="orange",
+            )

--- a/hms_tz/hms_tz/doctype/surgical_handover/test_surgical_handover.py
+++ b/hms_tz/hms_tz/doctype/surgical_handover/test_surgical_handover.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and Contributors
+# See license.txt
+
+import unittest
+
+
+class TestSurgicalHandover(unittest.TestCase):
+    pass


### PR DESCRIPTION
Add the Surgical Handover parent DocType to manage structured patient handover between surgical team and receiving ward/unit staff.

Schema (surgical_handover.json):
- Patient, Clinical Procedure, and Company links
- Handover parties: handing_over (surgeon/nurse) and receiving (ward nurse/practitioner) with Healthcare Practitioner links
- Handover timestamp and acknowledgement tracking
- Comprehensive checklist fields: patient_identified, procedure_confirmed, allergies_confirmed, vital_signs_stable, drains_documented, medications_reviewed, follow_up_plan_documented
- Key clinical fields: pain_level (0-10), consciousness_level, airway_status, wound_status
- Free-text fields: special_instructions and handover_notes
- Status workflow: Pending → Handed Over → Acknowledged

Controller (surgical_handover.py):
- before_save: validates handing_over ≠ receiving (same person cannot hand over to themselves)
- before_submit: ensures all 7 checklist items are completed before allowing submission
- Acknowledges handover on submit: auto-sets acknowledged_by and acknowledged_time from receiving practitioner

Client script (surgical_handover.js):
- Checklist progress indicator (e.g., "Checklist: 5/7") with green/orange color coding on dashboard
- "Acknowledge" action button that sets acknowledged_time
- Filters practitioner fields to active practitioners

Permissions: Nursing User, Physician (full CRUD)