### PR TITLE
fix(nursing): add patient guard clause and fix indentation in nurse_record.js

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
@@ -120,6 +120,7 @@ function set_queries(frm) {
 }
 
 function render_vital_signs(frm) {
+  if (!frm.doc.patient) return;
   frappe.call({
     method: "hms_tz.hms_tz.doctype.nurse_record.nurse_record.get_vital_signs",
     args: {


### PR DESCRIPTION
Add a null-check guard clause to render_vital_signs() to prevent unnecessary API calls when no patient is set on the form.

Also fix indentation alignment in string concatenation expressions across multiple functions to match prettier formatting standards:
- render_vital_signs: placeholder HTML alignment
- render_medication_progress: empty-state message alignment
- render_med_progress_chart: ternary operator alignment for badge class selection
- render_completed_medications: empty-state message alignment
- show_medication_alert_banner: patient link HTML construction
- render_consumables_placeholder: placeholder message alignment