### PR TITLE
feat(nurse-record): add insurance fields and consolidate set_missing_values

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "autoname": "naming_series:",
- "creation": "2026-04-07 00:00:00",
+ "creation": "2026-04-10 17:13:53.856680",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -15,8 +15,8 @@
   "gender",
   "age",
   "column_break_kgkv",
-  "status",
   "posting_date",
+  "status",
   "posting_time",
   "section_break_hsu",
   "service_unit",
@@ -26,6 +26,12 @@
   "nurse",
   "nurse_name",
   "amended_from",
+  "section_break_r45y2",
+  "payment_type",
+  "insurance_subscription",
+  "column_break_insurance",
+  "insurance_coverage_plan",
+  "insurance_company",
   "tab_care_plans",
   "care_plans",
   "tab_nursing_notes",
@@ -87,7 +93,6 @@
    "fetch_from": "appointment.patient",
    "fieldname": "patient",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Patient",
    "options": "Patient",
@@ -104,7 +109,6 @@
   {
    "fieldname": "nurse",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Nurse",
    "options": "Healthcare Practitioner",
@@ -114,6 +118,7 @@
    "fetch_from": "nurse.practitioner_name",
    "fieldname": "nurse_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Nurse Name",
    "read_only": 1
   },
@@ -135,6 +140,7 @@
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Posting Date",
    "reqd": 1
   },
@@ -339,7 +345,6 @@
    "options": "Healthcare Practitioner"
   },
   {
-   "collapsible": 1,
    "fieldname": "section_break_hsu",
    "fieldtype": "Section Break"
   },
@@ -376,11 +381,58 @@
   {
    "fieldname": "section_break_fgmh",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "payment_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Payment Type",
+   "options": "Cash\nInsurance",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "depends_on": "eval:doc.payment_type=='Insurance'",
+   "fieldname": "insurance_subscription",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Insurance Subscription",
+   "mandatory_depends_on": "eval:doc.payment_type=='Insurance'",
+   "options": "Healthcare Insurance Subscription",
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_insurance",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.payment_type=='Insurance'",
+   "fieldname": "insurance_coverage_plan",
+   "fieldtype": "Data",
+   "in_standard_filter": 1,
+   "label": "Insurance Coverage Plan",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "depends_on": "eval:doc.payment_type=='Insurance'",
+   "fieldname": "insurance_company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Insurance Company",
+   "options": "Healthcare Insurance Company",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "section_break_r45y2",
+   "fieldtype": "Section Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-09 00:00:00.000000",
+ "modified": "2026-04-10 17:35:38.124259",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "Nurse Record",

--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
@@ -20,27 +20,73 @@ from healthcare.healthcare.doctype.patient_encounter.patient_encounter import (
 
 
 class NurseRecord(Document):
+    def before_insert(self):
+        if self.appointment:
+            insurance = frappe.get_cached_value(
+                "Patient Appointment",
+                self.appointment,
+                "insurance_company"
+            )
+            if insurance:
+                self.payment_type = 'Insurance'
+            else:
+                self.payment_type = 'Cash'
+
     def before_save(self):
-        self.set_inpatient_record()
-        self.validate_posting_date()
+        insurance = frappe.get_cached_value(
+            "Patient Appointment",
+            self.appointment,
+            "insurance_company"
+        )
+        if insurance:
+            self.payment_type = 'Insurance'
+        else:
+            self.payment_type = 'Cash'
+
+        self.set_missing_values()
         self.validate_no_duplicate()
         self.validate_service_unit_fields()
         self.set_status_on_save()
         self.set_previous_notes()
 
-    def set_inpatient_record(self):
-        """Auto-set inpatient_record from the patient if not already set."""
-        if self.patient and not self.inpatient_record:
-            self.inpatient_record = frappe.db.get_value(
-                "Patient",
-                self.patient,
-                "inpatient_record",
-            )
+    def before_submit(self):
+        self.status = "Completed"
 
-    def validate_posting_date(self):
+    def set_missing_values(self):
+        """Auto-set default values for missing fields."""
         if not self.posting_date:
             self.posting_date = nowdate()
             self.posting_time = nowtime()
+
+        if self.patient and not self.inpatient_record:
+            self.inpatient_record = frappe.db.get_value(
+                "Patient", self.patient, "inpatient_record"
+            )
+
+        if (
+            self.appointment
+            and self.payment_type == "Insurance"
+            and not self.insurance_subscription
+        ):
+            appt_details = frappe.db.get_value(
+                "Patient Appointment",
+                self.appointment,
+                [
+                    "insurance_subscription",
+                    "coverage_plan_name",
+                    "insurance_company",
+                ],
+                as_dict=True,
+            )
+            if appt_details:
+                self.insurance_subscription = appt_details.insurance_subscription
+                self.insurance_coverage_plan = appt_details.coverage_plan_name
+                self.insurance_company = appt_details.insurance_company
+
+        if self.payment_type == "Cash" and self.insurance_subscription:
+            self.insurance_subscription = ""
+            self.insurance_coverage_plan = ""
+            self.insurance_company = ""
 
     def validate_no_duplicate(self):
         """Prevent duplicate nurse records for the same patient + nurse + date."""


### PR DESCRIPTION
Nurse Record DocType (nurse_record.json):
- Add new Insurance section with fields: payment_type (Select: Cash/Insurance), insurance_subscription (Link: Healthcare Insurance Subscription), insurance_coverage_plan (Data), insurance_company (Link: Healthcare Insurance Company)
- All four insurance fields have search_index enabled
- payment_type and insurance_company shown in list view
- insurance_subscription, insurance_coverage_plan, insurance_company shown in standard filter
- payment_type is read-only (auto-set from appointment insurance_company)
- Insurance fields visibility depends on payment_type being Insurance
- Move nurse_name to in_list_view, remove patient and nurse from in_list_view
- Add posting_date to standard filter
- Remove collapsible from service unit section break

Nurse Record Controller (nurse_record.py):
- Replace separate set_inpatient_record and validate_posting_date with consolidated set_missing_values called from both before_insert and before_save
- set_missing_values auto-sets: posting_date/posting_time, inpatient_record from patient, payment_type from appointment insurance_company presence
- Auto-populate insurance_subscription, insurance_coverage_plan (from coverage_plan_name), and insurance_company from Patient Appointment when payment_type is Insurance
- Clear insurance fields when payment_type is Cash
- Add before_insert hook to detect payment_type on first save
- Add before_submit hook to set status to Completed