### PR TITLE
feat(consumable-record): implement submission lifecycle with deposit validation and DN creation

### DIFF
--- a/hms_tz/hms_tz/doctype/consumable_item/consumable_item.json
+++ b/hms_tz/hms_tz/doctype/consumable_item/consumable_item.json
@@ -6,6 +6,7 @@
  "field_order": [
   "item_code",
   "item_name",
+  "is_stock_item",
   "qty_requested",
   "column_break_qty",
   "qty_dispensed",
@@ -20,6 +21,10 @@
   "amount",
   "percent_covered",
   "column_break_billing2",
+  "payment_type",
+  "insurance_subscription",
+  "insurance_company",
+  "insurance_coverage_plan",
   "insurance_item_code",
   "is_billable",
   "invoiced",
@@ -40,6 +45,13 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Item Name",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_stock_item",
+   "fieldtype": "Check",
+   "label": "Is Stock Item",
    "read_only": 1
   },
   {
@@ -123,6 +135,34 @@
   {
    "fieldname": "column_break_billing2",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "payment_type",
+   "fieldtype": "Select",
+   "label": "Payment Type",
+   "options": "\nCash\nInsurance"
+  },
+  {
+   "fieldname": "insurance_subscription",
+   "fieldtype": "Link",
+   "label": "Insurance Subscription",
+   "options": "Healthcare Insurance Subscription",
+   "depends_on": "eval:doc.payment_type=='Insurance'"
+  },
+  {
+   "fieldname": "insurance_company",
+   "fieldtype": "Link",
+   "label": "Insurance Company",
+   "options": "Healthcare Insurance Company",
+   "depends_on": "eval:doc.payment_type=='Insurance'",
+   "read_only": 1
+  },
+  {
+   "fieldname": "insurance_coverage_plan",
+   "fieldtype": "Data",
+   "label": "Insurance Coverage Plan",
+   "depends_on": "eval:doc.payment_type=='Insurance'",
+   "read_only": 1
   },
   {
    "fieldname": "insurance_item_code",

--- a/hms_tz/hms_tz/doctype/consumable_record/consumable_api.py
+++ b/hms_tz/hms_tz/doctype/consumable_record/consumable_api.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+"""
+Global Consumable API — reusable backend methods for the consumable dialog.
+Can be called from any DocType's client script (Nurse Record, Clinical Procedure, etc.)
+"""
+
+import json
+
+import frappe
+from erpnext.accounts.utils import get_balance_on
+from frappe import _
+from frappe.utils import flt, nowdate, nowtime
+
+from hms_tz.nhif.api.healthcare_utils import (
+    get_discount_percent,
+    get_item_rate,
+    get_mop_amount,
+)
+
+
+@frappe.whitelist()
+def get_consumable_item_details(
+    item_code,
+    company,
+    payment_type,
+    insurance_subscription=None,
+    insurance_company=None,
+    patient=None,
+    mode_of_payment=None,
+):
+    """
+    Get item details including rate based on payment type.
+
+    For Insurance: uses get_item_rate from healthcare_utils
+    For Cash: uses get_mop_amount from healthcare_utils
+
+    Returns: dict with rate, is_stock_item, item_name, uom, price_list
+    """
+    if not item_code or not company:
+        frappe.throw(_("Item Code and Company are required"))
+
+    item_doc = frappe.get_cached_value(
+        "Item",
+        item_code,
+        ["item_name", "stock_uom", "is_stock_item"],
+        as_dict=True,
+    )
+    if not item_doc:
+        frappe.throw(_("Item {0} not found").format(item_code))
+
+    result = {
+        "item_name": item_doc.item_name,
+        "uom": item_doc.stock_uom,
+        "is_stock_item": item_doc.is_stock_item,
+        "rate": 0,
+        "price_list": "",
+    }
+
+    if payment_type == "Insurance" and insurance_subscription:
+        try:
+            # Apply discount for non-NHIF insurance
+            discount_percent = 0
+            if insurance_company and "NHIF" not in insurance_company:
+                discount_percent = get_discount_percent(insurance_company)
+
+            item_price_rate, price_list = get_item_rate(
+                item_code,
+                company,
+                insurance_subscription,
+                insurance_company,
+                for_service_request=True,
+            )
+
+            rate = item_price_rate - (item_price_rate * (discount_percent / 100))
+            result["rate"] = rate
+            result["price_list"] = price_list
+
+        except Exception as e:
+            frappe.log_error(
+                title="Consumable: get_item_rate error",
+                message=str(e),
+            )
+            result["rate"] = 0
+            result["error"] = str(e)
+
+    elif payment_type == "Cash":
+        try:
+            rate = get_mop_amount(
+                item_code,
+                mop=mode_of_payment,
+                company=company,
+                patient=patient,
+            )
+            result["rate"] = rate or 0
+
+        except Exception as e:
+            frappe.log_error(
+                title="Consumable: get_mop_amount error",
+                message=str(e),
+            )
+            result["rate"] = 0
+            result["error"] = str(e)
+
+    return result
+
+
+@frappe.whitelist()
+def get_nhif_coverage_percent(
+    appointment,
+    company,
+    item_code,
+    insurance_coverage_plan,
+    insurance_company,
+    payment_type
+):
+    """
+    Get NHIF Co-Payment percent covered for the given item.
+
+    Returns percent_covered (default 100 if not found or non-NHIF).
+    """
+    if not item_code:
+        frappe.throw(_(f"Item Code is required"))
+
+    if payment_type != "Insurance":
+        return 100
+
+    if not insurance_company or "NHIF" not in insurance_company:
+        return 100
+
+    if not insurance_coverage_plan:
+        frappe.throw(_(f"Insurance Coverage Plan is required"))
+
+    scheme_id = frappe.get_cached_value(
+        "Healthcare Insurance Coverage Plan",
+        insurance_coverage_plan,
+        "nhif_scheme_id",
+    )
+    if not scheme_id:
+        frappe.throw(_(f"Scheme ID not found for {insurance_coverage_plan}"))
+
+    ref_code = ""
+    code_list = frappe.db.get_all(
+        "Item Customer Detail",
+        filters={"parent": item_code, "customer_name": "NHIF"},
+        fields=["ref_code"],
+    )
+    if len(code_list) > 0:
+        ref_code = code_list[0].ref_code
+
+    if not ref_code:
+        frappe.throw(_(f"Item: {item_code} does not have an NHIF Reference Code"))
+
+    is_covered = frappe.db.exists(
+        "NHIF Price Package",
+        {
+            "company": company,
+            "itemcode": ref_code,
+            "schemeid": scheme_id,
+        }
+    )
+
+    if not is_covered:
+        frappe.throw(_(f"Item: {item_code} is not covered by NHIF"))
+
+    years_of_insurance = frappe.get_cached_value(
+        "Patient Appointment",
+        appointment,
+        "years_of_insurance",
+    )
+
+    percent_details = frappe.get_cached_value(
+        "NHIF Co-Payment Item",
+        {
+            "itemcode": ref_code,
+            "schemeid": scheme_id,
+            "yearno": years_of_insurance,
+        },
+        ["percentcovered", "name"],
+        as_dict=True,
+    )
+
+    if not percent_details:
+        return 100
+
+    return percent_details.percentcovered or 0
+
+
+@frappe.whitelist()
+def validate_patient_deposit(patient, company, appointment, inpatient_record, total_amount):
+    """
+    Validate patient deposit including all costs (encounter, IPD, consumables).
+
+    Called from the consumable dialog before creating the record.
+    Returns dict with has_sufficient_balance, current_balance, required_amount.
+    """
+    total_amount = flt(total_amount)
+
+    if not inpatient_record:
+        inpatient_record = frappe.db.get_value("Patient", patient, "inpatient_record")
+
+    customer = frappe.get_cached_value("Patient", patient, "customer")
+    if not customer:
+        return {
+            "has_sufficient_balance": False,
+            "current_balance": 0,
+            "required_amount": total_amount,
+            "error": _(f"Patient {patient} does not have a linked Customer"),
+        }
+
+    patient_name = frappe.get_cached_value("Patient", patient, "patient_name")
+
+    if inpatient_record:
+        # Use the consolidated function which includes encounter + IPD + consumable costs
+        from hms_tz.nhif.api.patient_encounter import validate_patient_balance_vs_patient_costs
+
+        validate_patient_balance_vs_patient_costs(
+            patient=patient,
+            patient_name=patient_name,
+            appointment=appointment or "",
+            inpatient_record=inpatient_record,
+            company=company,
+            caller="Consumable Dialog",
+        )
+
+    # Return deposit balance for the dialog UI
+    deposit_balance = get_balance_on(
+        party_type="Customer", party=customer, company=company
+    )
+    available_balance = -1 * deposit_balance
+
+    return {
+        "has_sufficient_balance": available_balance >= total_amount,
+        "current_balance": available_balance,
+        "required_amount": total_amount - available_balance if available_balance < total_amount else 0,
+    }
+
+
+@frappe.whitelist()
+def create_consumable_record(args):
+    """
+    Create, save, and submit a Consumable Record from the dialog.
+
+    Args:
+        args: JSON string with:
+            - patient, company, appointment, encounter
+            - payment_type, mode_of_payment
+            - insurance_subscription, insurance_company, insurance_coverage_plan
+            - prescribed_by
+            - source_doctype, source_docname
+            - items: list of dicts with item_code, qty_requested, warehouse, rate,
+              payment_type, percent_covered, is_billable, insurance_subscription,
+              insurance_company, insurance_coverage_plan
+
+    Returns: dict with name, delivery_note, has_pending_payment, message
+    """
+    if isinstance(args, str):
+        args = json.loads(args)
+
+    args = frappe._dict(args)
+
+    doc = frappe.new_doc("Consumable Record")
+    doc.patient = args.patient
+    doc.company = args.company
+    doc.appointment = args.get("appointment")
+    doc.encounter = args.get("encounter")
+    doc.posting_date = nowdate()
+    doc.posting_time = nowtime()
+    doc.payment_type = args.payment_type
+    doc.mode_of_payment = args.get("mode_of_payment")
+    doc.prescribed_by = args.get("prescribed_by")
+    doc.source_doctype = args.get("source_doctype")
+    doc.source_docname = args.get("source_docname")
+    doc.insurance_subscription = args.get("insurance_subscription")
+    doc.insurance_company = args.get("insurance_company")
+    doc.insurance_coverage_plan = args.get("insurance_coverage_plan")
+
+    for item_data in args.get("items", []):
+        item_data = frappe._dict(item_data)
+        row = doc.append("items", {})
+        row.item_code = item_data.item_code
+        row.qty_requested = flt(item_data.qty_requested) or 1
+        row.warehouse = item_data.warehouse
+        row.rate = flt(item_data.rate)
+        row.price_list = item_data.get("price_list")
+        row.payment_type = item_data.get("payment_type") or args.payment_type
+        row.percent_covered = flt(item_data.get("percent_covered")) or 100
+        row.is_billable = 1 if item_data.get("is_billable") in [1, True, "1"] else 0
+        row.insurance_subscription = item_data.get("insurance_subscription") or args.get("insurance_subscription")
+        row.insurance_company = item_data.get("insurance_company") or args.get("insurance_company")
+        row.insurance_coverage_plan = item_data.get("insurance_coverage_plan") or args.get("insurance_coverage_plan")
+        row.uom = item_data.get("uom")
+
+    doc.insert(ignore_permissions=True)
+    doc.reload()
+
+    result = {
+        "name": doc.name,
+        "delivery_note": "",
+        "has_pending_payment": 0,
+        "message": _("Consumable Record {0} created successfully.").format(doc.name),
+    }
+
+    # Try to submit
+    try:
+        doc.submit()
+        doc.reload()
+        result["delivery_note"] = doc.delivery_note or ""
+        result["has_pending_payment"] = doc.has_pending_payment
+        if doc.has_pending_payment:
+            result["message"] = _(
+                "Consumable Record {0} created. Some items require cash payment before dispensing."
+            ).format(doc.name)
+        elif doc.delivery_note:
+            result["message"] = _(
+                "Consumable Record {0} created. Delivery Note {1} created (Draft)."
+            ).format(doc.name, doc.delivery_note)
+    except frappe.ValidationError as e:
+        # Submission blocked (e.g., insufficient deposit)
+        result["message"] = str(e)
+        result["has_pending_payment"] = 1
+
+    return result
+
+
+@frappe.whitelist()
+def submit_consumable_record(consumable_record: str):
+    """Submit a Consumable Record by loading a fresh copy from DB.
+    This avoids 'Document Modified' errors when the doc was modified
+    after the calling page was loaded.
+    """
+    doc = frappe.get_doc("Consumable Record", consumable_record)
+    doc.submit()
+
+    return {
+        "name": doc.name,
+        "status": doc.status,
+        "delivery_note": doc.delivery_note or "",
+    }

--- a/hms_tz/hms_tz/doctype/consumable_record/consumable_dialog.js
+++ b/hms_tz/hms_tz/doctype/consumable_record/consumable_dialog.js
@@ -1,0 +1,688 @@
+/**
+ * Global Consumable Dialog — reusable from any DocType (Nurse Record, Clinical Procedure, etc.)
+ *
+ * Usage:
+ *   hms_tz.open_consumable_dialog({
+ *     patient: frm.doc.patient,
+ *     company: frm.doc.company,
+ *     appointment: frm.doc.appointment,
+ *     payment_type: frm.doc.payment_type,
+ *     insurance_subscription: frm.doc.insurance_subscription,
+ *     insurance_company: frm.doc.insurance_company,
+ *     insurance_coverage_plan: frm.doc.insurance_coverage_plan,
+ *     prescribed_by: frm.doc.practitioner || frm.doc.nurse,
+ *     source_doctype: frm.doc.doctype,
+ *     source_docname: frm.doc.name,
+ *     mode_of_payment: frm.doc.mode_of_payment,
+ *     on_success: () => frm.reload_doc(),
+ *   });
+ */
+
+if (!window.hms_tz) {
+  window.hms_tz = {};
+}
+
+hms_tz.open_consumable_dialog = function (opts) {
+  opts = Object.assign({}, opts || {});
+
+  if (!opts.patient) {
+    frappe.msgprint(__("Please select a Patient first."));
+    return;
+  }
+  if (!opts.company) {
+    frappe.msgprint(__("Company is required."));
+    return;
+  }
+
+  const is_insurance = opts.payment_type === "Insurance";
+
+  const dialog = new frappe.ui.Dialog({
+    title: __("Add Consumable Items"),
+    size: "extra-large",
+    fields: [
+      {
+        fieldtype: "Section Break",
+        label: __("Patient Details"),
+      },
+      {
+        fieldname: "patient",
+        fieldtype: "Link",
+        label: __("Patient"),
+        options: "Patient",
+        default: opts.patient,
+        read_only: 1,
+      },
+      {
+        fieldname: "patient_name",
+        fieldtype: "Data",
+        label: __("Patient Name"),
+        default: opts.patient_name || "",
+        read_only: 1,
+      },
+      {
+        fieldtype: "Column Break",
+      },
+      {
+        fieldname: "company",
+        fieldtype: "Link",
+        label: __("Company"),
+        options: "Company",
+        default: opts.company,
+        read_only: 1,
+      },
+      {
+        fieldname: "payment_type",
+        fieldtype: "Select",
+        label: __("Payment Type"),
+        options: "\nCash\nInsurance",
+        default: opts.payment_type || "",
+        read_only: 1,
+      },
+      {
+        fieldname: "total_amount",
+        fieldtype: "Currency",
+        label: __("Total Amount"),
+        read_only: 1,
+        default: 0,
+      },
+      {
+        fieldtype: "Column Break",
+      },
+      {
+        fieldname: "insurance_subscription",
+        fieldtype: "Link",
+        label: __("Insurance Subscription"),
+        options: "Healthcare Insurance Subscription",
+        default: opts.insurance_subscription || "",
+        read_only: 1,
+        hidden: 1,
+        depends_on: "eval:doc.payment_type=='Insurance'",
+      },
+      {
+        fieldname: "insurance_coverage_plan",
+        fieldtype: "Data",
+        label: __("Coverage Plan"),
+        default: opts.insurance_coverage_plan || "",
+        read_only: 1,
+        depends_on: "eval:doc.payment_type=='Insurance'",
+      },
+      {
+        fieldname: "insurance_company",
+        fieldtype: "Link",
+        label: __("Insurance Company"),
+        options: "Healthcare Insurance Company",
+        default: opts.insurance_company || "",
+        read_only: 1,
+        depends_on: "eval:doc.payment_type=='Insurance'",
+      },
+      {
+        fieldname: "mode_of_payment",
+        fieldtype: "Link",
+        label: __("Mode of Payment"),
+        options: "Mode of Payment",
+        default: opts.mode_of_payment || "",
+        depends_on: "eval:doc.payment_type=='Cash'",
+      },
+      {
+        fieldname: "default_warehouse",
+        fieldtype: "Link",
+        label: __("Default Warehouse"),
+        options: "Warehouse",
+        get_query: () => ({
+          filters: {
+            company: opts.company,
+            is_group: 0,
+            warehouse_name: ["like", "%Pharmacy%"],
+          },
+        }),
+      },
+      {
+        fieldtype: "Section Break",
+      },
+      {
+        fieldname: "source_doctype",
+        fieldtype: "Select",
+        label: __("Source Doctype"),
+        options:
+          "\nLab Test\nRadiology Examination\nClinical Procedure\nTherapy Session",
+        default: opts.source_doctype || "",
+      },
+      {
+        fieldtype: "Column Break",
+      },
+      {
+        fieldname: "source_docname",
+        fieldtype: "Dynamic Link",
+        label: __("Source Document"),
+        options: "source_doctype",
+        default: opts.source_docname || "",
+        get_query: () => {
+          return {
+            filters: {
+              patient: opts.patient,
+              appointment: opts.appointment,
+            },
+          };
+        },
+      },
+      {
+        fieldtype: "Column Break",
+      },
+      {
+        fieldname: "service_name",
+        fieldtype: "Data",
+        label: __("Service Name"),
+        // read_only: 1,
+      },
+      {
+        fieldtype: "Section Break",
+        label: __("Consumable Items"),
+      },
+      {
+        fieldname: "items",
+        fieldtype: "Table",
+        label: __("Items"),
+        cannot_add_rows: false,
+        in_place_edit: true,
+        data: [],
+        fields: _get_item_table_fields(is_insurance),
+      },
+    ],
+
+    primary_action_label: __("Create"),
+    primary_action: (values) => {
+      _handle_create(dialog, values, opts);
+    },
+  });
+
+  // ─── Bind events ───
+  _bind_item_events(dialog, opts);
+
+  // Fetch patient name if not provided
+  if (opts.patient && !opts.patient_name) {
+    frappe.db.get_value("Patient", opts.patient, "patient_name", (r) => {
+      if (r && r.patient_name) {
+        dialog.set_value("patient_name", r.patient_name);
+      }
+    });
+  }
+
+  dialog.show();
+  return dialog;
+};
+
+function _get_item_table_fields(is_insurance) {
+  const fields = [
+    {
+      fieldname: "item_code",
+      fieldtype: "Link",
+      label: __("Item Code"),
+      options: "Item",
+      in_list_view: 1,
+      reqd: 1,
+      columns: 3,
+      get_query: () => ({
+        filters: { is_stock_item: 1, disabled: 0 },
+      }),
+    },
+    {
+      fieldname: "warehouse",
+      fieldtype: "Link",
+      label: __("Warehouse"),
+      options: "Warehouse",
+      in_list_view: 1,
+      reqd: 1,
+      columns: 2,
+    },
+    {
+      fieldname: "uom",
+      fieldtype: "Link",
+      label: __("UOM"),
+      options: "UOM",
+      read_only: 1,
+    },
+    {
+      fieldname: "qty_requested",
+      fieldtype: "Float",
+      label: __("Qty"),
+      in_list_view: 1,
+      default: 1,
+      columns: 1,
+    },
+    {
+      fieldname: "rate",
+      fieldtype: "Currency",
+      label: __("Rate"),
+      in_list_view: 1,
+      read_only: 1,
+      columns: 1,
+    },
+    {
+      fieldname: "amount",
+      fieldtype: "Currency",
+      label: __("Amount"),
+      in_list_view: 1,
+      read_only: 1,
+      columns: 1,
+    },
+    {
+      fieldname: "percent_covered",
+      fieldtype: "Percent",
+      label: __("% Covered"),
+      in_list_view: 1,
+      default: 100,
+      read_only: !is_insurance,
+      columns: 1,
+    },
+    {
+      fieldname: "payment_type",
+      fieldtype: "Select",
+      label: __("Payment Type"),
+      options: "\nCash\nInsurance",
+      in_list_view: 1,
+      columns: 1,
+    },
+    {
+      fieldname: "is_billable",
+      fieldtype: "Check",
+      label: __("Billable"),
+      default: 1,
+    },
+    {
+      fieldname: "item_name",
+      fieldtype: "Data",
+      label: __("Item Name"),
+      read_only: 1,
+      hidden: 1,
+    },
+    {
+      fieldname: "is_stock_item",
+      fieldtype: "Check",
+      label: __("Stock Item"),
+      read_only: 1,
+      hidden: 1,
+    },
+    {
+      fieldname: "price_list",
+      fieldtype: "Data",
+      label: __("Price List"),
+      hidden: 1,
+    },
+    {
+      fieldname: "insurance_subscription",
+      fieldtype: "Data",
+      label: __("Ins. Subscription"),
+      hidden: 1,
+    },
+    {
+      fieldname: "insurance_company",
+      fieldtype: "Data",
+      label: __("Ins. Company"),
+      hidden: 1,
+    },
+    {
+      fieldname: "insurance_coverage_plan",
+      fieldtype: "Data",
+      label: __("Coverage Plan"),
+      hidden: 1,
+    },
+  ];
+  return fields;
+}
+
+function _get_grid_row(grid, cdn) {
+  // Reliable way to get dialog table GridRow object
+  return grid.grid_rows.find((r) => r.doc.name === cdn) || null;
+}
+
+function _get_row_doc(grid, cdn) {
+  const gr = _get_grid_row(grid, cdn);
+  return gr ? gr.doc : null;
+}
+
+function _refresh_row(grid, cdn) {
+  // grid.refresh() doesn't re-render cell values in dialog tables.
+  // Individual GridRow.refresh() is required to update the visual display.
+  const gr = _get_grid_row(grid, cdn);
+  if (gr) gr.refresh();
+}
+
+function _bind_item_events(dialog, opts) {
+  const is_insurance = opts.payment_type === "Insurance";
+  const grid = dialog.fields_dict.items.grid;
+
+  // Track previous item_code per row to detect changes
+  const _prev_item_codes = {};
+
+  // Set defaults when a new row is added.
+  // Frappe's dialog grid calls on_add_row(row_idx) BEFORE grid.refresh(),
+  // so we must set defaults on grid.df.data directly (not on grid_row.doc).
+  dialog.fields_dict.items.df.on_add_row = function (row_idx) {
+    const data_row = grid.df.data[row_idx - 1];
+    if (!data_row) return;
+
+    // Set payment_type based on parent
+    data_row.payment_type = is_insurance ? "Insurance" : "Cash";
+
+    // Set default warehouse from the top-level field
+    const default_wh = dialog.get_value("default_warehouse");
+    if (default_wh) {
+      data_row.warehouse = default_wh;
+    }
+
+    // Set percent_covered default
+    data_row.percent_covered = 100;
+
+    // Set insurance fields for insurance patients
+    if (is_insurance) {
+      data_row.insurance_subscription = opts.insurance_subscription || "";
+      data_row.insurance_company = opts.insurance_company || "";
+      data_row.insurance_coverage_plan = opts.insurance_coverage_plan || "";
+    }
+
+    // No refresh needed — Frappe calls grid.refresh() after on_add_row
+  };
+
+  // Listen for field changes in the child table via the grid wrapper.
+  // Frappe's dialog grid does NOT call df.on_change for individual field changes,
+  // so we use the 'change' DOM event on the grid wrapper instead.
+  $(grid.wrapper).on("change", "input, select", function () {
+    // Debounce to let Frappe finish writing the value
+    setTimeout(() => {
+      _handle_grid_change(dialog, grid, opts, _prev_item_codes);
+    }, 100);
+  });
+}
+
+function _handle_grid_change(dialog, grid, opts, _prev_item_codes) {
+  // Iterate through all rows and check for item_code changes
+  grid.grid_rows.forEach((grid_row) => {
+    const row = grid_row.doc;
+    const cdn = row.name;
+
+    // Detect item_code change by comparing with tracked previous value
+    const prev_item = _prev_item_codes[cdn] || "";
+    if (row.item_code && row.item_code !== prev_item) {
+      _prev_item_codes[cdn] = row.item_code;
+      _fetch_item_details(dialog, grid, row, cdn, opts);
+      return;
+    }
+
+    // Qty or rate changed — recalculate
+    const qty = flt(row.qty_requested) || 1;
+    const rate = flt(row.rate);
+    const new_amount = qty * rate;
+    if (row.amount !== new_amount) {
+      row.amount = new_amount;
+      grid_row.refresh();
+      _recalculate_total(dialog);
+    }
+
+    // Payment type changed to Cash — set percent_covered
+    if (row.payment_type === "Cash" && row.percent_covered !== 100) {
+      row.percent_covered = 100;
+      grid_row.refresh();
+    }
+  });
+}
+
+function _fetch_item_details(dialog, grid, row, cdn, opts) {
+  const payment_type =
+    row.payment_type || dialog.get_value("payment_type") || "";
+
+  frappe.call({
+    method:
+      "hms_tz.hms_tz.doctype.consumable_record.consumable_api.get_consumable_item_details",
+    args: {
+      item_code: row.item_code,
+      company: dialog.get_value("company"),
+      payment_type: payment_type,
+      insurance_subscription: dialog.get_value("insurance_subscription") || "",
+      insurance_company: dialog.get_value("insurance_company") || "",
+      patient: dialog.get_value("patient"),
+      mode_of_payment: dialog.get_value("mode_of_payment") || "",
+    },
+    async: true,
+    callback: (r) => {
+      if (r.message) {
+        const d = r.message;
+        const current_row = _get_row_doc(grid, cdn);
+        if (!current_row) return;
+
+        current_row.item_name = d.item_name || "";
+        current_row.uom = d.uom || "";
+        current_row.is_stock_item = d.is_stock_item || 0;
+        current_row.rate = flt(d.rate);
+        current_row.price_list = d.price_list || "";
+
+        // Set default warehouse if not already set on the row
+        if (!current_row.warehouse) {
+          const default_wh = dialog.get_value("default_warehouse");
+          if (default_wh) {
+            current_row.warehouse = default_wh;
+          }
+        }
+
+        // Calculate amount
+        const qty = flt(current_row.qty_requested) || 1;
+        current_row.amount = qty * flt(current_row.rate);
+
+        _refresh_row(grid, cdn);
+        _recalculate_total(dialog);
+
+        // For NHIF insurance — fetch coverage percent
+        if (
+          payment_type === "Insurance" &&
+          opts.insurance_coverage_plan &&
+          opts.insurance_company &&
+          opts.insurance_company.includes("NHIF")
+        ) {
+          _fetch_coverage_percent(dialog, grid, current_row, cdn, opts);
+        }
+
+        if (d.error) {
+          frappe.msgprint({
+            title: __("Rate Lookup Warning"),
+            message: d.error,
+            indicator: "orange",
+          });
+        }
+      }
+    },
+  });
+}
+
+function _fetch_coverage_percent(dialog, grid, row, cdn, opts) {
+  frappe.call({
+    method:
+      "hms_tz.hms_tz.doctype.consumable_record.consumable_api.get_nhif_coverage_percent",
+    args: {
+      appointment: opts.appointment,
+      company: opts.company,
+      item_code: row.item_code,
+      insurance_coverage_plan: opts.insurance_coverage_plan,
+      insurance_company: opts.insurance_company,
+      payment_type: row.payment_type,
+    },
+    async: true,
+    callback: (r) => {
+      if (r.message !== undefined) {
+        const percent = flt(r.message);
+        const current_row = _get_row_doc(grid, cdn);
+        if (!current_row) return;
+
+        current_row.percent_covered = percent;
+
+        if (percent < 100 && percent > 0) {
+          const remaining = 100 - percent;
+          frappe.show_alert(
+            {
+              message: __(
+                "Item <b>{0}</b> is covered at <b>{1}%</b>. " +
+                  "Add another row for the remaining <b>{2}%</b> and set payment type to Cash.",
+                [row.item_code, percent, remaining]
+              ),
+              indicator: "orange",
+            },
+            10
+          );
+        } else if (percent === 0) {
+          current_row.payment_type = "Cash";
+          frappe.show_alert(
+            {
+              message: __(
+                "Item <b>{0}</b> is not covered by insurance. Payment type changed to Cash.",
+                [row.item_code]
+              ),
+              indicator: "red",
+            },
+            7
+          );
+        }
+
+        _refresh_row(grid, cdn);
+      }
+    },
+  });
+}
+
+function _recalculate_total(dialog) {
+  const items = dialog.fields_dict.items.grid.grid_rows.map((r) => r.doc);
+  let total = 0;
+  items.forEach((item) => {
+    total += flt(item.amount);
+  });
+  dialog.set_value("total_amount", total);
+}
+
+function _handle_create(dialog, values, opts) {
+  const items = dialog.fields_dict.items.grid.grid_rows.map((r) => r.doc);
+
+  if (!items || items.length === 0) {
+    frappe.msgprint(__("Please add at least one item."));
+    return;
+  }
+
+  // Validate each row
+  for (const item of items) {
+    if (!item.item_code) {
+      frappe.msgprint(__("Row {0}: Item Code is required.", [item.idx]));
+      return;
+    }
+    if (!item.warehouse) {
+      frappe.msgprint(__("Row {0}: Warehouse is required.", [item.idx]));
+      return;
+    }
+    if (flt(item.qty_requested) <= 0) {
+      frappe.msgprint(__("Row {0}: Qty must be greater than 0.", [item.idx]));
+      return;
+    }
+  }
+
+  // For cash patients — validate deposit first
+  const payment_type = dialog.get_value("payment_type");
+  if (payment_type === "Cash") {
+    let cash_total = 0;
+    items.forEach((item) => {
+      if (item.payment_type === "Cash" || !item.payment_type) {
+        cash_total += flt(item.amount);
+      }
+    });
+
+    if (cash_total > 0) {
+      frappe.call({
+        method:
+          "hms_tz.hms_tz.doctype.consumable_record.consumable_api.validate_patient_deposit",
+        args: {
+          patient: dialog.get_value("patient"),
+          company: dialog.get_value("company"),
+          appointment: opts.appointment || "",
+          inpatient_record: opts.inpatient_record || "",
+          total_amount: cash_total,
+        },
+        async: false,
+        callback: (r) => {
+          if (r.message && !r.message.has_sufficient_balance) {
+            frappe.msgprint({
+              title: __("Insufficient Deposit"),
+              message: __(
+                "Patient does not have sufficient deposit.<br>" +
+                  "Required: <b>{0}</b><br>Available: <b>{1}</b><br>" +
+                  "Please request the patient to deposit <b>{2}</b> more.",
+                [
+                  format_currency(cash_total),
+                  format_currency(r.message.current_balance),
+                  format_currency(r.message.required_amount),
+                ]
+              ),
+              indicator: "red",
+            });
+            return;
+          }
+        },
+      });
+    }
+  }
+
+  // Build items payload
+  const cleaned_items = items.map((item) => ({
+    item_code: item.item_code,
+    item_name: item.item_name,
+    qty_requested: flt(item.qty_requested),
+    warehouse: item.warehouse,
+    rate: flt(item.rate),
+    uom: item.uom,
+    price_list: item.price_list,
+    payment_type: item.payment_type || payment_type,
+    percent_covered: flt(item.percent_covered) || 100,
+    is_billable: item.is_billable ? 1 : 0,
+    insurance_subscription: item.insurance_subscription || "",
+    insurance_company: item.insurance_company || "",
+    insurance_coverage_plan: item.insurance_coverage_plan || "",
+  }));
+
+  frappe.dom.freeze(__("Creating Consumable Record..."));
+
+  frappe.call({
+    method:
+      "hms_tz.hms_tz.doctype.consumable_record.consumable_api.create_consumable_record",
+    args: {
+      args: JSON.stringify({
+        patient: dialog.get_value("patient"),
+        company: dialog.get_value("company"),
+        appointment: opts.appointment || "",
+        encounter: opts.encounter || "",
+        payment_type: payment_type,
+        mode_of_payment: dialog.get_value("mode_of_payment") || "",
+        insurance_subscription:
+          dialog.get_value("insurance_subscription") || "",
+        insurance_company: dialog.get_value("insurance_company") || "",
+        insurance_coverage_plan:
+          dialog.get_value("insurance_coverage_plan") || "",
+        prescribed_by: opts.prescribed_by || "",
+        source_doctype: opts.source_doctype || "",
+        source_docname: opts.source_docname || "",
+        items: cleaned_items,
+      }),
+    },
+    callback: (r) => {
+      frappe.dom.unfreeze();
+      if (r.message) {
+        frappe.show_alert(
+          {
+            message: r.message.message || __("Consumable Record created."),
+            indicator: r.message.has_pending_payment ? "orange" : "green",
+          },
+          7
+        );
+        dialog.hide();
+        if (opts.on_success) {
+          opts.on_success(r.message);
+        }
+      }
+    },
+    error: () => {
+      frappe.dom.unfreeze();
+    },
+  });
+}

--- a/hms_tz/hms_tz/doctype/consumable_record/consumable_record.json
+++ b/hms_tz/hms_tz/doctype/consumable_record/consumable_record.json
@@ -15,6 +15,11 @@
   "posting_date",
   "posting_time",
   "status",
+  "section_break_payment",
+  "payment_type",
+  "mode_of_payment",
+  "column_break_payment2",
+  "has_pending_payment",
   "section_break_refs",
   "inpatient_record",
   "prescribed_by",
@@ -23,6 +28,7 @@
   "ref_docname",
   "source_doctype",
   "source_docname",
+  "delivery_note",
   "section_break_insurance",
   "insurance_subscription",
   "insurance_company",
@@ -101,8 +107,41 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Draft\nDispensed\nFinalized\nBilled",
+   "options": "Draft\nSubmitted\nPending Payment\nDispensed\nFinalized\nBilled",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_payment",
+   "fieldtype": "Section Break",
+   "label": "Payment Details"
+  },
+  {
+   "fieldname": "payment_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Payment Type",
+   "options": "\nCash\nInsurance",
+   "reqd": 1
+  },
+  {
+   "fieldname": "mode_of_payment",
+   "fieldtype": "Link",
+   "label": "Mode of Payment",
+   "options": "Mode of Payment",
+   "depends_on": "eval:doc.payment_type=='Cash'"
+  },
+  {
+   "fieldname": "column_break_payment2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_pending_payment",
+   "fieldtype": "Check",
+   "label": "Has Pending Payment",
+   "read_only": 1,
+   "hidden": 1
   },
   {
    "collapsible": 1,
@@ -151,6 +190,13 @@
    "fieldtype": "Dynamic Link",
    "label": "Source DocName",
    "options": "source_doctype"
+  },
+  {
+   "fieldname": "delivery_note",
+   "fieldtype": "Link",
+   "label": "Delivery Note",
+   "options": "Delivery Note",
+   "read_only": 1
   },
   {
    "collapsible": 1,

--- a/hms_tz/public/js/hms_tz.bundle.js
+++ b/hms_tz/public/js/hms_tz.bundle.js
@@ -3,3 +3,4 @@ import "./fingerprint/fingerprint.js";
 import "./facial/facial_recognition.js";
 import "./signature/signature.js";
 import "./request_approval.js";
+import "../../hms_tz/doctype/consumable_record/consumable_dialog.js";


### PR DESCRIPTION
Consumable Record Controller (consumable_record.py):
- Add before_submit hook: validate_items (require item_code, warehouse, qty > 0), validate_cash_patient_deposit (reuse validate_patient_balance_vs_patient_costs)
- Replace on_submit: remove direct update_status('Dispensed'), add try_create_delivery_note with payment-type-aware logic:
  * Cash patients: deposit already validated → auto-create Delivery Note immediately
  * Insurance patients with uninvoiced cash co-pay items → set status 'Pending Payment', hold DN until Sales Invoice is done
  * Insurance patients with all items covered → auto-create DN
- Add _create_delivery_note: group items by warehouse, create draft Delivery Note(s) with patient/customer mapping, practitioner, and consumable record reference
- Add set_stock_item_flags: set is_stock_item on each row from Item master
- Add before_save: call set_stock_item_flags alongside existing hooks
- Import validate_patient_balance_vs_patient_costs at module level