### PR TITLE
feat(nurse-record): add consumables management UI with submit and create invoice buttons

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
@@ -811,13 +811,214 @@ function show_medication_alert_banner(frm, medications) {
 function render_consumables_placeholder(frm) {
   if (!frm.fields_dict.consumables_html) return;
 
-  frm.fields_dict.consumables_html.$wrapper.html(
-    '<div class="text-muted text-center p-4">' +
-      __(
-        "Consumables tracking will be available after the Consumable Record module is implemented."
-      ) +
-      "</div>"
-  );
+  if (frm.is_new() || !frm.doc.patient) {
+    frm.fields_dict.consumables_html.$wrapper.html(
+      '<div class="text-muted text-center p-4">' +
+        __("Save the Nurse Record first to add consumables.") +
+        "</div>"
+    );
+    return;
+  }
+
+  // Add the "Add Consumables" button
+  const $wrapper = frm.fields_dict.consumables_html.$wrapper;
+  $wrapper.empty();
+
+  if (frm.doc.docstatus < 2) {
+    const $btn_container = $(
+      '<div class="d-flex justify-content-end mb-3" style="gap: 8px;"></div>'
+    ).appendTo($wrapper);
+
+    // "Create Invoice" button — only for cash patients
+    if (frm.doc.payment_type !== "Insurance" && frm.doc.inpatient_record) {
+      $('<button class="btn btn-warning btn-sm">')
+        .html('<i class="fa fa-file-text-o mr-1"></i>' + __("Create Invoice"))
+        .on("click", () => {
+          frappe.call({
+            method: "hms_tz.nhif.api.inpatient_record.create_sales_invoice",
+            args: {
+              args: JSON.stringify({
+                patient: frm.doc.patient,
+                appointment_no: frm.doc.appointment,
+                inpatient_record: frm.doc.inpatient_record,
+                company: frm.doc.company,
+              }),
+            },
+            freeze: true,
+            freeze_message: __("Creating Sales Invoice..."),
+            callback: (r) => {
+              if (r.message) {
+                frappe.set_route("Form", "Sales Invoice", r.message);
+              }
+            },
+          });
+        })
+        .appendTo($btn_container);
+    }
+
+    // "Add Consumables" button
+    $('<button class="btn btn-primary btn-sm">')
+      .html('<i class="fa fa-plus mr-1"></i>' + __("Add Consumables"))
+      .on("click", () => {
+        if (!window.hms_tz || !hms_tz.open_consumable_dialog) {
+          frappe.msgprint(
+            __("Consumable dialog not loaded. Please reload the page.")
+          );
+          return;
+        }
+        hms_tz.open_consumable_dialog({
+          patient: frm.doc.patient,
+          patient_name: frm.doc.patient_name,
+          appointment: frm.doc.appointment,
+          company: frm.doc.company,
+          payment_type: frm.doc.payment_type || "Cash",
+          insurance_subscription: frm.doc.insurance_subscription || "",
+          insurance_company: frm.doc.insurance_company || "",
+          insurance_coverage_plan: frm.doc.insurance_coverage_plan || "",
+          prescribed_by: frm.doc.nurse || "",
+          source_doctype: "",
+          source_docname: "",
+          mode_of_payment: "",
+          on_success: () => {
+            frm.reload_doc();
+          },
+        });
+      })
+      .appendTo($btn_container);
+  }
+
+  // Fetch and display existing consumable records
+  frappe.call({
+    method: "frappe.client.get_list",
+    args: {
+      doctype: "Consumable Record",
+      filters: {
+        appointment: frm.doc.appointment,
+      },
+      fields: [
+        "name",
+        "posting_date",
+        "status",
+        "total_amount",
+        "payment_type",
+        "delivery_note",
+        "docstatus",
+      ],
+      order_by: "creation desc",
+      limit_page_length: 50,
+    },
+    callback: (r) => {
+      if (!r.message || r.message.length === 0) {
+        $('<div class="text-muted text-center p-3">')
+          .text(__("No consumable records yet."))
+          .appendTo($wrapper);
+        return;
+      }
+
+      const records = r.message;
+      let table_html =
+        '<div class="table-responsive"><table class="table table-bordered table-sm">';
+      table_html += "<thead><tr>";
+      table_html += '<th class="text-left">' + __("Record") + "</th>";
+      table_html += '<th class="text-left">' + __("Date") + "</th>";
+      table_html += '<th class="text-left">' + __("Payment") + "</th>";
+      table_html += '<th class="text-right">' + __("Total") + "</th>";
+      table_html += '<th class="text-center">' + __("Status") + "</th>";
+      table_html += '<th class="text-left">' + __("Delivery Note") + "</th>";
+      table_html += '<th class="text-center">' + __("Action") + "</th>";
+      table_html += "</tr></thead><tbody>";
+
+      records.forEach((rec) => {
+        const status_color = {
+          Draft: "orange",
+          Submitted: "blue",
+          "Pending Payment": "red",
+          Dispensed: "green",
+          Finalized: "darkgreen",
+          Billed: "purple",
+        };
+        const color = status_color[rec.status] || "gray";
+
+        table_html += "<tr>";
+        table_html +=
+          '<td><a href="/app/consumable-record/' +
+          rec.name +
+          '">' +
+          rec.name +
+          "</a></td>";
+        table_html += "<td>" + (rec.posting_date || "") + "</td>";
+        table_html += "<td>" + (rec.payment_type || "") + "</td>";
+        table_html +=
+          '<td class="text-right">' +
+          format_currency(rec.total_amount || 0) +
+          "</td>";
+        table_html +=
+          '<td class="text-center"><span class="indicator-pill ' +
+          color +
+          '">' +
+          (rec.status || "Draft") +
+          "</span></td>";
+        table_html +=
+          "<td>" +
+          (rec.delivery_note
+            ? '<a href="/app/delivery-note/' +
+              rec.delivery_note +
+              '">' +
+              rec.delivery_note +
+              "</a>"
+            : "-") +
+          "</td>";
+
+        // Action column — Submit button for draft records
+        if (rec.docstatus === 0) {
+          table_html +=
+            '<td class="text-center">' +
+            '<button class="btn btn-xs btn-primary btn-submit-consumable" data-name="' +
+            rec.name +
+            '">' +
+            __("Submit") +
+            "</button></td>";
+        } else {
+          table_html += '<td class="text-center">-</td>';
+        }
+
+        table_html += "</tr>";
+      });
+
+      table_html += "</tbody></table></div>";
+      const $table = $(table_html).appendTo($wrapper);
+
+      // Wire submit buttons
+      $table.find(".btn-submit-consumable").on("click", function () {
+        const consumable_name = $(this).data("name");
+        frappe.confirm(
+          __("Are you sure you want to submit Consumable Record {0}?", [
+            consumable_name,
+          ]),
+          () => {
+            frappe.call({
+              method:
+                "hms_tz.hms_tz.doctype.consumable_record.consumable_api.submit_consumable_record",
+              args: { consumable_record: consumable_name },
+              freeze: true,
+              freeze_message: __("Submitting..."),
+              callback: (r) => {
+                if (!r.exc) {
+                  frappe.show_alert({
+                    message: __("Consumable Record {0} submitted.", [
+                      consumable_name,
+                    ]),
+                    indicator: "green",
+                  });
+                  frm.reload_doc();
+                }
+              },
+            });
+          }
+        );
+      });
+    },
+  });
 }
 
 function render_age(frm) {


### PR DESCRIPTION
Nurse Record Client Script (nurse_record.js):
- Rewrite render_consumables_placeholder to render a full consumable management UI:
  * Fetch and display existing Consumable Records in a table with columns: Record (link), Date, Payment Type, Total Amount, Status (color-coded indicator), Delivery Note (link), Action
  * Add 'Submit' button per draft consumable row — calls consumable_api.submit_consumable_record (fresh doc load to avoid modified errors)
  * Add 'Add Consumables' button — opens the global consumable dialog
  * Add 'Create Invoice' button (cash patients with inpatient_record only) — calls inpatient_record.create_sales_invoice with patient/appointment/inpatient args and redirects to the draft Sales Invoice form
- Minor formatting fixes: align indentation in completed_medications and medication status color ternaries