### PR TITLE
feat(billing): integrate consumable costs into invoice pipeline and deposit validation

### DIFF
--- a/hms_tz/nhif/api/healthcare_utils.py
+++ b/hms_tz/nhif/api/healthcare_utils.py
@@ -214,6 +214,41 @@ def get_healthcare_services_to_invoice(
 
             services_to_invoice.append(new_row)
 
+    # Get services from Consumable Records (cash items pending payment)
+    cr = DocType("Consumable Record")
+    ci = DocType("Consumable Item")
+
+    consumable_items = (
+        frappe.qb.from_(cr)
+        .inner_join(ci)
+        .on(cr.name == ci.parent)
+        .select(
+            ci.item_code,
+            ci.qty_requested,
+            ci.rate,
+            ci.name.as_("consumable_item_name"),
+            cr.name.as_("consumable_record"),
+        )
+        .where(
+            (cr.docstatus == 1)
+            & (ci.payment_type == "Cash")
+            & (ci.invoiced == 0)
+            & (ci.is_billable == 1)
+            & (cr.appointment == appointment)
+        )
+    ).run(as_dict=True)
+
+    for row in consumable_items:
+        new_row = {}
+        new_row["reference_type"] = "Consumable Item"
+        new_row["reference_name"] = row.consumable_item_name
+        new_row["service"] = row.item_code
+        new_row["rate"] = row.rate
+        new_row["qty"] = row.qty_requested
+        new_row["service_request"] = ""
+
+        services_to_invoice.append(new_row)
+
     return services_to_invoice
 
 
@@ -793,7 +828,6 @@ def get_restricted_LRPT(doc):
 # Sales Invoice Dialog Box for Healthcare Services
 @frappe.whitelist()
 def set_healthcare_services(doc, checked_values):
-    import json
 
     doc = frappe.get_cached_doc(json.loads(doc))
     checked_values = json.loads(checked_values)
@@ -829,6 +863,7 @@ def set_healthcare_services(doc, checked_values):
         if checked_item["dt"] not in [
             "Inpatient Occupancy",
             "Inpatient Consultancy",
+            "Consumable Item",
         ]:
             parent_encounter = frappe.get_cached_value(
                 checked_item["dt"],
@@ -859,7 +894,26 @@ def set_healthcare_services(doc, checked_values):
                 comapny_option = get_template_company_option(service_item, company)
                 item_line.healthcare_service_unit = comapny_option.service_unit
 
-        if item_line.healthcare_service_unit:
+        if checked_item["dt"] == "Consumable Item":
+            consumable_detials = frappe.get_cached_value(
+                "Consumable Item",
+                checked_item["dn"],
+                ["parent", "warehouse"],
+                as_dict=True
+            )
+
+            if consumable_detials:
+                item_line.warehouse = consumable_detials.get("warehouse")
+                consumable_record = consumable_detials.get("parent")
+
+                if consumable_record:
+                    item_line.healthcare_practitioner = frappe.get_cached_value(
+                        "Consumable Record",
+                        consumable_record,
+                        "prescribed_by",
+                    )
+
+        if item_line.healthcare_service_unit and not item_line.warehouse:
             item_line.warehouse = get_warehouse_from_service_unit(item_line.healthcare_service_unit)
 
     doc.set_missing_values(for_validate=True)

--- a/hms_tz/nhif/api/patient_encounter.py
+++ b/hms_tz/nhif/api/patient_encounter.py
@@ -1084,6 +1084,7 @@ def validate_patient_balance_vs_patient_costs(
     cash_limit=0,
     caller="",
     encounters=[],
+    exclude_consumable=None,
 ):
     def get_encounter_costs(encounters):
         encounter_cost = 0
@@ -1131,6 +1132,25 @@ def validate_patient_balance_vs_patient_costs(
 
         return inpatient_cost, cash_limit
 
+    def get_consumable_costs(patient, appointment, exclude_consumable=None):
+        """Sum total_amount from cash Consumable Records (draft + submitted)."""
+        filters = {
+            "patient": patient,
+            "payment_type": "Cash",
+            "docstatus": ["in", [0, 1]],
+        }
+        if appointment:
+            filters["appointment"] = appointment
+        if exclude_consumable:
+            filters["name"] = ["!=", exclude_consumable]
+
+        consumable_total = frappe.db.get_all(
+            "Consumable Record",
+            filters=filters,
+            fields=["sum(total_amount) as total"],
+        )
+        return flt(consumable_total[0].total) if consumable_total else 0
+
     cash_limit_details = frappe.get_cached_value(
         "HMS TZ Setting",
         {"company": company, "hms_tz_has_cash_limit_alert": 1},
@@ -1148,15 +1168,19 @@ def validate_patient_balance_vs_patient_costs(
     if not encounters or len(encounters) == 0:
         encounters = get_patient_encounters(patient, appointment, inpatient_record)
 
-        if not encounters or len(encounters) == 0:
-            return
-
-    total_amount_billed += get_encounter_costs(encounters)
+    if encounters and len(encounters) > 0:
+        total_amount_billed += get_encounter_costs(encounters)
 
     if inpatient_cost == 0 and cash_limit == 0:
         inpatient_cost, cash_limit = get_inpatient_costs(inpatient_record)
 
     total_amount_billed += flt(inpatient_cost)
+
+    # Include consumable record costs for cash patients
+    total_amount_billed += get_consumable_costs(patient, appointment, exclude_consumable)
+
+    if total_amount_billed <= 0:
+        return
 
     # get balance from payment entry after patient has deposit advances
     deposit_balance = get_balance_on(party_type="Customer", party=patient_name, company=company)
@@ -1164,7 +1188,10 @@ def validate_patient_balance_vs_patient_costs(
     patient_balance = (-1 * deposit_balance) + flt(cash_limit)
     cost_diff = fmt_money(total_amount_billed - patient_balance)
 
-    cash_limit_percent = 100 - ((total_amount_billed / patient_balance) * 100)
+    if flt(patient_balance) <= 0:
+        cash_limit_percent = -100
+    else:
+        cash_limit_percent = 100 - ((total_amount_billed / patient_balance) * 100)
 
     return make_cash_limit_alert(
         patient,


### PR DESCRIPTION
Healthcare Utils (healthcare_utils.py):
- get_healthcare_services_to_invoice: add Consumable Record query - fetch submitted, uninvoiced, billable, cash-type items from Consumable Item child table by appointment; add them as reference_type 'Consumable Item' to services_to_invoice list
- set_healthcare_services: add 'Consumable Item' to the list of DocTypes that skip parent_encounter lookup (alongside Inpatient Occupancy/Consultancy); fetch warehouse and prescribed_by from Consumable Item/Record for Sales Invoice line items; prevent warehouse override when already set from consumable source
- Remove redundant import json from set_healthcare_services (already imported at module level)

Patient Encounter (patient_encounter.py):
- validate_patient_balance_vs_patient_costs: add exclude_consumable parameter to avoid double-counting the current consumable record during validation
- Add get_consumable_costs inner function: sum total_amount from cash Consumable Records (draft + submitted) filtered by patient and appointment
- Include consumable costs in total_amount_billed calculation
- Fix early return: allow validation to proceed even when no encounters exist (consumables may still incur costs)
- Guard against zero/negative patient_balance in cash_limit_percent calculation to prevent ZeroDivisionError