### PR TITLE
feat(preop): restructure Preoperative Assessment with medical history tab and chronic medications

### DIFF
--- a/hms_tz/hms_tz/doctype/preop_chronic_medication/preop_chronic_medication.json
+++ b/hms_tz/hms_tz/doctype/preop_chronic_medication/preop_chronic_medication.json
@@ -1,0 +1,148 @@
+{
+ "actions": [],
+ "allow_copy": 1,
+ "creation": "2026-04-14 12:46:16.687515",
+ "default_view": "List",
+ "doctype": "DocType",
+ "document_type": "Document",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "drug_code",
+  "drug_name",
+  "dosage",
+  "period",
+  "dosage_form",
+  "quantity",
+  "column_break_7",
+  "comment",
+  "usage_interval",
+  "interval",
+  "interval_uom",
+  "update_schedule",
+  "column_break_oevn",
+  "patient_instruction"
+ ],
+ "fields": [
+  {
+   "columns": 2,
+   "fieldname": "drug_code",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_list_view": 1,
+   "label": "Drug",
+   "options": "Medication",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "drug_code.medication_name",
+   "fieldname": "drug_name",
+   "fieldtype": "Data",
+   "label": "Drug Name / Description"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "drug_code.default_prescription_dosage",
+   "fieldname": "dosage",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_list_view": 1,
+   "label": "Dosage",
+   "options": "Prescription Dosage"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "drug_code.default_prescription_duration",
+   "fieldname": "period",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_list_view": 1,
+   "label": "Period",
+   "options": "Prescription Duration"
+  },
+  {
+   "columns": 1,
+   "fetch_from": "drug_code.default_dosage_form",
+   "fieldname": "dosage_form",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "in_list_view": 1,
+   "label": "Dosage Form",
+   "options": "Dosage Form"
+  },
+  {
+   "fieldname": "column_break_7",
+   "fieldtype": "Column Break"
+  },
+  {
+   "columns": 2,
+   "fieldname": "comment",
+   "fieldtype": "Small Text",
+   "ignore_xss_filter": 1,
+   "in_list_view": 1,
+   "label": "Comment"
+  },
+  {
+   "default": "0",
+   "fieldname": "usage_interval",
+   "fieldtype": "Check",
+   "label": "Dosage by Time Interval"
+  },
+  {
+   "depends_on": "usage_interval",
+   "fieldname": "interval",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Interval"
+  },
+  {
+   "depends_on": "usage_interval",
+   "fieldname": "interval_uom",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Interval UOM",
+   "options": "\nHour\nDay"
+  },
+  {
+   "default": "1",
+   "fieldname": "update_schedule",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Update Schedule",
+   "print_hide": 1,
+   "report_hide": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "quantity",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Quantity",
+   "search_index": 1
+  },
+  {
+   "fieldname": "patient_instruction",
+   "fieldtype": "Small Text",
+   "label": "Patient Instruction"
+  },
+  {
+   "fieldname": "column_break_oevn",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-14 12:54:19.909887",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Preop Chronic Medication",
+ "owner": "Administrator",
+ "permissions": [],
+ "restrict_to_domain": "Healthcare",
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hms_tz/hms_tz/doctype/preop_chronic_medication/preop_chronic_medication.py
+++ b/hms_tz/hms_tz/doctype/preop_chronic_medication/preop_chronic_medication.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PreopChronicMedication(Document):
+	pass

--- a/hms_tz/hms_tz/doctype/preoperative_assessment/preoperative_assessment.js
+++ b/hms_tz/hms_tz/doctype/preoperative_assessment/preoperative_assessment.js
@@ -3,19 +3,7 @@
 
 frappe.ui.form.on("Preoperative Assessment", {
   setup(frm) {
-    frm.set_query("patient", () => ({
-      filters: { status: "Active" },
-    }));
-
-    frm.set_query("service_name", () => ({
-      filters: { disabled: 0 },
-    }));
-
-    frm.set_query("ot_schedule", () => {
-      const filters = {};
-      if (frm.doc.patient) filters.patient = frm.doc.patient;
-      return { filters };
-    });
+    frm.trigger("set_filters");
   },
 
   refresh(frm) {
@@ -59,6 +47,10 @@ frappe.ui.form.on("Preoperative Assessment", {
 
     // Render consumables tab
     render_consumables_section(frm);
+  },
+
+  onload: (frm) => {
+    frm.trigger("set_filters");
   },
 
   ot_schedule(frm) {
@@ -128,6 +120,41 @@ frappe.ui.form.on("Preoperative Assessment", {
       frm.set_value("insurance_coverage_plan", "");
       frm.set_value("insurance_company", "");
     }
+  },
+
+  set_filters: (frm) => {
+    frm.set_query("appointment", () => {
+      return {
+        filters: {
+          status: ["not in", ["Open", "Scheduled", "Cancelled"]],
+        },
+      };
+    });
+    frm.set_query("patient", () => {
+      return {
+        filters: { status: "Active" },
+      };
+    });
+
+    frm.set_query("service_name", () => {
+      return {
+        filters: { disabled: 0 },
+      };
+    });
+
+    frm.set_query("ot_schedule", () => {
+      const filters = {};
+      if (frm.doc.patient) filters.patient = frm.doc.patient;
+      return { filters };
+    });
+    frm.set_query("pre_operative_notes_template", () => {
+      return {
+        filters: {
+          disabled: 0,
+          terms: ["!=", ""],
+        },
+      };
+    });
   },
 });
 

--- a/hms_tz/hms_tz/doctype/preoperative_assessment/preoperative_assessment.json
+++ b/hms_tz/hms_tz/doctype/preoperative_assessment/preoperative_assessment.json
@@ -39,12 +39,18 @@
   "airway_assessment",
   "mallampati_score",
   "column_break_assessment",
-  "blood_type",
+  "blood_group",
   "last_oral_intake",
+  "section_break_sahn",
+  "pre_operative_notes_template",
+  "pre_operative_note",
+  "medical_history_tab",
+  "chronic_medications_section",
+  "chronic_medications",
   "section_break_history",
   "allergies",
-  "current_medications",
-  "medical_history_notes",
+  "section_break_fzsa",
+  "surgical_history",
   "tab_consumables",
   "consumables_html",
   "amended_from"
@@ -148,34 +154,18 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "blood_type",
-   "fieldtype": "Data",
-   "label": "Blood Type"
-  },
-  {
    "fieldname": "last_oral_intake",
    "fieldtype": "Datetime",
    "label": "Last Oral Intake"
   },
   {
    "fieldname": "section_break_history",
-   "fieldtype": "Section Break",
-   "label": "Medical History"
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "allergies",
    "fieldtype": "Small Text",
    "label": "Allergies"
-  },
-  {
-   "fieldname": "current_medications",
-   "fieldtype": "Small Text",
-   "label": "Current Medications"
-  },
-  {
-   "fieldname": "medical_history_notes",
-   "fieldtype": "Text",
-   "label": "Medical History Notes"
   },
   {
    "depends_on": "eval: doc.appointment",
@@ -327,11 +317,61 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "medical_history_tab",
+   "fieldtype": "Tab Break",
+   "label": "Medical History"
+  },
+  {
+   "fieldname": "section_break_sahn",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "pre_operative_notes_template",
+   "fieldtype": "Link",
+   "label": "Pre Operative Notes Template",
+   "options": "Healthcare Notes Template",
+   "search_index": 1
+  },
+  {
+   "fetch_from": "pre_operative_notes_template.terms",
+   "fetch_if_empty": 1,
+   "fieldname": "pre_operative_note",
+   "fieldtype": "Text Editor",
+   "label": "Pre Operative Note"
+  },
+  {
+   "fieldname": "chronic_medications_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "chronic_medications",
+   "fieldtype": "Table",
+   "label": "Chronic Medications",
+   "options": "Preop Chronic Medication"
+  },
+  {
+   "fieldname": "section_break_fzsa",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "surgical_history",
+   "fieldtype": "Text",
+   "label": "Surgical History"
+  },
+  {
+   "fieldname": "blood_group",
+   "fieldtype": "Select",
+   "label": "Blood Group",
+   "options": "\nA Positive\nA Negative\nAB Positive\nAB Negative\nB Positive\nB Negative\nO Positive\nO Negative",
+   "search_index": 1,
+   "sort_options": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-11 09:03:33.145098",
+ "modified": "2026-04-15 10:30:44.852747",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "Preoperative Assessment",

--- a/hms_tz/hms_tz/doctype/preoperative_assessment/preoperative_assessment.py
+++ b/hms_tz/hms_tz/doctype/preoperative_assessment/preoperative_assessment.py
@@ -9,6 +9,7 @@ from frappe.model.document import Document
 class PreoperativeAssessment(Document):
     def before_save(self):
         self.set_missing_values()
+        self.fetch_patient_medical_history()
         self.validate_clearance_checks()
 
     def set_missing_values(self):
@@ -70,6 +71,37 @@ class PreoperativeAssessment(Document):
             self.insurance_subscription = ""
             self.insurance_coverage_plan = ""
             self.insurance_company = ""
+
+
+    def fetch_patient_medical_history(self):
+        """Fetch allergies, chronic medications, and surgical history from Patient."""
+
+        if not self.patient:
+            return
+
+        patient_doc = frappe.get_cached_doc("Patient", self.patient)
+
+        if not self.allergies and patient_doc.allergies:
+            self.allergies = patient_doc.allergies
+
+        if not self.surgical_history and patient_doc.surgical_history:
+            self.surgical_history = patient_doc.surgical_history
+
+        if len(self.chronic_medications) == 0:
+            for row in patient_doc.chronic_medications:
+                self.append("chronic_medications", {
+                    "drug_code": row.drug_code,
+                    "drug_name": row.drug_name,
+                    "dosage": row.dosage,
+                    "period": row.period,
+                    "dosage_form": row.dosage_form,
+                    "quantity": row.quantity,
+                    "comment": row.comment,
+                    "patient_instruction": row.patient_instruction,
+                    "usage_interval": row.usage_interval,
+                    "interval": row.interval,
+                    "interval_uom": row.interval_uom
+                })
 
     def validate_clearance_checks(self):
         """Warn if marking as Cleared without all checks complete."""


### PR DESCRIPTION
Preoperative Assessment - Schema (preoperative_assessment.json):
- Replace blood_type (Data) with blood_group (Select) field with standard options: A Positive, A Negative, AB Positive, AB Negative, B Positive, B Negative, O Positive, O Negative
- Add Medical History tab (medical_history_tab) with:
  - Pre Operative Notes section: pre_operative_notes_template (Link to Healthcare Notes Template) and pre_operative_note (Text Editor, fetched from template.terms)
  - Chronic Medications section: chronic_medications (Table of Preop Chronic Medication child DocType)
  - Allergies section: allergies (Small Text) - moved from inline
  - Surgical History section: surgical_history (Text) - replaces medical_history_notes
- Remove deprecated fields: current_medications (replaced by chronic medications table), medical_history_notes (replaced by surgical_history)

Preoperative Assessment - Client Script (preoperative_assessment.js):
- Refactor set_query calls into a dedicated set_filters handler triggered on both setup and onload events
- Add query filter for appointment: status not in Open, Scheduled, Cancelled
- Add query filter for patient: status Active
- Add query filter for service_name: disabled 0
- Add query filter for pre_operative_notes_template: disabled 0, terms != ""
- Fix indentation alignment on consumable HTML template strings and delivery_note link concatenation

Preoperative Assessment - Server Logic (preoperative_assessment.py):
- Add fetch_patient_medical_history() method called during before_save:
  - Auto-populates allergies from Patient.allergies if empty
  - Auto-populates surgical_history from Patient.surgical_history if empty
  - Copies Patient.chronic_medications rows into the Preop Chronic Medication child table (drug_code, drug_name, dosage, period, dosage_form, quantity, comment, patient_instruction, usage_interval, interval, interval_uom) if table is empty

New DocType - Preop Chronic Medication (child table):
- Child table DocType mirroring Patient chronic_medications structure
- Fields: drug_code (Link to Medication, reqd), drug_name (Data, fetched), dosage (Link to Prescription Dosage), period (Link to Prescription Duration), dosage_form (Link to Dosage Form), quantity (Int), comment (Small Text), usage_interval (Check), interval (Int), interval_uom (Select: Hour/Day), update_schedule (Check, hidden), patient_instruction (Small Text)
- Editable grid with 50 rows per page, restricted to Healthcare domain