### PR TITLE
feat(postop): add submittable workflow, ward handover dialog, and recovery nurse validation

### DIFF
--- a/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.js
+++ b/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.js
@@ -4,7 +4,11 @@
 frappe.ui.form.on("Postoperative Recovery", {
   setup(frm) {
     frm.set_query("recovery_nurse", () => ({
-      filters: { practitioner_role: "Nurse" },
+      filters: {
+        status: "Active",
+        practitioner_role: "Nurse",
+        hms_tz_company: frm.doc.company,
+      },
     }));
     frm.set_query("patient", () => ({
       filters: { status: "Active" },
@@ -65,6 +69,16 @@ frappe.ui.form.on("Postoperative Recovery", {
       frm.add_custom_button(__("Add Aldrete Score"), () => {
         add_aldrete_template(frm);
       });
+
+      // "Handover Patient to Ward" button — only after submission
+      if (frm.doc.docstatus === 1) {
+        frm.add_custom_button(__("Handover Patient to Ward"), () => {
+          show_handover_to_ward_dialog(frm);
+        });
+        frm.$wrapper
+          .find('[data-label="Handover%20Patient%20to%20Ward"]')
+          .addClass("btn-primary");
+      }
     }
   },
 });
@@ -105,6 +119,150 @@ function add_aldrete_template(frm) {
       frm.refresh_field("recovery_scores");
       d.hide();
       frm.dirty();
+    },
+  });
+  d.show();
+}
+
+function show_handover_to_ward_dialog(frm) {
+  let d = new frappe.ui.Dialog({
+    title: __("Handover Patient to Ward"),
+    size: "large",
+    fields: [
+      { fieldtype: "Section Break", label: __("Transfer Details") },
+      {
+        fieldname: "from_location",
+        fieldtype: "Link",
+        label: __("From Location (Theater/Recovery)"),
+        options: "Healthcare Service Unit",
+        get_query: function () {
+          return {
+            filters: { company: frm.doc.company },
+          };
+        },
+      },
+      {
+        fieldname: "handed_over_by",
+        fieldtype: "Link",
+        label: __("Handed Over By"),
+        options: "Healthcare Practitioner",
+        reqd: 1,
+        get_query: function () {
+          return {
+            filters: {
+              status: "Active",
+              hms_tz_company: frm.doc.company,
+            },
+          };
+        },
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "to_location",
+        fieldtype: "Link",
+        label: __("To Location (Ward)"),
+        options: "Healthcare Service Unit",
+        get_query: function () {
+          return {
+            filters: { company: frm.doc.company },
+          };
+        },
+      },
+      {
+        fieldname: "received_by",
+        fieldtype: "Link",
+        label: __("Received By"),
+        options: "Healthcare Practitioner",
+        get_query: function () {
+          return {
+            filters: {
+              status: "Active",
+              hms_tz_company: frm.doc.company,
+            },
+          };
+        },
+      },
+      { fieldtype: "Section Break", label: __("Handover Checklist") },
+      {
+        fieldname: "patient_identity_verified",
+        fieldtype: "Check",
+        label: __("Patient Identity Verified"),
+      },
+      {
+        fieldname: "vitals_stable",
+        fieldtype: "Check",
+        label: __("Vitals Stable"),
+      },
+      {
+        fieldname: "allergies_documented",
+        fieldtype: "Check",
+        label: __("Allergies Documented"),
+      },
+      {
+        fieldname: "iv_lines_checked",
+        fieldtype: "Check",
+        label: __("IV Lines Checked"),
+      },
+      {
+        fieldname: "medications_documented",
+        fieldtype: "Check",
+        label: __("Medications Documented"),
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "consent_verified",
+        fieldtype: "Check",
+        label: __("Consent Verified"),
+      },
+      {
+        fieldname: "surgical_site_marked",
+        fieldtype: "Check",
+        label: __("Surgical Site Marked"),
+      },
+      {
+        fieldname: "specimens_handed_over",
+        fieldtype: "Check",
+        label: __("Specimens Handed Over"),
+      },
+      {
+        fieldname: "drain_tubes_documented",
+        fieldtype: "Check",
+        label: __("Drain/Tubes Documented"),
+      },
+      {
+        fieldname: "blood_products_available",
+        fieldtype: "Check",
+        label: __("Blood Products Available"),
+      },
+      { fieldtype: "Section Break", label: __("Notes") },
+      {
+        fieldname: "clinical_notes",
+        fieldtype: "Small Text",
+        label: __("Clinical Notes"),
+      },
+    ],
+    primary_action_label: __("Create Handover"),
+    primary_action(values) {
+      frappe.call({
+        method:
+          "hms_tz.hms_tz.doctype.postoperative_recovery.postoperative_recovery.create_surgical_handover",
+        args: {
+          postoperative_recovery: frm.doc.name,
+          ...values,
+        },
+        freeze: true,
+        freeze_message: __("Creating Surgical Handover..."),
+        callback: function (r) {
+          if (r.message) {
+            frappe.show_alert({
+              message: __("Surgical Handover {0} created.", [r.message]),
+              indicator: "green",
+            });
+            d.hide();
+            frm.reload_doc();
+          }
+        },
+      });
     },
   });
   d.show();

--- a/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.json
+++ b/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.json
@@ -1,19 +1,20 @@
 {
  "actions": [],
  "autoname": "naming_series:",
- "creation": "2026-04-09 00:00:00.000000",
+ "creation": "2026-04-09 00:00:00",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "naming_series",
   "patient",
   "patient_name",
   "clinical_procedure",
   "ot_schedule",
   "column_break_01",
   "company",
+  "posting_date",
   "status",
   "recovery_nurse",
+  "naming_series",
   "section_break_timing",
   "admission_time",
   "discharge_time",
@@ -25,7 +26,8 @@
   "section_break_notes",
   "postop_care_plan_html",
   "complications",
-  "notes"
+  "notes",
+  "amended_from"
  ],
  "fields": [
   {
@@ -36,6 +38,7 @@
    "reqd": 1
   },
   {
+   "fetch_from": "clinical_procedure.patient",
    "fieldname": "patient",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -56,13 +59,17 @@
    "fieldname": "clinical_procedure",
    "fieldtype": "Link",
    "label": "Clinical Procedure",
-   "options": "Clinical Procedure"
+   "options": "Clinical Procedure",
+   "reqd": 1,
+   "search_index": 1
   },
   {
+   "fetch_from": "clinical_procedure.ot_schedule",
    "fieldname": "ot_schedule",
    "fieldtype": "Link",
    "label": "OT Schedule",
-   "options": "OT Schedule"
+   "options": "OT Schedule",
+   "search_index": 1
   },
   {
    "fieldname": "column_break_01",
@@ -82,7 +89,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "In Recovery\nStable\nDischarged to Ward\nDischarged Home\nTransferred to ICU"
+   "options": "In Recovery\nStable\nDischarged to Ward\nTransferred to ICU"
   },
   {
    "fieldname": "recovery_nurse",
@@ -152,10 +159,28 @@
    "fieldname": "notes",
    "fieldtype": "Text",
    "label": "Notes"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Postoperative Recovery",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date",
+   "search_index": 1
   }
  ],
+ "is_submittable": 1,
  "links": [],
- "modified": "2026-04-09 00:00:00.000000",
+ "modified": "2026-04-15 13:00:31.877958",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "Postoperative Recovery",
@@ -187,6 +212,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.py
+++ b/hms_tz/hms_tz/doctype/postoperative_recovery/postoperative_recovery.py
@@ -9,11 +9,18 @@ from frappe.utils import flt
 
 class PostoperativeRecovery(Document):
     def before_submit(self):
+        self.validate_nurse()
         self.validate_discharge_criteria()
+
+    def validate_nurse(self):
+        if not self.recovery_nurse:
+            frappe.throw(
+                _("Please select a recovery nurse.")
+            )
 
     def validate_discharge_criteria(self):
         """Validate Aldrete score meets minimum before discharge."""
-        if self.status in ("Discharged to Ward", "Discharged Home"):
+        if self.status == "Discharged to Ward":
             if not self.discharge_criteria_met:
                 frappe.throw(
                     _("Please confirm that discharge criteria have been met before discharging the patient.")
@@ -24,10 +31,48 @@ class PostoperativeRecovery(Document):
 
             if total_max > 0 and total_score < (total_max * 0.7):
                 frappe.msgprint(
-                    _("Warning: Total recovery score ({0}/{1}) is below 70% threshold. "
-                      "Please confirm patient is safe for discharge.").format(
-                        total_score, total_max
+                    _(
+                        f"Warning: Total recovery score: <b>{total_score}/{total_max}</b> is below 70% threshold. "
+                        "Please confirm patient is safe for discharge."
                     ),
                     alert=True,
                     indicator="orange",
                 )
+
+
+@frappe.whitelist()
+def create_surgical_handover(postoperative_recovery: str, **kwargs) -> str:
+    """Create a Surgical Handover record (Theater to Ward) from the
+    Postoperative Recovery form."""
+    pr = frappe.get_doc("Postoperative Recovery", postoperative_recovery)
+
+    sh = frappe.new_doc("Surgical Handover")
+    sh.patient = pr.patient
+    sh.clinical_procedure = pr.clinical_procedure
+    sh.company = pr.company
+    sh.type = "Theater to Ward"
+    sh.handover_time = frappe.utils.now_datetime()
+
+    # Transfer details
+    transfer_fields = ["from_location", "to_location", "handed_over_by", "received_by"]
+    for field in transfer_fields:
+        if kwargs.get(field):
+            sh.set(field, kwargs[field])
+
+    # Checklist items
+    checklist_fields = [
+        "patient_identity_verified", "consent_verified", "surgical_site_marked",
+        "allergies_documented", "iv_lines_checked", "vitals_stable",
+        "medications_documented", "blood_products_available",
+        "specimens_handed_over", "drain_tubes_documented",
+    ]
+    for field in checklist_fields:
+        sh.set(field, 1 if kwargs.get(field) else 0)
+
+    # Notes
+    if kwargs.get("clinical_notes"):
+        sh.clinical_notes = kwargs["clinical_notes"]
+
+    sh.insert(ignore_permissions=True)
+
+    return sh.name


### PR DESCRIPTION
Postoperative Recovery - Schema (postoperative_recovery.json):
- Make submittable (is_submittable: true) with amended_from field
- Add posting_date field (Date, default Today, search_index)
- Add fetch_from on patient (from clinical_procedure.patient) and ot_schedule (from clinical_procedure.ot_schedule)
- Make clinical_procedure required with search_index
- Add search_index on ot_schedule
- Remove "Discharged Home" from status options (now: In Recovery, Stable, Discharged to Ward, Transferred to ICU)
- Move naming_series to bottom of field_order
- Add row_format Dynamic

Postoperative Recovery - Client Script (postoperative_recovery.js):
- Enhance recovery_nurse set_query: filter by status Active, practitioner_role Nurse, and hms_tz_company matching frm.doc.company
- Add "Handover Patient to Ward" button (visible after submission only, styled as btn-primary)
- Implement show_handover_to_ward_dialog() with:
  - Transfer Details section: from_location and to_location (Link to Healthcare Service Unit filtered by company), handed_over_by (reqd, Link to Healthcare Practitioner filtered by Active and company), received_by (Link to Healthcare Practitioner)
  - Handover Checklist section with 10 check fields: patient_identity_verified, vitals_stable, allergies_documented, iv_lines_checked, medications_documented, consent_verified, surgical_site_marked, specimens_handed_over, drain_tubes_documented, blood_products_available
  - Notes section: clinical_notes (Small Text)
  - Primary action calls create_surgical_handover API

Postoperative Recovery - Server Logic (postoperative_recovery.py):
- Add validate_nurse() called on before_submit: throws if recovery_nurse is not set
- Update validate_discharge_criteria() to check only "Discharged to Ward" status (removed "Discharged Home" check)
- Fix Aldrete score warning message: use f-string with bold formatting for score display
- Add create_surgical_handover() whitelisted API:
  - Creates Surgical Handover record with type "Theater to Ward"
  - Auto-sets patient, clinical_procedure, company from the recovery doc
  - Sets handover_time to current datetime
  - Copies transfer fields (from_location, to_location, handed_over_by, received_by) and checklist fields (10 boolean checks) from dialog
  - Copies clinical_notes if provided
  - Inserts with ignore_permissions