### PR TITLE
feat(clinical-procedure): add OT schedule linking, implant/specimen dialogs, auto postop recovery, and refine custom field layout

### DIFF
--- a/hms_tz/hooks.py
+++ b/hms_tz/hooks.py
@@ -199,6 +199,7 @@ doc_events = {
     },
     "Clinical Procedure": {
         "after_insert": "hms_tz.nhif.api.clinical_procedure.after_insert",
+        "before_save": "hms_tz.nhif.api.clinical_procedure.before_save",
         "onload": "hms_tz.nhif.api.clinical_procedure.onload",
         "before_submit": "hms_tz.nhif.api.clinical_procedure.before_submit",
         "on_submit": "hms_tz.nhif.api.clinical_procedure.on_submit",

--- a/hms_tz/nhif/api/clinical_procedure.js
+++ b/hms_tz/nhif/api/clinical_procedure.js
@@ -1,7 +1,16 @@
 frappe.ui.form.on("Clinical Procedure", {
   setup: function (frm) {
-    frm.set_query("practitioner", function () {
+    frm.set_query("practitioner", () => {
       return { filters: { practitioner_role: "Doctor" } };
+    });
+    frm.set_query("ot_schedule", () => {
+      return {
+        filters: {
+          patient: frm.doc.patient,
+          company: frm.doc.company,
+          procedure_template: frm.doc.procedure_template,
+        },
+      };
     });
   },
   refresh: function (frm) {
@@ -12,6 +21,7 @@ frappe.ui.form.on("Clinical Procedure", {
     render_cp_consumables_section(frm);
     render_cp_vital_signs(frm);
     render_cp_anesthesia_records(frm);
+    render_cp_implant_specimen_buttons(frm);
   },
 
   onload: function (frm) {
@@ -25,17 +35,6 @@ frappe.ui.form.on("Clinical Procedure", {
       });
     }
   },
-
-  record_vital_signs: function (frm) {
-    if (frm.is_new() || frm.doc.docstatus === 2) return;
-    show_cp_vital_signs_dialog(frm);
-  },
-
-  add_anesthesia: function (frm) {
-    if (frm.is_new() || frm.doc.docstatus === 2) return;
-    show_cp_anesthesia_dialog(frm);
-  },
-
   request_approval_no: (frm) => {
     if (
       !frm.doc.insurance_company ||
@@ -651,15 +650,35 @@ function render_cp_consumables_section(frm) {
 
 function render_cp_vital_signs(frm) {
   if (!frm.fields_dict.cp_vital_signs_html) return;
-  if (!frm.doc.patient) {
+
+  if (frm.is_new() || !frm.doc.patient) {
     frm.fields_dict.cp_vital_signs_html.$wrapper.html(
       '<div class="text-muted text-center p-4">' +
-        __("No vital signs recorded.") +
+        __("Save the Clinical Procedure first to record vital signs.") +
         "</div>"
     );
     return;
   }
 
+  const $wrapper = frm.fields_dict.cp_vital_signs_html.$wrapper;
+  $wrapper.empty();
+
+  // Button container (same pattern as consumables)
+  const $btn_container = $(
+    '<div class="d-flex justify-content-end mb-3" style="gap: 8px;"></div>'
+  ).appendTo($wrapper);
+
+  // "Record Vital Signs" button
+  if (frm.doc.docstatus !== 2) {
+    $('<button class="btn btn-primary btn-sm">')
+      .html('<i class="fa fa-heartbeat mr-1"></i>' + __("Record Vital Signs"))
+      .on("click", () => {
+        show_cp_vital_signs_dialog(frm);
+      })
+      .appendTo($btn_container);
+  }
+
+  // Fetch and display existing vital signs
   frappe.call({
     method: "hms_tz.hms_tz.doctype.nurse_record.nurse_record.get_vital_signs",
     args: {
@@ -668,22 +687,17 @@ function render_cp_vital_signs(frm) {
     },
     callback: function (r) {
       if (r.message && r.message.length > 0) {
-        render_cp_vitals_chart_and_table(frm, r.message);
+        render_cp_vitals_chart_and_table(frm, r.message, $wrapper);
       } else {
-        frm.fields_dict.cp_vital_signs_html.$wrapper.html(
-          '<div class="text-muted text-center p-4">' +
-            __("No vital signs recorded for this patient episode.") +
-            "</div>"
-        );
+        $('<div class="text-muted text-center p-3">')
+          .text(__("No vital signs recorded for this patient episode."))
+          .appendTo($wrapper);
       }
     },
   });
 }
 
-function render_cp_vitals_chart_and_table(frm, vitals) {
-  let $wrapper = frm.fields_dict.cp_vital_signs_html.$wrapper;
-  $wrapper.empty();
-
+function render_cp_vitals_chart_and_table(frm, vitals, $wrapper) {
   let chart_id = "cp-vitals-chart-" + frm.doc.name;
   $wrapper.append('<div class="mb-4"><div id="' + chart_id + '"></div></div>');
 
@@ -830,28 +844,43 @@ function show_cp_vital_signs_dialog(frm) {
 
 function render_cp_anesthesia_records(frm) {
   if (!frm.fields_dict.cp_anesthesia_html) return;
+
   if (frm.is_new() || !frm.doc.patient) {
     frm.fields_dict.cp_anesthesia_html.$wrapper.html(
       '<div class="text-muted text-center p-4">' +
-        __("No anesthesia records.") +
+        __("Save the Clinical Procedure first to add anesthesia records.") +
         "</div>"
     );
     return;
   }
 
+  const $wrapper = frm.fields_dict.cp_anesthesia_html.$wrapper;
+  $wrapper.empty();
+
+  // Button container (same pattern as consumables)
+  const $btn_container = $(
+    '<div class="d-flex justify-content-end mb-3" style="gap: 8px;"></div>'
+  ).appendTo($wrapper);
+
+  // "Add Anesthesia" button
+  if (frm.doc.docstatus !== 2) {
+    $('<button class="btn btn-primary btn-sm">')
+      .html('<i class="fa fa-medkit mr-1"></i>' + __("Add Anesthesia"))
+      .on("click", () => {
+        show_cp_anesthesia_dialog(frm);
+      })
+      .appendTo($btn_container);
+  }
+
+  // Fetch and display existing anesthesia records
   frappe.call({
     method: "hms_tz.nhif.api.clinical_procedure.get_anesthesia_records",
     args: { clinical_procedure: frm.doc.name },
     callback: function (r) {
-      let $wrapper = frm.fields_dict.cp_anesthesia_html.$wrapper;
-      $wrapper.empty();
-
       if (!r.message || r.message.length === 0) {
-        $wrapper.html(
-          '<div class="text-muted text-center p-3">' +
-            __("No anesthesia records yet.") +
-            "</div>"
-        );
+        $('<div class="text-muted text-center p-3">')
+          .text(__("No anesthesia records yet."))
+          .appendTo($wrapper);
         return;
       }
 
@@ -887,7 +916,7 @@ function render_cp_anesthesia_records(frm) {
       });
 
       html += "</tbody></table></div>";
-      $wrapper.html(html);
+      $(html).appendTo($wrapper);
     },
   });
 }
@@ -902,6 +931,16 @@ function show_cp_anesthesia_dialog(frm) {
         fieldtype: "Link",
         label: __("Anesthetist"),
         options: "Healthcare Practitioner",
+        reqd: 1,
+        get_query: function () {
+          return {
+            filters: {
+              status: "Active",
+              practitioner_role: "Doctor",
+              hms_tz_company: frm.doc.company,
+            },
+          };
+        },
       },
       {
         fieldname: "anesthesia_type",
@@ -939,12 +978,49 @@ function show_cp_anesthesia_dialog(frm) {
       },
       { fieldtype: "Section Break", label: __("Drugs Administered") },
       {
-        fieldname: "drugs_text",
-        fieldtype: "Small Text",
-        label: __("Drugs (Drug, Dosage, Route — one per line)"),
-        description: __(
-          "Format: Drug Name, Dosage, Route (IV/IM/Inhalation/Oral/Subcutaneous)"
-        ),
+        fieldname: "drugs",
+        fieldtype: "Table",
+        label: __("Drugs Administered"),
+        fields: [
+          {
+            fieldname: "drug",
+            fieldtype: "Link",
+            label: __("Drug"),
+            options: "Medication",
+            in_list_view: 1,
+            reqd: 1,
+            get_query: function () {
+              return {
+                filters: {
+                  disabled: 0,
+                },
+              };
+            },
+          },
+          {
+            fieldname: "dosage",
+            fieldtype: "Link",
+            label: __("Dosage"),
+            options: "Prescription Dosage",
+            in_list_view: 1,
+            reqd: 1,
+          },
+          {
+            fieldname: "route",
+            fieldtype: "Select",
+            label: __("Route"),
+            options: "\nIV\nIM\nInhalation\nOral\nSubcutaneous",
+            in_list_view: 1,
+            reqd: 1,
+          },
+          {
+            fieldname: "administered_time",
+            fieldtype: "Time",
+            label: __("Administered Time"),
+            in_list_view: 1,
+            reqd: 1,
+          },
+        ],
       },
       { fieldtype: "Section Break", label: __("Notes") },
       {
@@ -972,6 +1048,227 @@ function show_cp_anesthesia_dialog(frm) {
             });
             d.hide();
             render_cp_anesthesia_records(frm);
+          }
+        },
+      });
+    },
+  });
+  d.show();
+}
+
+// ─── Implant & Specimen Buttons ───
+
+function render_cp_implant_specimen_buttons(frm) {
+  if (!frm.fields_dict.impant_specimen_bts) return;
+
+  if (frm.is_new() || !frm.doc.patient) {
+    frm.fields_dict.impant_specimen_bts.$wrapper.html(
+      '<div class="text-muted text-center p-4">' +
+        __("Save the Clinical Procedure first.") +
+        "</div>"
+    );
+    return;
+  }
+
+  const $wrapper = frm.fields_dict.impant_specimen_bts.$wrapper;
+  $wrapper.empty();
+
+  if (frm.doc.docstatus === 2) return;
+
+  const $btn_container = $(
+    '<div class="d-flex justify-content-end mb-3" style="gap: 8px;"></div>'
+  ).appendTo($wrapper);
+
+  // "Add Implant" button
+  $('<button class="btn btn-primary btn-sm">')
+    .html('<i class="fa fa-cube mr-1"></i>' + __("Add Implant"))
+    .on("click", () => {
+      show_cp_implant_dialog(frm);
+    })
+    .appendTo($btn_container);
+
+  // "Add Specimen" button
+  $('<button class="btn btn-primary btn-sm">')
+    .html('<i class="fa fa-flask mr-1"></i>' + __("Add Specimen"))
+    .on("click", () => {
+      show_cp_specimen_dialog(frm);
+    })
+    .appendTo($btn_container);
+}
+
+function show_cp_implant_dialog(frm) {
+  let d = new frappe.ui.Dialog({
+    title: __("Add Implant"),
+    size: "large",
+    fields: [
+      {
+        fieldname: "implant_type",
+        fieldtype: "Data",
+        label: __("Implant Type"),
+        reqd: 1,
+      },
+      {
+        fieldname: "manufacturer",
+        fieldtype: "Data",
+        label: __("Manufacturer"),
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "lot_number",
+        fieldtype: "Data",
+        label: __("Lot Number"),
+      },
+      {
+        fieldname: "serial_number",
+        fieldtype: "Data",
+        label: __("Serial Number"),
+      },
+      { fieldtype: "Section Break", label: __("Implant Details") },
+      {
+        fieldname: "anatomical_location",
+        fieldtype: "Data",
+        label: __("Anatomical Location"),
+      },
+      {
+        fieldname: "expiry_date",
+        fieldtype: "Date",
+        label: __("Expiry Date"),
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "implanted_by",
+        fieldtype: "Link",
+        label: __("Implanted By"),
+        options: "Healthcare Practitioner",
+        get_query: function () {
+          return {
+            filters: {
+              status: "Active",
+              practitioner_role: "Doctor",
+              hms_tz_company: frm.doc.company,
+            },
+          };
+        },
+      },
+      {
+        fieldname: "implant_date",
+        fieldtype: "Date",
+        label: __("Implant Date"),
+        default: frappe.datetime.get_today(),
+      },
+      { fieldtype: "Section Break", label: __("Status & Notes") },
+      {
+        fieldname: "status",
+        fieldtype: "Select",
+        label: __("Status"),
+        options: "Planned\nImplanted\nRemoved\nReplaced",
+        default: "Implanted",
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "notes",
+        fieldtype: "Small Text",
+        label: __("Notes"),
+      },
+    ],
+    primary_action_label: __("Create & Submit"),
+    primary_action(values) {
+      frappe.call({
+        method: "hms_tz.nhif.api.clinical_procedure.create_implant_registry",
+        args: {
+          clinical_procedure: frm.doc.name,
+          ...values,
+        },
+        freeze: true,
+        freeze_message: __("Creating Implant Registry..."),
+        callback: function (r) {
+          if (r.message) {
+            frappe.show_alert({
+              message: __("Implant Registry {0} created and submitted.", [
+                r.message,
+              ]),
+              indicator: "green",
+            });
+            d.hide();
+            frm.reload_doc();
+          }
+        },
+      });
+    },
+  });
+  d.show();
+}
+
+function show_cp_specimen_dialog(frm) {
+  let d = new frappe.ui.Dialog({
+    title: __("Add Specimen"),
+    size: "large",
+    fields: [
+      {
+        fieldname: "specimen_type",
+        fieldtype: "Data",
+        label: __("Specimen Type"),
+        reqd: 1,
+      },
+      {
+        fieldname: "anatomical_site",
+        fieldtype: "Data",
+        label: __("Anatomical Site"),
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "collection_time",
+        fieldtype: "Datetime",
+        label: __("Collection Time"),
+        default: frappe.datetime.now_datetime(),
+      },
+      {
+        fieldname: "collected_by",
+        fieldtype: "Link",
+        label: __("Collected By"),
+        options: "Healthcare Practitioner",
+        get_query: function () {
+          return {
+            filters: {
+              status: "Active",
+              hms_tz_company: frm.doc.company,
+            },
+          };
+        },
+      },
+      { fieldtype: "Section Break", label: __("Lab & Pathology") },
+      {
+        fieldname: "status",
+        fieldtype: "Select",
+        label: __("Status"),
+        options: "Collected\nSent to Lab\nResults Received\nArchived",
+        default: "Collected",
+      },
+      { fieldtype: "Column Break" },
+      {
+        fieldname: "pathology_notes",
+        fieldtype: "Small Text",
+        label: __("Pathology Notes"),
+      },
+    ],
+    primary_action_label: __("Create"),
+    primary_action(values) {
+      frappe.call({
+        method: "hms_tz.nhif.api.clinical_procedure.create_surgical_specimen",
+        args: {
+          clinical_procedure: frm.doc.name,
+          ...values,
+        },
+        freeze: true,
+        freeze_message: __("Creating Surgical Specimen..."),
+        callback: function (r) {
+          if (r.message) {
+            frappe.show_alert({
+              message: __("Surgical Specimen {0} created.", [r.message]),
+              indicator: "green",
+            });
+            d.hide();
+            frm.reload_doc();
           }
         },
       });

--- a/hms_tz/nhif/api/clinical_procedure.py
+++ b/hms_tz/nhif/api/clinical_procedure.py
@@ -4,6 +4,8 @@
 
 from __future__ import unicode_literals
 
+import json
+
 import frappe
 from frappe import _
 from frappe.query_builder import DocType
@@ -20,6 +22,11 @@ from hms_tz.nhif.utils import validate_issued_services, validate_point_of_care
 
 def after_insert(doc, method):
     create_revenue_entry(doc)
+
+
+def before_save(doc, method):
+    get_ot_schedule(doc)
+    get_preop_notes(doc)
 
 
 def onload(doc, method):
@@ -43,6 +50,8 @@ def on_submit(doc, methd):
         doc.hms_tz_ref_childname,
         lrpmt_status="Submitted",
     )
+    if doc.inpatient_record:
+        create_postoperative_recovery(doc)
 
 
 def before_submit(doc, method):
@@ -83,6 +92,67 @@ def update_procedure_prescription(doc):
             .set(hsrp.lrpmt_status, "Submitted")
             .where((hsrp.ref_docname == doc.hms_tz_ref_childname))
         ).run()
+
+
+def get_ot_schedule(doc):
+    if doc.ot_schedule:
+        return
+
+    ot_schedule = frappe.get_cached_value(
+        "OT Schedule",
+        {
+            "patient": doc.patient,
+            "company": doc.company,
+            "procedure_template": doc.procedure_template
+        },
+        "name"
+    )
+    if not ot_schedule:
+        return
+
+    doc.ot_schedule = ot_schedule
+    doc.surgical_team = []
+
+    ot_schedule_doc = frappe.get_cached_doc("OT Schedule", ot_schedule)
+    for row in ot_schedule_doc.get("surgical_team"):
+        doc.append("surgical_team", {
+            "practitioner": row.practitioner,
+            "role": row.role
+        })
+
+    frappe.db.set_value(
+        "OT Schedule",
+        doc.ot_schedule,
+        "status",
+        "Completed"
+    )
+
+
+def get_preop_notes(doc):
+    if doc.pre_operative_note:
+        return
+
+    pre_operative_note = frappe.get_cached_value(
+        "Preoperative Assessment",
+        {"clinical_procedure": doc.name},
+        "pre_operative_note"
+    )
+
+    if not pre_operative_note:
+        pre_operative_note = frappe.get_cached_value(
+            "Preoperative Assessment",
+            {
+                "patient": doc.patient,
+                "ot_schedule": doc.ot_schedule,
+                "service_name": doc.procedure_template
+            },
+            "pre_operative_note"
+        )
+
+    if not pre_operative_note:
+        return
+
+    doc.pre_operative_note = pre_operative_note
 
 
 def validate_swab_count(doc):
@@ -172,9 +242,12 @@ def get_anesthesia_records(clinical_procedure: str) -> list[dict]:
 @frappe.whitelist()
 def create_anesthesia_record(clinical_procedure: str, **kwargs) -> str:
     """Create an Anesthesia Record from the Clinical Procedure dialog."""
+
     cp = frappe.get_doc("Clinical Procedure", clinical_procedure)
     ar = frappe.new_doc("Anesthesia Record")
     ar.patient = cp.patient
+    ar.appointment = cp.appointment
+    ar.inpatient_record = cp.inpatient_record
     ar.clinical_procedure = clinical_procedure
     ar.ot_schedule = cp.get("ot_schedule") or ""
     ar.company = cp.company
@@ -191,29 +264,103 @@ def create_anesthesia_record(clinical_procedure: str, **kwargs) -> str:
 
     # Parse drugs_text into child table rows
     # Format: "Drug Name, Dosage, Route" — one per line
-    drugs_text = kwargs.get("drugs_text", "")
+    drugs_text = kwargs.get("drugs") or []
     if drugs_text:
-        for line in drugs_text.strip().split("\n"):
-            parts = [p.strip() for p in line.split(",")]
-            if not parts or not parts[0]:
-                continue
-            row = ar.append("drugs_administered", {})
-            # Try to find Medication by name
-            drug_name = parts[0]
-            medication = frappe.db.get_value("Medication", {"drug_name": drug_name})
-            if medication:
-                row.drug = medication
-                row.drug_name = drug_name
-            else:
-                # Try exact match on name
-                if frappe.db.exists("Medication", drug_name):
-                    row.drug = drug_name
-                else:
-                    row.drug_name = drug_name
-            if len(parts) > 1:
-                row.dosage = parts[1]
-            if len(parts) > 2:
-                row.route = parts[2]
+        drugs = json.loads(drugs_text)
+        for drug in drugs:
+            #  = json.loads(drg)
+            ar.append("drugs_administered", {
+                "drug": drug.get("drug"),
+                # "drug_name": drug.get("drug"),
+                "dosage": drug.get("dosage"),
+                "route": drug.get("route"),
+                "administered_time": drug.get("administered_time")
+            })
 
     ar.insert(ignore_permissions=True)
     return ar.name
+
+
+@frappe.whitelist()
+def create_implant_registry(clinical_procedure: str, **kwargs) -> str:
+    """Create an Implant Registry from the Clinical Procedure dialog and submit it."""
+    cp = frappe.get_doc("Clinical Procedure", clinical_procedure)
+    ir = frappe.new_doc("Implant Registry")
+    ir.patient = cp.patient
+    ir.clinical_procedure = clinical_procedure
+    ir.company = cp.company
+
+    simple_fields = [
+        "implant_type", "manufacturer", "lot_number", "serial_number",
+        "anatomical_location", "expiry_date", "implanted_by",
+        "implant_date", "status", "notes",
+    ]
+    for field in simple_fields:
+        if kwargs.get(field):
+            ir.set(field, kwargs[field])
+
+    ir.insert(ignore_permissions=True)
+    ir.submit()
+
+    # Link implant to the clinical procedure
+    frappe.db.set_value(
+        "Clinical Procedure", clinical_procedure, "implant", ir.name
+    )
+
+    return ir.name
+
+
+@frappe.whitelist()
+def create_surgical_specimen(clinical_procedure: str, **kwargs) -> str:
+    """Create a Surgical Specimen from the Clinical Procedure dialog."""
+    cp = frappe.get_doc("Clinical Procedure", clinical_procedure)
+    ss = frappe.new_doc("Surgical Specimen")
+    ss.patient = cp.patient
+    ss.clinical_procedure = clinical_procedure
+    ss.company = cp.company
+
+    simple_fields = [
+        "specimen_type", "anatomical_site", "collection_time",
+        "collected_by", "status", "pathology_notes",
+    ]
+    for field in simple_fields:
+        if kwargs.get(field):
+            ss.set(field, kwargs[field])
+
+    ss.insert(ignore_permissions=True)
+
+    # Link specimen to the clinical procedure
+    frappe.db.set_value(
+        "Clinical Procedure", clinical_procedure, "surgical_specimen", ss.name
+    )
+
+    return ss.name
+
+
+def create_postoperative_recovery(doc):
+    """Auto-create a Postoperative Recovery record when the Clinical Procedure
+    has an inpatient record and is submitted."""
+    # Avoid duplicates
+    if frappe.db.exists("Postoperative Recovery", {"clinical_procedure": doc.name, "docstatus": ["!=", 2]}):
+        return
+
+    pr = frappe.new_doc("Postoperative Recovery")
+    pr.patient = doc.patient
+    pr.clinical_procedure = doc.name
+    pr.company = doc.company
+    pr.ot_schedule = doc.get("ot_schedule") or ""
+    pr.posting_date = frappe.utils.nowdate()
+    pr.admission_time = frappe.utils.now_datetime()
+
+    pr.flags.ignore_permissions = True
+    pr.flags.ignore_mandatory = True
+    pr.insert()
+
+    frappe.msgprint(
+        _("Postoperative Recovery {0} created.").format(
+            frappe.utils.get_link_to_form("Postoperative Recovery", pr.name)
+        ),
+        alert=True,
+        indicator="green",
+    )
+

--- a/hms_tz/patches/custom_fields/custom_fields_json/28_nursing_ot_fields.json
+++ b/hms_tz/patches/custom_fields/custom_fields_json/28_nursing_ot_fields.json
@@ -98,7 +98,6 @@
         "insert_after": "is_group",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Clinical Procedure",
         "fieldname": "tab_intraoperative",
@@ -127,9 +126,17 @@
     },
     {
         "dt": "Clinical Procedure",
+        "fieldname": "estimated_blood_loss",
+        "fieldtype": "Float",
+        "label": "Estimated Blood Loss (ml)",
+        "insert_after": "anesthesia_type",
+        "doctype": "Custom Field"
+    },
+    {
+        "dt": "Clinical Procedure",
         "fieldname": "column_break_intraop",
         "fieldtype": "Column Break",
-        "insert_after": "anesthesia_type",
+        "insert_after": "estimated_blood_loss",
         "doctype": "Custom Field"
     },
     {
@@ -150,41 +157,10 @@
     },
     {
         "dt": "Clinical Procedure",
-        "fieldname": "section_break_ebl",
-        "fieldtype": "Section Break",
-        "insert_after": "closure_time",
-        "doctype": "Custom Field"
-    },
-    {
-        "dt": "Clinical Procedure",
-        "fieldname": "estimated_blood_loss",
-        "fieldtype": "Float",
-        "label": "Estimated Blood Loss (ml)",
-        "insert_after": "section_break_ebl",
-        "doctype": "Custom Field"
-    },
-    {
-        "dt": "Clinical Procedure",
-        "fieldname": "column_break_ebl",
-        "fieldtype": "Column Break",
-        "insert_after": "estimated_blood_loss",
-        "doctype": "Custom Field"
-    },
-    {
-        "dt": "Clinical Procedure",
-        "fieldname": "intraop_notes",
-        "fieldtype": "Text",
-        "label": "Intraoperative Notes",
-        "insert_after": "column_break_ebl",
-        "doctype": "Custom Field"
-    },
-
-    {
-        "dt": "Clinical Procedure",
         "fieldname": "tab_who_checklist",
         "fieldtype": "Tab Break",
         "label": "WHO Safety Checklist",
-        "insert_after": "intraop_notes",
+        "insert_after": "procedure_notes",
         "doctype": "Custom Field"
     },
     {
@@ -227,7 +203,6 @@
         "insert_after": "column_break_who",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Clinical Procedure",
         "fieldname": "section_break_swab",
@@ -283,13 +258,12 @@
         "insert_after": "instrument_count_after",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Clinical Procedure",
         "fieldname": "tab_postop",
         "fieldtype": "Tab Break",
         "label": "Post-Operative",
-        "insert_after": "count_verified",
+        "insert_after": "tab_who_checklist",
         "doctype": "Custom Field"
     },
     {
@@ -324,7 +298,6 @@
         "insert_after": "postop_care_plan",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Clinical Procedure",
         "fieldname": "surgical_specimen",
@@ -341,7 +314,6 @@
         "insert_after": "surgical_specimen",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Clinical Procedure",
         "fieldname": "tab_cp_consumables",
@@ -358,7 +330,6 @@
         "insert_after": "tab_cp_consumables",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Clinical Procedure",
         "fieldname": "tab_cp_charts",
@@ -377,18 +348,10 @@
     },
     {
         "dt": "Clinical Procedure",
-        "fieldname": "record_vital_signs",
-        "fieldtype": "Button",
-        "label": "Record Vital Signs",
-        "insert_after": "section_cp_vital_signs",
-        "doctype": "Custom Field"
-    },
-    {
-        "dt": "Clinical Procedure",
         "fieldname": "cp_vital_signs_html",
         "fieldtype": "HTML",
         "label": "Vital Signs Chart & Summary",
-        "insert_after": "record_vital_signs",
+        "insert_after": "section_cp_vital_signs",
         "doctype": "Custom Field"
     },
     {
@@ -401,21 +364,12 @@
     },
     {
         "dt": "Clinical Procedure",
-        "fieldname": "add_anesthesia",
-        "fieldtype": "Button",
-        "label": "Add Anesthesia",
-        "insert_after": "section_cp_anesthesia",
-        "doctype": "Custom Field"
-    },
-    {
-        "dt": "Clinical Procedure",
         "fieldname": "cp_anesthesia_html",
         "fieldtype": "HTML",
         "label": "Anesthesia Records",
-        "insert_after": "add_anesthesia",
+        "insert_after": "section_cp_anesthesia",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Clinical Procedure",
         "fieldname": "tab_surgical_team",
@@ -433,7 +387,6 @@
         "insert_after": "tab_surgical_team",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Lab Test",
         "fieldname": "tab_lt_consumables",
@@ -450,7 +403,6 @@
         "insert_after": "tab_lt_consumables",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Radiology Examination",
         "fieldname": "tab_re_consumables",
@@ -467,7 +419,6 @@
         "insert_after": "tab_re_consumables",
         "doctype": "Custom Field"
     },
-
     {
         "dt": "Therapy Session",
         "fieldname": "tab_ts_consumables",


### PR DESCRIPTION
hooks.py:
- Register before_save hook for Clinical Procedure to trigger OT Schedule auto-linking and pre-operative notes fetching on every save

Clinical Procedure - Client Script (clinical_procedure.js):
- Add ot_schedule set_query: filter by patient, company, procedure_template
- Remove record_vital_signs and add_anesthesia button handlers (replaced by inline buttons rendered inside HTML sections)
- Add render_cp_implant_specimen_buttons() called on refresh:
  - Renders "Add Implant" button: opens dialog for implant_type, manufacturer, lot_number, serial_number, anatomical_location, expiry_date, implanted_by (Link to Healthcare Practitioner filtered by Active/Doctor/company), implant_date, status, notes; calls create_implant_registry API and auto-submits
  - Renders "Add Specimen" button: opens dialog for specimen_type, anatomical_site, collection_time, collected_by (Link to Healthcare Practitioner filtered by Active/company), status, pathology_notes; calls create_surgical_specimen API
- Refactor render_cp_vital_signs(): move "Record Vital Signs" button from DocType Button field to inline button rendered inside the HTML wrapper, add save-first validation, improve empty-state messaging
- Refactor render_cp_anesthesia_records(): move "Add Anesthesia" button from DocType Button field to inline button rendered inside the HTML wrapper, improve empty-state messaging
- Enhance show_cp_anesthesia_dialog():
  - Add reqd and get_query on anesthetist (filter Active/Doctor/company)
  - Replace drugs_text (Small Text, comma-separated) with drugs (Table) using structured fields: drug (Link to Medication, reqd), dosage (Link to Prescription Dosage, reqd), route (Select: IV/IM/Inhalation/ Oral/Subcutaneous, reqd), administered_time (Time, reqd)
- Fix indentation alignment on approval reference number HTML strings and consumable delivery_note link concatenation

Clinical Procedure - Server APIs (clinical_procedure.py):
- Add before_save hook calling get_ot_schedule() and get_preop_notes()
- get_ot_schedule(): auto-links OT Schedule by matching patient, company, procedure_template; copies surgical_team rows from OT Schedule to Clinical Procedure; updates OT Schedule status to Completed
- get_preop_notes(): fetches pre_operative_note from Preoperative Assessment linked by clinical_procedure name, or by patient + ot_schedule + service_name fallback
- Refactor create_anesthesia_record(): accept drugs as JSON array of objects (drug, dosage, route, administered_time) instead of comma-separated text parsing; set appointment and inpatient_record
- Add create_implant_registry() whitelisted API: creates and submits Implant Registry, then links it back to the Clinical Procedure implant field via frappe.db.set_value
- Add create_surgical_specimen() whitelisted API: creates Surgical Specimen, then links it back to the Clinical Procedure surgical_specimen field via frappe.db.set_value
- Add create_postoperative_recovery(): auto-creates a Postoperative Recovery draft on Clinical Procedure submission when inpatient_record exists; sets patient, company, ot_schedule, posting_date, admission_time; avoids duplicates; shows alert with link
- Call create_postoperative_recovery from on_submit when inpatient_record is present

Migration - Custom Fields (28_nursing_ot_fields.json):
- Move estimated_blood_loss from separate section to inline after anesthesia_type in the Intraoperative tab
- Remove redundant fields: section_break_ebl, column_break_ebl, intraop_notes (intraop notes covered by existing procedure_notes)
- Remove Button-type custom fields: record_vital_signs, add_anesthesia (replaced by inline buttons in HTML sections)
- Fix insert_after ordering: cp_vital_signs_html after section, cp_anesthesia_html after section, tab_who_checklist after procedure_notes, tab_postop after tab_who_checklist
- Remove blank lines between JSON entries for cleaner formatting