### PR TITLE
refactor: rename "NHIF EmployerName" label to "EmployerName"

### DIFF
--- a/hms_tz/hms_tz/doctype/healthcare_insurance_coverage_plan/healthcare_insurance_coverage_plan.json
+++ b/hms_tz/hms_tz/doctype/healthcare_insurance_coverage_plan/healthcare_insurance_coverage_plan.json
@@ -75,7 +75,7 @@
   {
    "fieldname": "nhif_employername",
    "fieldtype": "Data",
-   "label": "NHIF EmployerName"
+   "label": "EmployerName"
   },
   {
    "fieldname": "amended_from",

--- a/hms_tz/hms_tz/doctype/patient/patient.json
+++ b/hms_tz/hms_tz/doctype/patient/patient.json
@@ -436,7 +436,7 @@
    "options": "Triage"
   },
   {
-    "label": "NHIF EmployerName",
+    "label": "EmployerName",
     "fieldname": "nhif_employername",
     "fieldtype": "Data",
     "read_only": 1


### PR DESCRIPTION
The `nhif_employername` field label was previously "NHIF EmployerName", tying it to a specific insurance provider. Since this field is now also used for Jubilee (and potentially other insurers), the label is renamed to the generic "EmployerName" to accurately reflect its broader usage.

Updated in:
- Healthcare Insurance Coverage Plan DocType
- Patient DocType