### PR TITLE
feat: integrate Jubilee insurance authorization into Patient Appointment

### DIFF
--- a/hms_tz/jubilee/api/api.py
+++ b/hms_tz/jubilee/api/api.py
@@ -202,8 +202,11 @@ def get_authorization_number(
             card_no=card_no,
             authorization_no=data.get("AuthorizationNo", ""),
         )
-        if data.get("AuthorizationNo") and "OK" not in data.get("Status"):
+        if not data.get("AuthorizationNo"):
             frappe.throw(title=data.get("Status"), msg=data["Description"])
+
+        elif data.get("AuthorizationNo") and "OK" not in data.get("Status"):
+            frappe.msgprint(title=data.get("Status"), msg=data["Description"])
 
         frappe.msgprint(_(data["Description"]), alert=True)
         return data

--- a/hms_tz/nhif/api/patient_appointment.js
+++ b/hms_tz/nhif/api/patient_appointment.js
@@ -338,32 +338,11 @@ frappe.ui.form.on("Patient Appointment", {
       frappe.msgprint("Appointment is already cancelled");
       return;
     }
-    if (!frm.doc.insurance_company.includes("NHIF")) {
-      frappe.show_alert(
-        {
-          message: __("This feature is not applicable for non NHIF insurance"),
-          indicator: "orange",
-        },
-        5
-      );
-      return;
-    }
+
     if (!frm.doc.insurance_subscription) {
       frappe.msgprint(
         "Select Insurance Subscription to get authorization number"
       );
-      return;
-    }
-    if (!frm.doc.biometric_method) {
-      frappe.msgprint("Please select a Biometric Method");
-      return;
-    } else if (frm.doc.biometric_method == "NONE" && !frm.doc.remarks) {
-      frappe.msgprint({
-        title: __("Remarks Missing"),
-        message: __(
-          "Please provide remarks for the selected Biometric Method"
-        ),
-      });
       return;
     }
 
@@ -371,9 +350,37 @@ frappe.ui.form.on("Patient Appointment", {
       frm.save();
     }
 
-    frm.trigger("authorize_patient");
+    if (frm.doc.insurance_company.includes("NHIF")) {
+      if (!frm.doc.biometric_method) {
+        frappe.msgprint("Please select a Biometric Method");
+        return;
+      } else if (frm.doc.biometric_method == "NONE" && !frm.doc.remarks) {
+        frappe.msgprint({
+          title: __("Remarks Missing"),
+          message: __(
+            "Please provide remarks for the selected Biometric Method"
+          ),
+        });
+        return;
+      }
+
+      frm.trigger("authorize_nhif_patient");
+    } else if (frm.doc.insurance_company.includes("Jubilee")) {
+      frm.trigger("authorize_jubilee_patient");
+    } else {
+      frappe.show_alert(
+        {
+          message: __(
+            "This feature is applicable for NHIF and Jubilee insurance only"
+          ),
+          indicator: "orange",
+        },
+        10
+      );
+      return;
+    }
   },
-  authorize_patient: async (frm) => {
+  authorize_nhif_patient: async (frm) => {
     try {
       let biometricData;
 
@@ -481,6 +488,45 @@ frappe.ui.form.on("Patient Appointment", {
         );
       }
     }
+  },
+  authorize_jubilee_patient: async (frm) => {
+    frappe.call({
+      method: "hms_tz.jubilee.api.api.get_authorization_number",
+      args: {
+        company: frm.doc.company,
+        card_no: frm.doc.coverage_plan_card_number || "",
+        appointment_no: frm.doc.name,
+        insurance_subscription: frm.doc.insurance_subscription,
+        insurance_provider: "Jubilee",
+      },
+      async: true,
+      freeze: true,
+      freeze_message: __('<i class="fa fa-spinner fa-spin fa-4x"></i>'),
+      callback: (data) => {
+        if (data.message && data.message !== "Error") {
+          frappe.utils.play_sound("submit");
+          const result = data.message;
+          if (result.AuthorizationNo) {
+            frm.set_value("authorization_number", result.AuthorizationNo);
+            frm.save().then(() => {
+              frm.reload_doc();
+            });
+            frappe.show_alert(
+              {
+                message: __("Authorization Number is updated"),
+                indicator: "green",
+              },
+              5
+            );
+          }
+        } else {
+          frappe.utils.play_sound("error");
+        }
+      },
+      onerror: function () {
+        frappe.utils.play_sound("error");
+      },
+    });
   },
   get_patient_details_from_nhif: (frm) => {
     if (!frm.doc.insurance_company.includes("NHIF")) {


### PR DESCRIPTION
**patient_appointment.js:**
- Refactor `get_authorization_number` handler to dispatch by insurance
  provider: NHIF-specific biometric validation is now scoped under an
  `insurance_company.includes("NHIF")` branch, while Jubilee triggers
  a separate `authorize_jubilee_patient` handler.
- Rename `authorize_patient` to `authorize_nhif_patient` to clearly
  distinguish it from the new Jubilee flow.
- Add `authorize_jubilee_patient` handler that calls
  `hms_tz.jubilee.api.api.get_authorization_number` via frappe.call,
  sets the `authorization_number` field from the response's
  `AuthorizationNo`, saves, and reloads the form.
- Update unsupported-provider message from "not applicable for non
  NHIF insurance" to "applicable for NHIF and Jubilee insurance only".
  
**api.py (Jubilee):**
- Fix `get_authorization_number` error handling: if `AuthorizationNo`
  is missing from the response, throw an error (previously only threw
  when AuthorizationNo was present but status was not OK).
- Downgrade the existing non-OK status case from `frappe.throw` to
  `frappe.msgprint` when an AuthorizationNo is still returned, so the
  authorization number can still be captured by the client.