### PR TITLE
feat(jubilee): implement procedure list sync from Jubilee API

### DIFF
--- a/hms_tz/hooks.py
+++ b/hms_tz/hooks.py
@@ -287,6 +287,7 @@ scheduler_events = {
             "hms_tz.nhif.nhif_api.admission.get_room_types",
             "hms_tz.nhif.nhif_api.facility.get_facilities",
             "hms_tz.nhif.nhif_api.approval.get_approval_services",
+            "hms_tz.jubilee.api.api.get_procedure_list",
         ],
     },
     # 	"hourly": [

--- a/hms_tz/jubilee/api/api.py
+++ b/hms_tz/jubilee/api/api.py
@@ -4,6 +4,7 @@ import frappe
 import requests
 from erpnext import get_default_company
 from frappe import _
+from frappe.utils import now_datetime
 
 from hms_tz.jubilee.doctype.jubilee_response_log.jubilee_response_log import add_jubilee_log
 
@@ -211,3 +212,133 @@ def get_authorization_number(
         frappe.msgprint(_(data["Description"]), alert=True)
         return data
 
+
+@frappe.whitelist()
+def enqueue_get_jubilee_procedures(company: str):
+
+    frappe.enqueue(
+        method="hms_tz.jubilee.api.api.get_procedure_list",
+        company=company,
+        queue='default',
+        at_front=True,
+    )
+    frappe.msgprint(_("Procedure list will be synced in the background"), alert=True)
+    return
+
+def get_procedure_list(company: str | None = None):
+    """Fetch procedure list from Jubilee API and sync to Jubilee Procedure DocType."""
+
+    if not company:
+        company = get_default_company()
+
+    if not company:
+        company = frappe.defaults.get_user_default("Company")
+
+    if not company:
+        hms_tz_records = frappe.get_list(
+            "HMS TZ Setting",
+            fields=["company"],
+            filters={"enable_jubilee_api": 1},
+            limit=1,
+        )
+        if len(hms_tz_records) > 0:
+            company = hms_tz_records[0].company
+
+    if not company:
+        frappe.throw(_("No companies found to connect to Jubilee"))
+
+    setting_doc = frappe.get_cached_doc("HMS TZ Setting", company)
+
+    if not setting_doc.enable_jubilee_api:
+        frappe.throw(
+            _(f"HMS TZ Setting for company: {company} does not have Jubilee API enabled.")
+        )
+
+    token = setting_doc.get_jubilee_token()
+    headers = {"Authorization": "Bearer " + token}
+    url = f"{setting_doc.jubilee_url}/jubileeapi/GetProcedureList"
+
+    r = requests.get(url, headers=headers, timeout=60)
+
+    data = json.loads(r.text) if r.text else {}
+
+    if r.status_code != 200 or data.get("Status") != "OK":
+        add_jubilee_log(
+            request_type="GetProcedureList",
+            request_url=url,
+            request_header=headers,
+            response_data=data,
+            status_code=r.status_code,
+            company=company,
+            ref_doctype="Jubilee Procedure",
+        )
+        frappe.throw(
+            title="Jubilee API Error",
+            msg=_(
+                f"Failed to fetch procedure list<br><br>"
+                f"Status Code: {r.status_code}<br>"
+                f"Jubilee Response: <b>{data.get('Description')}</b>"
+            ),
+        )
+
+    add_jubilee_log(
+        request_type="GetProcedureList",
+        request_url=url,
+        request_header=headers,
+        response_data=data,
+        status_code=r.status_code,
+        company=company,
+        ref_doctype="Jubilee Procedure",
+    )
+
+    procedures = data.get("Description", [])
+    if procedures:
+        _sync_procedures(procedures, company)
+
+    frappe.msgprint(
+        _(f"Successfully synced {len(procedures)} procedures from Jubilee"),
+        alert=True,
+    )
+
+    return data
+
+
+def _sync_procedures(procedures: list[dict], company: str):
+    """Delete existing Jubilee Procedure records for the company and bulk-insert fresh data."""
+
+    frappe.db.delete("Jubilee Procedure", filters={"disabled": 0})
+
+    fields = [
+        "name",
+        "procedure_code",
+        "procedure_name",
+        "creation",
+        "owner",
+        "modified",
+        "modified_by",
+    ]
+    values = []
+
+    user = frappe.session.user
+    timestamp = now_datetime()
+
+    for row in procedures:
+        values.append(
+            (
+                row.get("ProcedureCode"),
+                row.get("ProcedureCode"),
+                row.get("ProcedureName"),
+                timestamp,
+                user,
+                timestamp,
+                user,
+            )
+        )
+
+    if values:
+        frappe.db.bulk_insert(
+            "Jubilee Procedure",
+            fields=fields,
+            values=values,
+            ignore_duplicates=True,
+        )

--- a/hms_tz/nhif/api/insurance_company.js
+++ b/hms_tz/nhif/api/insurance_company.js
@@ -1,9 +1,11 @@
 frappe.ui.form.on("Healthcare Insurance Company", {
   onload: function (frm) {
     add_nhif_actions_btn(frm);
+    add_jubilee_actions_btn(frm);
   },
   refresh: function (frm) {
     add_nhif_actions_btn(frm);
+    add_jubilee_actions_btn(frm);
   },
 });
 
@@ -339,5 +341,28 @@ var add_nhif_actions_btn = function (frm) {
       });
     },
     __("NHIF Actions")
+  );
+};
+
+var add_jubilee_actions_btn = (frm) => {
+  if (!frm.doc.insurance_company_name.includes("Jubilee")) {
+    return;
+  }
+
+  frm.add_custom_button(
+    __("Get Jubilee Procedures"),
+    function () {
+      frappe.call({
+        method: "hms_tz.jubilee.api.api.enqueue_get_jubilee_procedures",
+        args: {
+          company: frm.doc.company,
+          caller: "Front End",
+        },
+        freeze: true,
+        freeze_message: __('<i class="fa fa-spinner fa-spin fa-4x"></i>'),
+        callback: (data) => {},
+      });
+    },
+    __("Jubilee Actions")
   );
 };


### PR DESCRIPTION
Add server-side logic to fetch and bulk-sync the procedure catalogue from the Jubilee insurance API, with a UI trigger on Healthcare Insurance Company and daily scheduler automation.

API layer (api.py):
- Add enqueue_get_jubilee_procedures() whitelisted endpoint that dispatches get_procedure_list() to a background job via frappe.enqueue (default queue, at_front=True)
- Add get_procedure_list() that authenticates via HMS TZ Setting, calls GET /jubileeapi/GetProcedureList, logs both success and failure responses via add_jubilee_log, and delegates to _sync_procedures() on success
- Add _sync_procedures() helper that performs a delete-and-bulk-insert strategy: deletes all non-disabled Jubilee Procedure records, then uses frappe.db.bulk_insert with ignore_duplicates=True for idempotent re-population; disabled records are preserved across syncs
- Import now_datetime from frappe.utils for bulk_insert timestamp fields (creation, modified)

Client script (insurance_company.js):
- Add add_jubilee_actions_btn() function that conditionally renders a "Get Jubilee Procedures" button under a "Jubilee Actions" group on Healthcare Insurance Company forms where the company name contains "Jubilee"
- The button calls enqueue_get_jubilee_procedures via frappe.call with a freeze spinner, triggering the background sync
- Wire the new button into both onload and refresh events alongside the existing NHIF actions

Scheduler (hooks.py):
- Register get_procedure_list in the daily scheduler_events so the procedure catalogue is automatically refreshed every day, alongside existing NHIF daily sync jobs (room types, facilities, approvals)

Files modified:
- hms_tz/jubilee/api/api.py
- hms_tz/nhif/api/insurance_company.js
- hms_tz/hooks.py