### PR TITLE
feat(jubilee): refactor HSIC coverage to match against price packages

### DIFF
--- a/hms_tz/jubilee/api/price_package.py
+++ b/hms_tz/jubilee/api/price_package.py
@@ -332,32 +332,38 @@ def process_jubilee_coverages(company, coverage_plan=None):
 
     jubilee_customer = frappe.get_cached_value("HMS TZ Setting", company, "jubilee_customer_name")
     service_map = get_insurance_items(jubilee_customer)
-    services = service_map.values()
+    price_packages = get_price_packages(company)
 
     for plan in coverage_plan_list:
         has_data = False
-        for svc in services:
-            hsic_name = frappe.generate_hash(length=10)
 
-            row = (
-                hsic_name,
-                now_datetime(),
-                frappe.session.user,
-                now_datetime(),
-                frappe.session.user,
-                svc.get("service_type"),
-                svc.get("service_name"),
-                1,
-                plan.get("name"),
-                company,
-                1,
-                nowdate(),
-                "2099-12-31",
-            )
-            hsic_data.append(row)
+        for package in price_packages:
+            if not service_map.get(package.get("itemcode")):
+                continue
 
-            if not has_data and row:
-                has_data = True
+            services = service_map.get(package.get("itemcode"))
+            for svc in services:
+                hsic_name = frappe.generate_hash(length=10)
+
+                row = (
+                    hsic_name,
+                    now_datetime(),
+                    frappe.session.user,
+                    now_datetime(),
+                    frappe.session.user,
+                    svc.get("service_type"),
+                    svc.get("service_name"),
+                    1,
+                    plan.get("name"),
+                    company,
+                    1,
+                    nowdate(),
+                    "2099-12-31",
+                )
+                hsic_data.append(row)
+
+                if not has_data and row:
+                    has_data = True
 
         if has_data:
             plans_for_deletion.append(plan.name)
@@ -371,7 +377,6 @@ def process_jubilee_coverages(company, coverage_plan=None):
         values=hsic_data,
         ignore_duplicates=True,
     )
-    frappe.db.commit()
     return True
 
 
@@ -383,3 +388,23 @@ def _parse_response_data(data: str) -> dict:
         return json.loads(data)
     except json.JSONDecodeError:
         return ast.literal_eval(data)
+
+
+def get_price_packages(company):
+    jpp = DocType("Jubilee Price Package")
+    price_packages = (
+        frappe.qb.from_(jpp)
+        .select(
+            jpp.itemcode,
+            jpp.itemprice,
+            jpp.itemname,
+            jpp.cleanname,
+            jpp.strength,
+            jpp.dosage
+        )
+        .where(
+            (jpp.company == company)
+        )
+    ).run(as_dict=True)
+
+    return price_packages

--- a/hms_tz/nhif/api/insurance_company.js
+++ b/hms_tz/nhif/api/insurance_company.js
@@ -365,6 +365,20 @@ var add_jubilee_actions_btn = (frm) => {
   );
 
   frm.add_custom_button(
+    __("Process Jubilee Records"),
+    () => {
+      frappe.call({
+        method: "hms_tz.jubilee.api.price_package.process_jubilee_records",
+        args: { company: frm.doc.company },
+        freeze: true,
+        freeze_message: __('<i class="fa fa-spinner fa-spin fa-4x"></i>'),
+        callback: (data) => {},
+      });
+    },
+    __("Jubilee Actions")
+  );
+
+  frm.add_custom_button(
     __("Get Jubilee Procedures"),
     () => {
       frappe.call({


### PR DESCRIPTION
Rewrite the HSIC record generation in process_jubilee_coverages to iterate over Jubilee Price Package records and cross-reference them against the service_map, instead of iterating directly over service_map values. This ensures HSIC records are only created for services that have a corresponding Jubilee Price Package entry (matched by itemcode), aligning coverage records with actual insurer-priced items.

Changes in price_package.py:
- Replace direct iteration over service_map.values() with a package-first loop that checks service_map.get(package.itemcode), skipping packages without a local service mapping via continue
- Extract get_price_packages() helper to query all Jubilee Price Package records for a given company (renamed from get_price_package_map for clarity)
- Remove explicit frappe.db.commit() call after bulk_insert, relying on Frappe implicit transaction handling for background jobs

Changes in insurance_company.js:
- Add Process Jubilee Records button under the Jubilee Actions dropdown on Healthcare Insurance Company form, calling hms_tz.jubilee.api.price_package.process_jubilee_records to trigger Item Price and HSIC generation as background jobs
- Minor formatting: normalize empty callback arrow functions