### PR TITLE
feat(jubilee): add Jubilee Procedure custom field on Patient Encounter

### DIFF
--- a/hms_tz/patches/custom_fields/custom_fields_json/29_jubilee_fields.json
+++ b/hms_tz/patches/custom_fields/custom_fields_json/29_jubilee_fields.json
@@ -1,0 +1,13 @@
+[
+    {
+        "dt": "Patient Encounter",
+        "fieldname": "jubilee_procedure",
+        "fieldtype": "Link",
+        "label": "Jubilee Procedure",
+        "options": "Jubilee Procedure",
+        "insert_after": "main_diagnosis_code",
+        "bold": 1,
+        "depends_on": "eval: doc.insurance_company && doc.insurance_company.includes('Jubilee')",
+        "doctype": "Custom Field"
+    }
+]


### PR DESCRIPTION
Add custom field definition for jubilee_procedure on the Patient Encounter DocType via the after_migrate patch system.

Field definition (29_jubilee_fields.json):
- fieldname: jubilee_procedure
- fieldtype: Link → Jubilee Procedure
- insert_after: main_diagnosis_code
- bold: true for visual emphasis
- depends_on: conditionally visible only when insurance_company contains Jubilee

This field allows practitioners to select the Jubilee procedure code required by the VerifyItems API payload (ProcedureId parameter) before verifying services on a Jubilee-insured patient encounter.