### PR TITLE
feat(jubilee): add Jubilee Service Request Disease child DocType

### DIFF
--- a/hms_tz/jubilee/doctype/jubilee_service_request_disease/__init__.py
+++ b/hms_tz/jubilee/doctype/jubilee_service_request_disease/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt

--- a/hms_tz/jubilee/doctype/jubilee_service_request_disease/jubilee_service_request_disease.json
+++ b/hms_tz/jubilee/doctype/jubilee_service_request_disease/jubilee_service_request_disease.json
@@ -1,0 +1,96 @@
+{
+ "actions": [],
+ "creation": "2025-04-27 10:00:00.000000",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "status",
+  "medical_code",
+  "disease_code",
+  "description",
+  "column_break_disease",
+  "patient_encounter",
+  "codification_table",
+  "created_by",
+  "date_created"
+ ],
+ "fields": [
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Provisional\nFinal"
+  },
+  {
+   "fieldname": "medical_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Medical Code",
+   "options": "Code Value"
+  },
+  {
+   "fetch_from": "medical_code.code_value",
+   "fetch_if_empty": 1,
+   "fieldname": "disease_code",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Disease Code"
+  },
+  {
+   "fetch_from": "medical_code.definition",
+   "fieldname": "description",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Description",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_disease",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "patient_encounter",
+   "fieldtype": "Link",
+   "label": "Patient Encounter",
+   "options": "Patient Encounter",
+   "read_only": 1
+  },
+  {
+   "fieldname": "codification_table",
+   "fieldtype": "Link",
+   "label": "Codification Table",
+   "options": "Codification Table",
+   "read_only": 1
+  },
+  {
+   "fieldname": "created_by",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Created By",
+   "read_only": 1
+  },
+  {
+   "fieldname": "date_created",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date Created"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-04-27 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jubilee",
+ "name": "Jubilee Service Request Disease",
+ "owner": "Administrator",
+ "permissions": [],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/jubilee/doctype/jubilee_service_request_disease/jubilee_service_request_disease.py
+++ b/hms_tz/jubilee/doctype/jubilee_service_request_disease/jubilee_service_request_disease.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class JubileeServiceRequestDisease(Document):
+	pass


### PR DESCRIPTION
Add a new child table DocType to store disease/diagnosis entries for Jubilee Service Request pre-authorization payloads.

Fields:
- status: Select (Provisional/Final) — diagnosis certainty level
- medical_code: Link to Code Value — ICD code reference
- disease_code: Data, fetched from medical_code.code_value
- description: Data (read-only), fetched from medical_code.definition
- patient_encounter: Link to Patient Encounter (read-only) — source reference
- codification_table: Link to Codification Table (read-only) — source reference
- created_by: Data (read-only) — user who created the entry
- date_created: Date — entry creation date

Configuration:
- Module: Jubilee
- istable: True (child table, used in Jubilee Service Request)
- editable_grid: True (inline editing in parent form)
- quick_entry: True
- track_changes: True