### PR TITLE
feat(jubilee): add Jubilee Service Request Item child DocType

### DIFF
--- a/hms_tz/jubilee/doctype/jubilee_service_request_item/__init__.py
+++ b/hms_tz/jubilee/doctype/jubilee_service_request_item/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt

--- a/hms_tz/jubilee/doctype/jubilee_service_request_item/jubilee_service_request_item.json
+++ b/hms_tz/jubilee/doctype/jubilee_service_request_item/jubilee_service_request_item.json
@@ -1,0 +1,108 @@
+{
+ "actions": [],
+ "creation": "2025-04-27 10:00:00.000000",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "item_name",
+  "item_code",
+  "item_quantity",
+  "unit_price",
+  "amount_claimed",
+  "column_break_item",
+  "ref_doctype",
+  "ref_docname",
+  "patient_encounter",
+  "created_by",
+  "date_created"
+ ],
+ "fields": [
+  {
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Item Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Item Code",
+   "read_only": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "item_quantity",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Quantity"
+  },
+  {
+   "fieldname": "unit_price",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Unit Price",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount_claimed",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount Claimed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_item",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "ref_doctype",
+   "fieldtype": "Link",
+   "label": "Ref DocType",
+   "options": "DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "ref_docname",
+   "fieldtype": "Data",
+   "label": "Ref Docname",
+   "read_only": 1
+  },
+  {
+   "fieldname": "patient_encounter",
+   "fieldtype": "Link",
+   "label": "Patient Encounter",
+   "options": "Patient Encounter",
+   "read_only": 1
+  },
+  {
+   "fieldname": "created_by",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Created By",
+   "read_only": 1
+  },
+  {
+   "fieldname": "date_created",
+   "fieldtype": "Date",
+   "label": "Date Created"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-04-27 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jubilee",
+ "name": "Jubilee Service Request Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/hms_tz/jubilee/doctype/jubilee_service_request_item/jubilee_service_request_item.py
+++ b/hms_tz/jubilee/doctype/jubilee_service_request_item/jubilee_service_request_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class JubileeServiceRequestItem(Document):
+	pass


### PR DESCRIPTION
Add a new child table DocType to store the billable services and items included in a Jubilee Service Request payload for pre-authorization.

Fields included:
- item_name: Data (read-only) — name of the service/item
- item_code: Data (read-only) — internal item code mapping
- item_quantity: Int (default: 1) — quantity of the service/item
- unit_price: Currency (read-only) — individual price of the item
- amount_claimed: Currency (read-only) — total amount for the item
- ref_doctype: Link to DocType (read-only) — source document type (e.g. Clinical Procedure)
- ref_docname: Data (read-only) — source document ID
- patient_encounter: Link to Patient Encounter (read-only) — overarching encounter
- created_by: Data (read-only) — practitioner/user who added the item
- date_created: Date — timestamp of entry

Configuration:
- Module: Jubilee
- istable: True (child table for Jubilee Service Request)
- editable_grid: True (inline editing support)
- quick_entry: True
- track_changes: True