### PR TITLE
feat(jubilee): add Jubilee Service Request DocType for pre-authorization

### DIFF
--- a/hms_tz/jubilee/doctype/jubilee_service_request/__init__.py
+++ b/hms_tz/jubilee/doctype/jubilee_service_request/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt

--- a/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.js
+++ b/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2025, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Jubilee Service Request", {
+  refresh: function (frm) {
+    // Show status indicator on the dashboard
+    if (frm.doc.preauth_status === "OK") {
+      frm.dashboard.set_headline(
+        __(
+          '<span class="indicator whitespace-nowrap green">' +
+            "Pre-Authorization Submitted Successfully — Submission ID: " +
+            frm.doc.submission_id +
+            "</span>"
+        )
+      );
+    } else if (frm.doc.preauth_status === "ERROR") {
+      frm.dashboard.set_headline(
+        __(
+          '<span class="indicator whitespace-nowrap red">' +
+            "Pre-Authorization Failed: " +
+            frm.doc.preauth_description +
+            "</span>"
+        )
+      );
+    }
+  },
+});

--- a/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.json
+++ b/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.json
@@ -1,0 +1,456 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2025-04-27 10:00:00",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "patient_encounter",
+  "appointment",
+  "inpatient_record",
+  "column_break_main",
+  "patient",
+  "patient_name",
+  "patient_type_code",
+  "column_break_xdpg",
+  "company",
+  "posting_date",
+  "posting_time",
+  "sec_procedure",
+  "jubilee_procedure",
+  "procedure_name",
+  "practitioner_no",
+  "column_break_service",
+  "jubilee_benefit",
+  "benefit_code",
+  "benefit_name",
+  "column_break_blqc",
+  "total_amount",
+  "benefit_balance",
+  "section_response",
+  "submission_id",
+  "preauth_status",
+  "column_break_response",
+  "preauth_description",
+  "column_break_tpgb",
+  "naming_series",
+  "amended_from",
+  "patient_details_tab",
+  "section_patient_details",
+  "first_name",
+  "last_name",
+  "gender",
+  "column_break_patient",
+  "date_of_birth",
+  "card_no",
+  "authorization_no",
+  "column_break_szub",
+  "telephone_no",
+  "attendance_date",
+  "admitted_date",
+  "discharge_date",
+  "section_break_eajs",
+  "claim_month",
+  "claim_year",
+  "column_break_ofmb",
+  "bill_no",
+  "provider_id",
+  "diseases_tab",
+  "section_diseases",
+  "diseases",
+  "items_tab",
+  "section_items",
+  "items"
+ ],
+ "fields": [
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "JSR-.YYYY.-.####",
+   "reqd": 1
+  },
+  {
+   "fieldname": "patient_encounter",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient Encounter",
+   "options": "Patient Encounter",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient_encounter.appointment",
+   "fieldname": "appointment",
+   "fieldtype": "Link",
+   "label": "Patient Appointment",
+   "options": "Patient Appointment",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "patient_encounter.patient",
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Patient",
+   "options": "Patient",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "patient_encounter.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "patient_encounter.company",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "read_only": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date"
+  },
+  {
+   "fieldname": "posting_time",
+   "fieldtype": "Time",
+   "label": "Posting Time"
+  },
+  {
+   "default": "OP",
+   "fieldname": "patient_type_code",
+   "fieldtype": "Select",
+   "label": "Patient Type Code",
+   "options": "OP\nIN"
+  },
+  {
+   "fieldname": "section_patient_details",
+   "fieldtype": "Section Break",
+   "label": "Patient Details"
+  },
+  {
+   "fieldname": "first_name",
+   "fieldtype": "Data",
+   "label": "First Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_name",
+   "fieldtype": "Data",
+   "label": "Last Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "gender",
+   "fieldtype": "Data",
+   "label": "Gender",
+   "read_only": 1
+  },
+  {
+   "fieldname": "date_of_birth",
+   "fieldtype": "Date",
+   "label": "Date of Birth",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_patient",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "telephone_no",
+   "fieldtype": "Data",
+   "label": "Telephone No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "card_no",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Card No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "authorization_no",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Authorization No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "attendance_date",
+   "fieldtype": "Datetime",
+   "label": "Attendance Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "jubilee_procedure",
+   "fieldtype": "Link",
+   "label": "Jubilee Procedure",
+   "options": "Jubilee Procedure"
+  },
+  {
+   "fetch_from": "jubilee_benefit.benefit_code",
+   "fetch_if_empty": 1,
+   "fieldname": "benefit_code",
+   "fieldtype": "Data",
+   "label": "Benefit Code",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "jubilee_benefit.benefit_name",
+   "fetch_if_empty": 1,
+   "fieldname": "benefit_name",
+   "fieldtype": "Data",
+   "label": "Benefit Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_service",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "practitioner_no",
+   "fieldtype": "Data",
+   "label": "Practitioner No (MCT Code)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "provider_id",
+   "fieldtype": "Data",
+   "label": "Provider ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_amount",
+   "fieldtype": "Currency",
+   "label": "Total Amount",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_diseases",
+   "fieldtype": "Section Break",
+   "label": "Diseases"
+  },
+  {
+   "fieldname": "diseases",
+   "fieldtype": "Table",
+   "label": "Diseases",
+   "options": "Jubilee Service Request Disease"
+  },
+  {
+   "fieldname": "section_items",
+   "fieldtype": "Section Break",
+   "label": "Items"
+  },
+  {
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "options": "Jubilee Service Request Item"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_response",
+   "fieldtype": "Section Break",
+   "label": "Pre-Authorization Response"
+  },
+  {
+   "fieldname": "submission_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Submission ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "preauth_status",
+   "fieldtype": "Data",
+   "in_standard_filter": 1,
+   "label": "Pre-Auth Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_response",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "preauth_description",
+   "fieldtype": "Small Text",
+   "label": "Pre-Auth Description",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Jubilee Service Request",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_xdpg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_blqc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_tpgb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "patient_details_tab",
+   "fieldtype": "Tab Break",
+   "label": "Patient Details"
+  },
+  {
+   "fieldname": "items_tab",
+   "fieldtype": "Tab Break",
+   "label": "Items"
+  },
+  {
+   "fieldname": "diseases_tab",
+   "fieldtype": "Tab Break",
+   "label": "Diseases"
+  },
+  {
+   "fetch_from": "jubilee_benefit.benefit_balance",
+   "fetch_if_empty": 1,
+   "fieldname": "benefit_balance",
+   "fieldtype": "Data",
+   "label": "Benefit Balance",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_szub",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "claim_year",
+   "fieldtype": "Int",
+   "label": "Claim Year",
+   "read_only": 1
+  },
+  {
+   "fieldname": "claim_month",
+   "fieldtype": "Int",
+   "label": "Claim Month",
+   "read_only": 1
+  },
+  {
+   "fieldname": "admitted_date",
+   "fieldtype": "Datetime",
+   "label": "Admitted Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "discharge_date",
+   "fieldtype": "Datetime",
+   "label": "Discharge Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "inpatient_record",
+   "fieldtype": "Link",
+   "label": "Inpatient Record",
+   "options": "Inpatient Record",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.docstatus == 0;",
+   "fieldname": "jubilee_benefit",
+   "fieldtype": "Link",
+   "label": "Jubilee Benefit",
+   "options": "Jubilee Benefit"
+  },
+  {
+   "fetch_from": "jubilee_procedure.procedure_name",
+   "fieldname": "procedure_name",
+   "fieldtype": "Data",
+   "label": "Procedure Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sec_procedure",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_eajs",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_ofmb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "bill_no",
+   "fieldtype": "Data",
+   "label": "Bill No",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-04-27 15:31:04.360510",
+ "modified_by": "Administrator",
+ "module": "Jubilee",
+ "name": "Jubilee Service Request",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Healthcare Administrator",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Physician",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "patient_name",
+ "track_changes": 1
+}

--- a/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.py
+++ b/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt
+
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.query_builder import DocType
+from frappe.utils import get_datetime, get_fullname, get_time, getdate, nowdate, nowtime
+
+from hms_tz.hms_tz.doctype.healthcare_service_request.healthcare_service_request import (
+    get_childs_map,
+    get_item_rate,
+    get_item_refcode,
+)
+from hms_tz.jubilee.api.api import send_preauthorization
+
+ct = DocType("Codification Table")
+pe = DocType("Patient Encounter")
+
+
+class JubileeServiceRequest(Document):
+    def before_save(self):
+        """Auto-populate fields from Patient Encounter for manual creation (Path B)."""
+
+        self.set_missing_values()
+
+    def before_submit(self):
+        """Send the pre-authorization request to Jubilee API on submit."""
+        result = send_preauthorization(self.name)
+        self.preauth_status = result.get("status") or ""
+        self.preauth_description = result.get("description") or ""
+        self.submission_id = result.get("submission_id") or ""
+
+    def set_missing_values(self):
+        """Pull patient demographics, diseases, and items from the linked encounter."""
+        if not self.patient_encounter:
+            frappe.throw(_("Patient Encounter is required"))
+
+        encounter = frappe.get_doc("Patient Encounter", self.patient_encounter)
+
+        self.appointment = encounter.appointment
+        self.patient = encounter.patient
+        self.patient_name = encounter.patient_name
+        self.company = encounter.company
+
+        patient_doc = frappe.get_cached_doc("Patient", encounter.patient)
+        self.first_name = patient_doc.first_name
+        self.last_name = patient_doc.last_name or ""
+        self.gender = patient_doc.sex
+        self.date_of_birth = patient_doc.dob
+        self.telephone_no = patient_doc.mobile or ""
+        self.inpatient_record = patient_doc.inpatient_record
+
+        if encounter.appointment:
+            appt = frappe.get_cached_doc("Patient Appointment", encounter.appointment)
+            self.card_no = appt.coverage_plan_card_number or ""
+            self.authorization_no = appt.authorization_number or ""
+            self.attendance_date = f"{appt.appointment_date} {appt.appointment_time or '00:00:00'}"
+
+        if encounter.practitioner:
+            mct_code = frappe.db.get_value(
+                "Healthcare Practitioner", encounter.practitioner, "tz_mct_code"
+            )
+            self.practitioner_no = mct_code or ""
+
+        self.jubilee_procedure = encounter.get("jubilee_procedure") or ""
+
+        self.provider_id = frappe.get_cached_value(
+            "HMS TZ Setting", self.company, "jubilee_provider_id"
+        ) or ""
+
+        if not self.posting_date:
+            self.posting_date = nowdate()
+        if not self.posting_time:
+            self.posting_time = nowtime()
+
+        posting = getdate(self.posting_date)
+        self.claim_year = posting.year
+        self.claim_month = posting.month
+
+        self.bill_no = "".join(self.name.split("-")[1:])
+
+        self.set_diseases()
+        self.set_items(encounter)
+        self.set_inpatient_dates()
+
+    def set_diseases(self):
+        """Populate disease child table from encounter's preliminary and final diagnoses."""
+
+        self.diseases = []
+
+        diagnosis_list = (
+            frappe.qb.from_(ct)
+            .join(pe)
+            .on(ct.parent == pe.name)
+            .select(
+                ct.name,
+                ct.parent,
+                ct.code_value,
+                ct.code_value.as_("medical_code"),
+                ct.code.as_("code"),
+                ct.definition,
+                ct.modified,
+                ct.parentfield,
+                pe.practitioner,
+            )
+            .where(
+                (ct.parenttype == "Patient Encounter")
+                & (ct.parent == self.patient_encounter)
+            )
+            .groupby(ct.code_value, ct.parentfield)
+            .orderby(ct.parentfield, order=frappe.qb.desc)
+        ).run(as_dict=True)
+
+        for row in diagnosis_list:
+            new_row = self.append("diseases", {})
+            if row.parentfield == "patient_encounter_preliminary_diagnosis":
+                new_row.status = "Provisional"
+            elif row.parentfield == "patient_encounter_final_diagnosis":
+                new_row.status = "Final"
+
+            new_row.patient_encounter = row.parent
+            new_row.codification_table = row.name
+            new_row.medical_code = row.code_value
+
+            # Convert ICD code format (CDC to NHIF style)
+            if row.code and len(row.code) > 3 and "." not in row.code:
+                new_row.disease_code = row.code[:3] + "." + (row.code[3:4] or "0")
+            elif row.code and len(row.code) <= 5 and "." in row.code:
+                new_row.disease_code = row.code
+            else:
+                new_row.disease_code = row.code[:3] if row.code else ""
+
+            new_row.description = (row.definition or "")[:139]
+            new_row.created_by = row.practitioner
+            new_row.date_created = row.modified
+
+    def set_items(self, encounter_doc):
+        """Populate item child table from encounter's service items."""
+
+        self.items = []
+
+        total_amount = 0
+        for child in get_childs_map():
+            if not encounter_doc.get(child.get("table")):
+                continue
+
+            for row in encounter_doc.get(child.get("table")):
+                if not row.get(child.get("item")):
+                    continue
+
+                # Skip cancelled/prescribed/restricted items
+                if (
+                    row.get("prescribe")
+                    or row.get("is_not_available_inhouse")
+                    or row.get("is_cancelled")
+                    or row.get("is_restricted")
+                ):
+                    continue
+
+                ref_code = get_item_refcode(
+                    child.get("doctype"),
+                    row.get(child.get("item")),
+                    encounter_doc.company,
+                    encounter_doc.insurance_company,
+                )
+
+                item_code = frappe.get_cached_value(
+                    child.get("doctype"),
+                    row.get(child.get("item")),
+                    "item",
+                )
+                if not item_code:
+                    continue
+
+                item_rate = get_item_rate(
+                    item_code,
+                    encounter_doc.company,
+                    encounter_doc.insurance_subscription,
+                    encounter_doc.insurance_company,
+                )
+
+                quantity = row.get("quantity") or 1
+                amount = item_rate * quantity
+
+                new_row = self.append("items", {})
+                new_row.item_name = row.get(child.get("item"))
+                new_row.item_code = str(ref_code) if ref_code else ""
+                new_row.item_quantity = quantity
+                new_row.unit_price = item_rate
+                new_row.amount_claimed = amount
+                new_row.ref_doctype = row.get("doctype")
+                new_row.ref_docname = row.get("name")
+                new_row.patient_encounter = encounter_doc.name
+                new_row.created_by = get_fullname(frappe.session.user)
+                new_row.date_created = nowdate()
+
+                total_amount += amount
+
+        self.total_amount = total_amount
+
+    def set_inpatient_dates(self):
+        """Set admitted/discharged dates from the encounter's inpatient record."""
+
+        if not self.inpatient_record:
+            return
+
+        (
+            discharge_date,
+            scheduled_date,
+            admitted_datetime,
+            time_created,
+        ) = frappe.get_cached_value(
+            "Inpatient Record",
+            self.inpatient_record,
+            [
+                "discharge_date",
+                "scheduled_date",
+                "admitted_datetime",
+                "creation",
+            ],
+        )
+
+        if not admitted_datetime:
+            return
+
+        if scheduled_date and getdate(scheduled_date) < getdate(admitted_datetime):
+            self.admitted_date = f"{scheduled_date} {get_time(get_datetime(time_created))}"
+        else:
+            self.admitted_date = str(admitted_datetime)
+
+        if discharge_date and getdate(self.admitted_date) == getdate(discharge_date):
+            self.patient_type_code = "OP"
+            self.admitted_date = None
+            self.discharge_date = None
+        elif discharge_date:
+            self.patient_type_code = "IN"
+            self.discharge_date = f"{discharge_date} {nowtime()}"
+
+            # Override claim year/month from discharge date when inpatient
+            d = getdate(discharge_date)
+            self.claim_year = d.year
+            self.claim_month = d.month
+
+    def calculate_totals(self):
+        """Recalculate total_amount from items."""
+        total = 0
+        for row in self.items:
+            row.amount_claimed = (row.unit_price or 0) * (row.item_quantity or 1)
+            total += row.amount_claimed
+
+        self.total_amount = total
+
+
+@frappe.whitelist()
+def create_preauthorization_doc(source_doctype, source_docname, benefit_code):
+    """Create a Jubilee Service Request record and submit it.
+
+    Called automatically from the verify dialog's primary_action button.
+    The doctor stays on the encounter page throughout.
+    On submit, the before_submit hook sends the pre-authorization to Jubilee.
+
+    Args:
+        args: dict with source_doctype, source_docname, benefit_code.
+    """
+
+    if not source_docname:
+        frappe.throw(_("Source document name is required"))
+
+    source_doc = frappe.get_doc(source_doctype, source_docname)
+
+    benefit_name = ""
+    benefit_balance = 0
+    if benefit_code:
+        benefit_name, benefit_balance = frappe.get_cached_value(
+            "Jubilee Benefit",
+            {"appointment": source_doc.appointment, "benefit_code": benefit_code},
+            ["benefit_name", "benefit_balance"],
+        )
+
+    jsr = frappe.get_doc({
+        "doctype": "Jubilee Service Request",
+        "patient_encounter": source_docname,
+        "benefit_code": benefit_code,
+        "benefit_name": benefit_name,
+        "benefit_balance": benefit_balance,
+    })
+    jsr.insert(ignore_permissions=True)
+    jsr.submit()
+    jsr.reload()
+
+    source_doc.add_comment(
+        comment_type="Comment",
+        text=(
+            f"Jubilee Pre-Authorization request sent<br>"
+            f"Service Request: <b>{jsr.name}</b><br>"
+            f"Status: <b>{jsr.preauth_status or 'N/A'}</b><br>"
+            f"Submission ID: <b>{jsr.submission_id or 'N/A'}</b>"
+        ),
+    )
+
+    return {
+        "status": jsr.preauth_status or "ERROR",
+        "submission_id": jsr.submission_id or "",
+        "description": jsr.preauth_description or "",
+        "service_request": jsr.name,
+    }
+
+

--- a/hms_tz/jubilee/doctype/jubilee_service_request/test_jubilee_service_request.py
+++ b/hms_tz/jubilee/doctype/jubilee_service_request/test_jubilee_service_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Aakvatech and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestJubileeServiceRequest(FrappeTestCase):
+	pass


### PR DESCRIPTION
Introduce a new submittable DocType "Jubilee Service Request" (JSR) to manage the complete lifecycle of Jubilee Insurance pre-authorization requests. This replaces the previous ad-hoc flow and centralizes all pre-authorization logic within a structured, auditable document.

DocType schema (jubilee_service_request.json):
- Naming series: JSR-.YYYY.-.####
- is_submittable: True, triggers before_submit hook on document submission
- Tab layout: Main info / Patient Details / Diseases / Items
- Header fields:
  - patient_encounter (Link, required), source encounter
  - appointment, patient, patient_name, company (fetched/read-only)
  - posting_date, posting_time, patient_type_code (OP/IN)
  - inpatient_record (Link, read-only), for admitted/discharged logic
- Service section:
  - jubilee_procedure (Link to Jubilee Procedure)
  - jubilee_benefit, benefit_code, benefit_name, benefit_balance
  - practitioner_no (MCT Code), provider_id, total_amount
- Patient Details tab (auto-populated):
  - first_name, last_name, gender, date_of_birth
  - card_no, authorization_no, telephone_no, attendance_date
  - claim_month, claim_year, bill_no
  - admitted_date, discharge_date
- Diseases tab: child table (Jubilee Service Request Disease)
- Items tab: child table (Jubilee Service Request Item)
- Pre-Authorization Response section (collapsible):
  - submission_id, preauth_status, preauth_description
- Permissions: System Manager (full), Healthcare Administrator (no delete), Physician (create/read/write/share/print)

Controller (jubilee_service_request.py):
- before_save: calls set_missing_values() to auto-populate all fields from the linked Patient Encounter and associated records
- before_submit: calls send_preauthorization() and sets preauth_status, preauth_description, submission_id on self so that Frappe final submit save includes the API response values (avoids the frappe.db.set_value overwrite issue)
- set_missing_values(): orchestrates population of patient demographics, card_no, authorization_no, attendance_date, practitioner_no, provider_id, claim_year, claim_month, bill_no, diseases, items, and inpatient dates
- set_diseases(): queries Codification Table joined to Patient Encounter to populate preliminary (Provisional) and final (Final) diagnoses; converts ICD code to Jubilee-compatible dotted notation
- set_items(): iterates all encounter child tables via get_childs_map(), skips prescribed/cancelled/restricted/unavailable items, resolves ref_code (Jubilee item code), unit_price, and amount_claimed per item
- set_inpatient_dates(): derives admitted_date and discharge_date from Inpatient Record; sets patient_type_code to IN/OP accordingly; overrides claim_year/claim_month from discharge_date for inpatients
- calculate_totals(): helper to recalculate total_amount from items child table

create_preauthorization_doc() whitelisted function:
- Called from patient_encounter.js when doctor clicks "Request Pre-Authorization"
- Looks up Jubilee Benefit for benefit_name/benefit_balance
- Creates and immediately submits a JSR document, triggering before_submit which calls the Jubilee SendPreauthorization API
- Calls jsr.reload() to sync in-memory object with DB values written during submit
- Adds a comment on the source encounter with the result
- Returns status, submission_id, description, service_request to JS for display

Client script (jubilee_service_request.js):
- On refresh: displays a colored dashboard headline indicator
  - Green: Pre-Authorization Submitted Successfully, Submission ID shown
  - Red: Pre-Authorization Failed with preauth_description shown