### PR TITLE
refactor(jubilee): enforce one-JSR-per-encounter in create_preauthorization_doc

### DIFF
--- a/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.py
+++ b/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.py
@@ -255,20 +255,19 @@ class JubileeServiceRequest(Document):
 
 @frappe.whitelist()
 def create_preauthorization_doc(source_doctype, source_docname, benefit_code):
-    """Create a Jubilee Service Request record and submit it.
-
-    Called automatically from the verify dialog's primary_action button.
-    The doctor stays on the encounter page throughout.
-    On submit, the before_submit hook sends the pre-authorization to Jubilee.
-
-    Args:
-        args: dict with source_doctype, source_docname, benefit_code.
-    """
+    """Create or reuse a Jubilee Service Request record and submit it."""
 
     if not source_docname:
         frappe.throw(_("Source document name is required"))
 
     source_doc = frappe.get_doc(source_doctype, source_docname)
+
+    existing_jsr = frappe.db.get_value(
+        "Jubilee Service Request",
+        {"patient_encounter": source_docname},
+        ["name", "docstatus"],
+        as_dict=True,
+    )
 
     benefit_name = ""
     benefit_balance = 0
@@ -277,18 +276,32 @@ def create_preauthorization_doc(source_doctype, source_docname, benefit_code):
             "Jubilee Benefit",
             {"appointment": source_doc.appointment, "benefit_code": benefit_code},
             ["benefit_name", "benefit_balance"],
-        )
+        ) or ("", 0)
 
-    jsr = frappe.get_doc({
-        "doctype": "Jubilee Service Request",
-        "patient_encounter": source_docname,
-        "benefit_code": benefit_code,
-        "benefit_name": benefit_name,
-        "benefit_balance": benefit_balance,
-    })
-    jsr.insert(ignore_permissions=True)
+    if existing_jsr:
+        jsr = frappe.get_doc("Jubilee Service Request", existing_jsr.name)
+
+        if existing_jsr.docstatus == 1:
+            return {
+                "status": jsr.preauth_status or "ERROR",
+                "submission_id": jsr.submission_id or "",
+                "description": jsr.preauth_description or "",
+                "service_request": jsr.name,
+            }
+
+        jsr.benefit_code = benefit_code
+        jsr.benefit_name = benefit_name
+        jsr.benefit_balance = benefit_balance
+        jsr.save(ignore_permissions=True)
+    else:
+        jsr = frappe.new_doc("Jubilee Service Request")
+        jsr.patient_encounter = source_docname
+        jsr.benefit_code = benefit_code
+        jsr.benefit_name = benefit_name
+        jsr.benefit_balance = benefit_balance
+        jsr.save(ignore_permissions=True)
+
     jsr.submit()
-    jsr.reload()
 
     source_doc.add_comment(
         comment_type="Comment",
@@ -306,5 +319,3 @@ def create_preauthorization_doc(source_doctype, source_docname, benefit_code):
         "description": jsr.preauth_description or "",
         "service_request": jsr.name,
     }
-
-


### PR DESCRIPTION
Prevent duplicate Jubilee Service Request documents from being created when a doctor clicks "Request Pre-Authorization" more than once for the same Patient Encounter. Previously, each call unconditionally inserted a new JSR; now the function checks for an existing one first.

create_preauthorization_doc() logic:
- Resolves benefit_name and benefit_balance upfront (before the existence check) so the values are available regardless of which branch is taken
- Queries Jubilee Service Request filtered by patient_encounter to find an existing document (latest by creation date), returning name + docstatus
- Three-branch execution:
  1. Submitted JSR exists (docstatus == 1): Return the stored preauth_status, submission_id, and preauth_description immediately without re-calling the Jubilee API
  2. Draft JSR exists (docstatus == 0): Update benefit_code, benefit_name, benefit_balance on the existing draft and call save(); the before_save hook (set_missing_values) re-populates all encounter-derived fields with the latest encounter data before submit
  3. No JSR found: Create via frappe.new_doc(), set patient_encounter and benefit fields, then call save() to trigger before_save population before submit
- Removed redundant jsr.reload() after submit; the before_submit hook already writes preauth_status/submission_id/preauth_description onto self before Frappe final document save, so the in-memory jsr object is already current
- Switched new-document path from frappe.get_doc + insert to frappe.new_doc + attribute assignment + save for consistency with the draft-reuse path and to ensure before_save fires in both cases