### PR TITLE
feat(jubilee): add get_preauthorization_status endpoint and Check Status button

### DIFF
--- a/hms_tz/jubilee/api/api.py
+++ b/hms_tz/jubilee/api/api.py
@@ -792,3 +792,103 @@ def send_preauthorization(service_request_name):
         result["description"] = str(error_text)
 
     return result
+
+
+@frappe.whitelist()
+def get_preauthorization_status(service_request_name):
+    """Fetch the status of a previously submitted pre-authorization request from Jubilee.
+
+    Calls GET /jubileeapi/getPreauthorizationStatus?submissionID=<id>
+
+    Args:
+        service_request_name: Name of the Jubilee Service Request document.
+            Its submission_id field is used as the submissionID query parameter.
+
+    Returns:
+        dict: {
+            "status": "OK" | "ERROR",
+            "description": <dict with full details on OK, or error string on ERROR>,
+            "service_request": <jsr.name>,
+        }
+    """
+    jsr = frappe.get_doc("Jubilee Service Request", service_request_name)
+
+    if not jsr.submission_id:
+        frappe.throw(
+            _(
+                "Cannot check status: this Service Request has no Submission ID. "
+                "Please send the pre-authorization first."
+            )
+        )
+
+    setting_doc = frappe.get_cached_doc("HMS TZ Setting", jsr.company)
+    if not setting_doc.enable_jubilee_api:
+        frappe.throw(_("Jubilee API is not enabled for this company"))
+
+    token = setting_doc.get_jubilee_token()
+    url = f"{setting_doc.jubilee_url}/jubileeapi/getPreauthorizationStatus"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    params = {"submissionID": jsr.submission_id}
+
+    result = {"status": "ERROR", "description": "", "service_request": jsr.name}
+    r = None
+
+    try:
+        r = requests.get(url, headers=headers, params=params, timeout=60)
+        data = json.loads(r.text) if r.text else {}
+
+        add_jubilee_log(
+            request_type="getPreauthorizationStatus",
+            request_url=url,
+            request_header=headers,
+            request_body=str(params),
+            response_data=data,
+            status_code=r.status_code,
+            company=jsr.company,
+            ref_doctype="Jubilee Service Request",
+            ref_docname=jsr.name,
+            card_no=jsr.card_no,
+        )
+
+        status = data.get("Status") or data.get("status") or "ERROR"
+        description = data.get("Description") or data.get("description") or ""
+
+        if status == "ERROR":
+            frappe.throw(_(description))
+        else:
+            preauth_status = description.get("PreauthorizationStatus") or ""
+            preauth_description = description.get("details") or ""
+            frappe.db.set_value(
+                "Jubilee Service Request",
+                jsr.name,
+                {
+                    "preauth_status": preauth_status,
+                    "preauth_description": preauth_description,
+                },
+            )
+
+        result.update({"status": status, "description": preauth_description or preauth_status })
+
+    except Exception:
+        error_text = r.text if r and r.text else "NO RESPONSE — Timeout or connection error"
+        error_status = r.status_code if r else "NO STATUS CODE"
+
+        add_jubilee_log(
+            request_type="getPreauthorizationStatus",
+            request_url=url,
+            request_header=headers,
+            request_body=str(params),
+            response_data=error_text,
+            status_code=error_status,
+            company=jsr.company,
+            ref_doctype="Jubilee Service Request",
+            ref_docname=jsr.name,
+            card_no=jsr.card_no,
+        )
+
+        result["description"] = str(error_text)
+
+    return result

--- a/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.js
+++ b/hms_tz/jubilee/doctype/jubilee_service_request/jubilee_service_request.js
@@ -23,5 +23,57 @@ frappe.ui.form.on("Jubilee Service Request", {
         )
       );
     }
+
+    frm.trigger("get_preauth_status");
+  },
+
+  get_preauth_status: (frm) => {
+    if (
+      frm.doc.submission_id &&
+      frm.doc.docstatus == 1 &&
+      (!frm.doc.preauth_status || frm.doc.preauth_status != "ERROR")
+    ) {
+      frm.add_custom_button(__("Get Pre-Auth Status"), () => {
+        frappe.call({
+          method: "hms_tz.jubilee.api.api.get_preauthorization_status",
+          args: {
+            service_request_name: frm.doc.name,
+          },
+          freeze: true,
+          freeze_message: __("Checking Pre-Auth Status..."),
+          callback: function (r) {
+            if (r.message) {
+              let data = r.message;
+
+              if (data.status != "ERROR") {
+                frappe.utils.play_sound("success");
+                frappe.show_alert({
+                  message: __(`${data.description}`),
+                });
+
+                frm.reload_doc();
+              } else {
+                frappe.utils.play_sound("error");
+                frappe.msgprint({
+                  title: __("Pre-Authorization Error"),
+                  indicator: "red",
+                  message: __(`${data.description}`),
+                });
+              }
+            }
+          },
+          onerror: function () {
+            frappe.utils.play_sound("error");
+            frappe.msgprint({
+              title: __("Pre-Authorization Error"),
+              indicator: "red",
+              message: __(
+                "An unexpected error occurred while fetching the pre-authorization status."
+              ),
+            });
+          },
+        });
+      });
+    }
   },
 });


### PR DESCRIPTION
Implement Jubilee API endpoint 11 (getPreauthorizationStatus) in the backend and expose a "Get Pre-Auth Status" button on the Jubilee Service Request form to allow practitioners to check the outcome of a previously submitted pre-authorization without leaving the document.

api.py — get_preauthorization_status() new whitelisted function:
- Accepts service_request_name, loads the JSR document
- Validates that submission_id is set (throws if missing)
- Validates that the Jubilee API is enabled for the company
- Sends GET /jubileeapi/getPreauthorizationStatus?submissionID=<id> with Bearer token authorization
- On success response (status != "ERROR"):
  - Extracts preauth_status from description.preathorizationStatus
  - Extracts preauth_description from description.details
  - Persists both values to the JSR document via frappe.db.set_value so the form reflects the latest status from Jubilee
  - Returns {status, description} to the caller
- On API error response (status == "ERROR"):
  - Throws the error description directly so the JS onerror/msgprint handler can display the Jubilee error message to the user
- On exception (timeout, connection error):
  - Captures raw response text or fallback message
  - Logs via add_jubilee_log with ref_doctype/ref_docname for auditability
  - Returns {status: "ERROR", description: <error_text>}

jubilee_service_request.js — form enhancements:
- refresh: now triggers the get_preauth_status event after rendering the dashboard headline indicator so the button is always re-evaluated on every form load
- get_preauth_status new event handler:
  - Adds a "Get Pre-Auth Status" custom button when the JSR is submitted (docstatus == 1), has a submission_id, and is not already in ERROR state
  - Button click calls get_preauthorization_status via frappe.call with freeze: true and freeze_message "Checking Pre-Auth Status..." to block the screen while waiting for the Jubilee API response
  - On success: plays success sound, shows frappe.show_alert with the preauth description, then calls frm.reload_doc() to display the newly persisted status on the document
  - On error: plays error sound, shows red frappe.msgprint with the error description from Jubilee
  - onerror: shows a generic error msgprint for unexpected JS/network failures
- Prettier reformatting of existing string concatenation in refresh handler (no functional change)

Bug fixes applied before staging:
- Fixed frappe.call method path from hms_tz.hms_tz.jubilee.api.api to hms_tz.jubilee.api.api (wrong double-prefix)
- Fixed args key from jsr_name to service_request_name to match the Python function signature