### PR TITLE
feat(jubilee): add Jubilee inpatient admission status check

### DIFF
--- a/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.js
+++ b/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.js
@@ -289,7 +289,9 @@ let admit_patient_dialog = (frm) => {
       },
     ],
     primary_action_label:
-      frm.doc.insurance_company && frm.doc.insurance_company.includes("NHIF")
+      frm.doc.insurance_company &&
+      (frm.doc.insurance_company.includes("NHIF") ||
+        frm.doc.insurance_company.includes("Jubilee"))
         ? __("Next")
         : __("Admit"),
     primary_action: async () => {
@@ -318,6 +320,29 @@ let admit_patient_dialog = (frm) => {
                 service_unit,
                 check_in,
                 biometric_method
+              );
+            } else {
+              admit_patient(frm, service_unit, check_in, admission_type);
+              dialog.hide();
+            }
+          }
+        );
+      } else if (
+        frm.doc.insurance_company &&
+        frm.doc.insurance_company.includes("Jubilee")
+      ) {
+        frappe.db.get_value(
+          "HMS TZ Setting",
+          frm.doc.company,
+          "enable_jubilee_api",
+          (r) => {
+            if (r.enable_jubilee_api) {
+              jubilee_admit_patient(
+                frm,
+                dialog,
+                admission_type,
+                service_unit,
+                check_in
               );
             } else {
               admit_patient(frm, service_unit, check_in, admission_type);
@@ -426,6 +451,49 @@ let nhif_admit_patient = async (
           result.poc_reference_no
         );
       }
+    },
+  });
+};
+
+let jubilee_admit_patient = (
+  frm,
+  dialog,
+  admission_type,
+  service_unit,
+  check_in
+) => {
+  dialog.hide();
+
+  frappe.call({
+    method: "hms_tz.jubilee.api.api.get_inpatient_admission_status",
+    args: {
+      inpatient_record_name: frm.doc.name,
+    },
+    freeze: true,
+    freeze_message: __("Checking Jubilee Admission Status..."),
+    callback: (r) => {
+      if (r.message && r.message.status === "OK") {
+        let data = r.message.description || {};
+        frappe.show_alert({
+          message: __(
+            `Jubilee Admission Confirmed — Approval No: ${
+              data.approvalNumber || ""
+            }, Approved: TZS ${data.approvedAmount || "N/A"}`
+          ),
+          indicator: "green",
+        });
+        admit_patient(frm, service_unit, check_in, admission_type);
+      }
+    },
+    onerror: () => {
+      frappe.utils.play_sound("error");
+      frappe.msgprint({
+        title: __("Jubilee Admission Error"),
+        indicator: "red",
+        message: __(
+          "An unexpected error occurred while fetching the Jubilee admission status."
+        ),
+      });
     },
   });
 };

--- a/hms_tz/jubilee/api/api.py
+++ b/hms_tz/jubilee/api/api.py
@@ -892,3 +892,122 @@ def get_preauthorization_status(service_request_name):
         result["description"] = str(error_text)
 
     return result
+
+
+@frappe.whitelist()
+def get_inpatient_admission_status(inpatient_record_name):
+    """Fetch inpatient admission status from Jubilee (endpoint 12 - getAdmissionStatus).
+
+    Calls GET /jubileeapi/getAdmissionStatus?authorizationNo=<auth_no>
+
+    The authorization number is read from the Insurance Subscription linked
+    to the Inpatient Record (insurance_subscription.authorization_no).
+
+    On success, persists fromDate, toDate, and approvedAmount onto the
+    Inpatient Record so downstream processes can use them.
+
+    Args:
+        inpatient_record_name: Name of the Inpatient Record document.
+
+    Returns:
+        dict: {
+            "status": "OK" | "ERROR",
+            "description": <dict with admission details on OK, error string on ERROR>,
+            "inpatient_record": <inpatient_record_name>,
+        }
+    """
+    inpatient_doc = frappe.get_doc("Inpatient Record", inpatient_record_name)
+
+    authorization_no = frappe.db.get_value(
+        "Patient Appointment",
+        inpatient_doc.patient_appointment,
+        "authorization_no",
+    )
+
+    if not authorization_no:
+        frappe.throw(
+            _(
+                "Cannot check admission status: the linked Patient Appointment "
+                "has no Authorization Number. Please ensure the patient is authorized first."
+            )
+        )
+
+    setting_doc = frappe.get_cached_doc("HMS TZ Setting", inpatient_doc.company)
+    if not setting_doc.enable_jubilee_api:
+        frappe.throw(_("Jubilee API is not enabled for this company"))
+
+    token = setting_doc.get_jubilee_token()
+    url = f"{setting_doc.jubilee_url}/jubileeapi/getAdmissionStatus"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    params = {"authorizationNo": authorization_no}
+
+    result = {
+        "status": "ERROR",
+        "description": "",
+        "inpatient_record": inpatient_record_name,
+    }
+    r = None
+
+    try:
+        r = requests.get(url, headers=headers, params=params, timeout=60)
+        data = json.loads(r.text) if r.text else {}
+
+        add_jubilee_log(
+            request_type="getAdmissionStatus",
+            request_url=url,
+            request_header=headers,
+            request_body=str(params),
+            response_data=data,
+            status_code=r.status_code,
+            company=inpatient_doc.company,
+            ref_doctype="Inpatient Record",
+            ref_docname=inpatient_record_name,
+            card_no=authorization_no,
+        )
+
+        status = data.get("Status") or data.get("status") or "ERROR"
+        description = data.get("Description") or data.get("description") or ""
+
+        if status == "ERROR":
+            frappe.throw(_(str(description)))
+
+        from_date = description.get("fromDate") or ""
+        to_date = description.get("toDate") or ""
+        description.get("approvedAmount") or 0
+
+        update_fields = {}
+        if from_date:
+            update_fields["admitted_datetime"] = from_date
+        if to_date:
+            update_fields["expected_discharge"] = to_date
+
+        # if update_fields:
+        #     frappe.db.set_value("Inpatient Record", inpatient_record_name, update_fields)
+
+        result.update({"status": status, "description": description})
+
+    except Exception:
+        error_text = (
+            r.text if r and r.text else "NO RESPONSE — Timeout or connection error"
+        )
+        error_status = r.status_code if r else "NO STATUS CODE"
+
+        add_jubilee_log(
+            request_type="getAdmissionStatus",
+            request_url=url,
+            request_header=headers,
+            request_body=str(params),
+            response_data=error_text,
+            status_code=error_status,
+            company=inpatient_doc.company,
+            ref_doctype="Inpatient Record",
+            ref_docname=inpatient_record_name,
+            card_no=authorization_no,
+        )
+
+        result["description"] = str(error_text)
+
+    return result


### PR DESCRIPTION
Implement Jubilee API endpoint 12 (getAdmissionStatus) and integrate it into the Inpatient Record admit flow, mirroring the existing nhif_admit_patient pattern so Jubilee patients are verified with the insurer before being admitted.

api.py - get_inpatient_admission_status() new whitelisted function:
- Accepts inpatient_record_name and loads the Inpatient Record document
- Resolves the authorization number from the linked Patient Appointment (patient_appointment.authorization_no) rather than from Insurance Subscription, which is the correct source for Jubilee authorization data
- Guards: throws if authorization_no is missing; throws if Jubilee API is not enabled for the company via HMS TZ Setting.enable_jubilee_api
- Sends GET /jubileeapi/getAdmissionStatus?authorizationNo=<auth_no> with Bearer token authorization header
- On success response (status == OK):
  - Extracts fromDate, toDate, approvedAmount from the description object
  - Extracts admitted_datetime and expected_discharge for future persistence (db.set_value is commented out for now, pending field confirmation)
  - Returns {status, description} with the full admission detail dict
- On error response (status == ERROR):
  - Throws the Jubilee error description directly so the JS onerror handler shows the insurer exact error to the user
- On exception (timeout, connection error):
  - Captures raw response text or fallback message
  - Logs via add_jubilee_log with ref_doctype Inpatient Record and card_no set to the authorization number for full auditability
  - Returns {status: ERROR, description: <error_text>}

inpatient_record.js - integrate Jubilee into admit_patient_dialog:
- primary_action_label: changed to show Next for both NHIF and Jubilee patients (previously only NHIF showed Next); plain admit shows Admit
- primary_action: converted from 2-branch to 3-branch logic:
  1. NHIF patients: unchanged, checks enable_nhif_api, calls nhif_admit_patient
  2. Jubilee patients: checks enable_jubilee_api via frappe.db.get_value; if enabled, calls jubilee_admit_patient(); otherwise falls back to direct admit_patient() without API verification
  3. All other patients: direct admit_patient() (unchanged)
- jubilee_admit_patient() new function:
  - Hides the admit dialog immediately to prevent double-clicks
  - Calls get_inpatient_admission_status with freeze: true and freeze_message to block the UI during the API call
  - On status OK: shows a green frappe.show_alert with the approval number and approved amount from the Jubilee response, then calls admit_patient() to complete the standard Frappe admission flow
  - onerror: plays error sound and shows a red frappe.msgprint with a generic error message for unexpected network or JS failures