### PR TITLE
feat(hms_tz): rename NHIF Folio Counter to Insurance Folio Counter

### DIFF
--- a/hms_tz/hms_tz/doctype/insurance_folio_counter/__init__.py
+++ b/hms_tz/hms_tz/doctype/insurance_folio_counter/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt

--- a/hms_tz/hms_tz/doctype/insurance_folio_counter/insurance_folio_counter.js
+++ b/hms_tz/hms_tz/doctype/insurance_folio_counter/insurance_folio_counter.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, Aakvatech and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Insurance Folio Counter", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/hms_tz/hms_tz/doctype/insurance_folio_counter/insurance_folio_counter.json
+++ b/hms_tz/hms_tz/doctype/insurance_folio_counter/insurance_folio_counter.json
@@ -1,33 +1,45 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "NHIF-FC-.#####",
+ "autoname": "hash",
  "creation": "2022-11-28 09:02:31.862037",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "insurance_provider",
   "company",
-  "claim_year",
   "folio_no",
   "column_break_4",
-  "posting_date",
-  "claim_month"
+  "claim_month",
+  "claim_year",
+  "posting_date"
  ],
  "fields": [
   {
+   "fieldname": "insurance_provider",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Insurance Provider",
+   "options": "NHIF\nJubilee\nStrategies\nAssembly",
+   "reqd": 1
+  },
+  {
    "fieldname": "company",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Company"
   },
   {
    "fieldname": "claim_year",
    "fieldtype": "Int",
+   "in_list_view": 1,
    "label": "Claim Year"
   },
   {
    "fieldname": "folio_no",
    "fieldtype": "Int",
+   "in_list_view": 1,
    "label": "Folio No"
   },
   {
@@ -42,15 +54,17 @@
   {
    "fieldname": "claim_month",
    "fieldtype": "Int",
+   "in_list_view": 1,
    "label": "Claim Month"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-11-28 10:29:01.447147",
+ "modified": "2026-04-29 07:51:39.294349",
  "modified_by": "Administrator",
- "module": "NHIF",
- "name": "NHIF Folio Counter",
+ "module": "Hms Tz",
+ "name": "Insurance Folio Counter",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -66,7 +80,9 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/hms_tz/hms_tz/doctype/insurance_folio_counter/insurance_folio_counter.py
+++ b/hms_tz/hms_tz/doctype/insurance_folio_counter/insurance_folio_counter.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+from frappe.utils import cint, now_datetime
+
+
+class InsuranceFolioCounter(Document):
+    pass
+
+
+def get_or_create_folio_counter(doc, insurance_provider: str) -> int:
+    """Get the next folio number for an insurance claim.
+
+    Queries Insurance Folio Counter filtered by company, claim_year,
+    claim_month, and insurance_provider. Creates a new counter record
+    if none exists, otherwise increments the existing one using
+    frappe.db.set_value to avoid race conditions from a full doc save.
+
+    Args:
+        doc: The parent claim document (must have company, claim_year,
+             claim_month attributes).
+        insurance_provider: One of 'NHIF', 'Jubilee', 'Strategies',
+                            'Assembly'.
+
+    Returns:
+        int: The next folio number to assign to the claim.
+    """
+    folio_counter = frappe.db.get_all(
+        "Insurance Folio Counter",
+        filters={
+            "company": doc.company,
+            "claim_year": doc.claim_year,
+            "claim_month": doc.claim_month,
+            "insurance_provider": insurance_provider,
+        },
+        fields=["name", "folio_no"],
+        page_length=1,
+    )
+
+    folio_no = 1
+    if not folio_counter:
+        frappe.get_doc(
+            {
+                "doctype": "Insurance Folio Counter",
+                "company": doc.company,
+                "claim_year": doc.claim_year,
+                "claim_month": doc.claim_month,
+                "posting_date": now_datetime(),
+                "insurance_provider": insurance_provider,
+                "folio_no": folio_no,
+            }
+        ).insert(ignore_permissions=True)
+    else:
+        folio_no = cint(folio_counter[0].folio_no) + 1
+        frappe.db.set_value(
+            "Insurance Folio Counter",
+            folio_counter[0].name,
+            {
+                "folio_no": folio_no,
+                "posting_date": now_datetime(),
+            },
+        )
+
+    return folio_no

--- a/hms_tz/hms_tz/doctype/insurance_folio_counter/test_insurance_folio_counter.py
+++ b/hms_tz/hms_tz/doctype/insurance_folio_counter/test_insurance_folio_counter.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestInsuranceFolioCounter(FrappeTestCase):
+    pass

--- a/hms_tz/jubilee/doctype/jubilee_patient_claim/jubilee_patient_claim.py
+++ b/hms_tz/jubilee/doctype/jubilee_patient_claim/jubilee_patient_claim.py
@@ -28,6 +28,7 @@ from frappe.utils import (
 from frappe.utils.pdf import get_pdf
 from PyPDF2 import PdfFileWriter
 
+from hms_tz.hms_tz.doctype.insurance_folio_counter.insurance_folio_counter import get_or_create_folio_counter
 from hms_tz.jubilee.doctype.jubilee_response_log.jubilee_response_log import add_jubilee_log
 from hms_tz.nhif.api.healthcare_utils import get_approval_number_from_LRPMT, to_base64
 
@@ -56,40 +57,7 @@ class JubileePatientClaim(Document):
         self.validate_multiple_appointments_per_authorization_no("before_insert")
 
     def after_insert(self):
-        folio_counter = frappe.db.get_all(
-            "Insurance Folio Counter",
-            filters={
-                "company": self.company,
-                "claim_year": self.claim_year,
-                "claim_month": self.claim_month,
-                "insurance_provider": "Jubilee"
-            },
-            fields=["name", "folio_no"],
-            page_length=1,
-        )
-
-        folio_no = 1
-        if len(folio_counter) == 0:
-            new_folio_doc = frappe.get_doc(
-                {
-                    "doctype": "Insurance Folio Counter",
-                    "company": self.company,
-                    "claim_year": self.claim_year,
-                    "claim_month": self.claim_month,
-                    "posting_date": now_datetime(),
-                    "insurance_provider": "Jubilee",
-                    "folio_no": folio_no,
-                }
-            ).insert(ignore_permissions=True)
-            new_folio_doc.reload()
-        else:
-            folio_no = cint(folio_counter[0].folio_no) + 1
-            frappe.set_value("Insurance Folio Counter", folio_counter[0].name, {
-                    "folio_no": folio_no,
-                    "posting_date": now_datetime()
-                }
-            )
-        frappe.set_value(self.doctype, self.name, "folio_no", folio_no)
+        self.set_folio_count()
 
         items = []
         for row in self.jubilee_patient_claim_item:
@@ -934,40 +902,8 @@ class JubileePatientClaim(Document):
         if cint(self.folio_no) != 0:
             return
 
-        folio_counter = frappe.db.get_all(
-            "Insurance Folio Counter",
-            filters={
-                "company": self.company,
-                "claim_year": self.claim_year,
-                "claim_month": self.claim_month,
-            },
-            fields=["name"],
-            page_length=1,
-        )
-
-        folio_no = 1
-        if len(folio_counter) == 0:
-            new_folio_doc = frappe.get_doc(
-                {
-                    "doctype": "Insurance Folio Counter",
-                    "company": self.company,
-                    "claim_year": self.claim_year,
-                    "claim_month": self.claim_month,
-                    "posting_date": now_datetime(),
-                    "folio_no": folio_no,
-                }
-            ).insert(ignore_permissions=True)
-            new_folio_doc.reload()
-        else:
-            folio_doc = frappe.get_doc("Insurance Folio Counter", folio_counter[0].name)
-            folio_no = cint(folio_doc.folio_no) + 1
-
-            folio_doc.folio_no += 1
-            folio_doc.posting_date = now_datetime()
-            folio_doc.save(ignore_permissions=True)
-
-        self.folio_no = folio_no
-        self.db_set("folio_no", folio_no)
+        self.folio_no = get_or_create_folio_counter(self, "NHIF")
+        self.db_set("folio_no", self.folio_no)
 
     @frappe.whitelist()
     def send_jubilee_claim(self):
@@ -1225,7 +1161,6 @@ class JubileePatientClaim(Document):
             else:
                 return unique_items
 
-        # claim_doc = frappe.get_doc("Jubilee Patient Claim", self.name)
         self.allow_changes = 1
         self.jubilee_patient_claim_item = reconcile_items(
             self.jubilee_patient_claim_item

--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -18,7 +18,6 @@ from frappe.utils import (
     get_time,
     get_url_to_form,
     getdate,
-    now_datetime,
     nowdate,
     nowtime,
     time_diff_in_seconds,
@@ -26,6 +25,7 @@ from frappe.utils import (
 from frappe.utils.pdf import get_pdf
 from PyPDF2 import PdfFileWriter
 
+from hms_tz.hms_tz.doctype.insurance_folio_counter.insurance_folio_counter import get_or_create_folio_counter
 from hms_tz.nhif.api.healthcare_utils import get_approval_number_from_LRPMT, to_base64
 from hms_tz.nhif.api.patient_encounter import finalized_encounter
 from hms_tz.nhif.doctype.nhif_tracking_claim_change.nhif_tracking_claim_change import track_changes_of_claim_items
@@ -844,40 +844,8 @@ class NHIFPatientClaim(Document):
         if cint(self.folio_no) != 0:
             return
 
-        folio_counter = frappe.db.get_all(
-            "NHIF Folio Counter",
-            filters={
-                "company": self.company,
-                "claim_year": self.claim_year,
-                "claim_month": self.claim_month,
-            },
-            fields=["name"],
-            page_length=1,
-        )
-
-        folio_no = 1
-        if len(folio_counter) == 0:
-            new_folio_doc = frappe.get_doc(
-                {
-                    "doctype": "NHIF Folio Counter",
-                    "company": self.company,
-                    "claim_year": self.claim_year,
-                    "claim_month": self.claim_month,
-                    "posting_date": now_datetime(),
-                    "folio_no": folio_no,
-                }
-            ).insert(ignore_permissions=True)
-            new_folio_doc.reload()
-        else:
-            folio_doc = frappe.get_doc("NHIF Folio Counter", folio_counter[0].name)
-            folio_no = cint(folio_doc.folio_no) + 1
-
-            folio_doc.folio_no += 1
-            folio_doc.posting_date = now_datetime()
-            folio_doc.save(ignore_permissions=True)
-
-        self.folio_no = folio_no
-        self.db_set("folio_no", folio_no)
+        self.folio_no = get_or_create_folio_counter(self, "NHIF")
+        self.db_set("folio_no", self.folio_no)
 
     def validate_reqd_fields(self):
         if not self.main_diagnosis_code:

--- a/hms_tz/patches.txt
+++ b/hms_tz/patches.txt
@@ -1,4 +1,5 @@
 [pre_model_sync]
+hms_tz.patches.rename_nhif_folio_counter_to_insurance_folio_counter
 
 [post_model_sync]
 hms_tz.patches.custom_fields.hms_tz_custom_fields

--- a/hms_tz/patches/rename_nhif_folio_counter_to_insurance_folio_counter.py
+++ b/hms_tz/patches/rename_nhif_folio_counter_to_insurance_folio_counter.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025, Aakvatech and contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+    """PRE-MODEL-SYNC: Rename NHIF Folio Counter → Insurance Folio Counter and backfill records.
+
+    All three steps run before model sync:
+
+    Step A — Rename the DocType (idempotent, guarded by existence check):
+        frappe.rename_doc() handles:
+          - Renaming the row in tabDocType
+          - Renaming the DB table (tabNHIF Folio Counter → tabInsurance Folio Counter)
+          - Updating all Link field values pointing to the old name
+
+    Step B — Add the insurance_provider column manually:
+        Since this patch runs before model sync, the new column from
+        insurance_folio_counter.json does not exist yet. We add it here so
+        the backfill in Step C can succeed immediately.
+        Model sync will later sync the full column definition (label, options,
+        reqd, etc.) — adding a column that already exists is a no-op.
+
+    Step C — Backfill insurance_provider = 'NHIF' on all pre-existing records:
+        Every record that existed before this rename was created by the NHIF
+        integration, so all of them receive insurance_provider = 'NHIF'.
+
+    Idempotent: all steps are guarded so repeated bench migrate is safe.
+    """
+    if frappe.db.exists("DocType", "NHIF Folio Counter"):
+        frappe.rename_doc(
+            "DocType",
+            "NHIF Folio Counter",
+            "Insurance Folio Counter",
+            force=True,
+        )
+        frappe.db.commit()
+
+    if not frappe.db.has_column("Insurance Folio Counter", "insurance_provider"):
+        frappe.db.sql(
+            """
+            ALTER TABLE `tabInsurance Folio Counter`
+            ADD COLUMN `insurance_provider` VARCHAR(140) DEFAULT NULL
+            """
+        )
+        frappe.db.commit()
+
+    frappe.db.sql(
+        """
+        UPDATE `tabInsurance Folio Counter`
+        SET insurance_provider = 'NHIF'
+        WHERE (insurance_provider IS NULL OR insurance_provider = '')
+        """
+    )
+    frappe.db.commit()


### PR DESCRIPTION
Generalized the folio counter infrastructure to support multiple insurance providers beyond NHIF (Jubilee, Strategies, Assembly).

Changes:
- Renamed DocType 'NHIF Folio Counter' → 'Insurance Folio Counter'
  - Moved from NHIF module to HMS TZ module
  - Changed naming_series from 'NHIF-FC-.#####' to hash
  - Added 'insurance_provider' Select field (NHIF, Jubilee, Strategies, Assembly)
  - Deleted nhif_folio_counter.json to prevent model sync conflicts

- Added migration patch (pre_model_sync): patches/rename_nhif_folio_counter_to_insurance_folio_counter.py
  - Step A: frappe.rename_doc() renames the DocType and underlying DB table, preserving all production data
  - Step B: Manually adds insurance_provider column before model sync
  - Step C: Backfills insurance_provider = 'NHIF' on all pre-existing records

- Extracted shared folio counter helper: hms_tz/doctype/insurance_folio_counter/insurance_folio_counter.py
  - get_or_create_folio_counter(doc, insurance_provider) replaces duplicated inline logic in both NHIF and Jubilee claim controllers

- Refactored callers to use the shared helper:
  - nhif_patient_claim.py: set_folio_count() now calls get_or_create_folio_counter(self, 'NHIF')
  - jubilee_patient_claim.py: after_insert() now calls get_or_create_folio_counter(self, 'Jubilee')