### PR TITLE
feat: add consumable items from Consumable Record to billing reports

### DIFF
--- a/hms_tz/hms_tz/report/ipd_billing_report/ipd_billing_report.py
+++ b/hms_tz/hms_tz/report/ipd_billing_report/ipd_billing_report.py
@@ -669,10 +669,22 @@ def get_ipd_consultancy_transactions(filters):
 
 
 def get_consumable_transactions(filters):
-    """Fetch non-invoiced consumable items for cash IPD patients."""
-    ipd_conditions = get_ipd_conditions(filters)
+	"""Fetch non-invoiced consumable items for cash IPD patients."""
 
-    data = frappe.db.sql(
+	conditions = ""
+	if filters.get("patient"):
+		conditions += f"AND cr.patient = '{filters.get('patient')}' "
+
+	if filters.get("appointment_no"):
+		conditions += f"AND cr.appointment = '{filters.get('appointment_no')}' "
+
+	if filters.get("from_date"):
+		conditions += f"AND cr.posting_date >= '{filters.get('from_date')}' "
+
+	if filters.get("to_date"):
+		conditions += f"AND cr.posting_date <= '{filters.get('to_date')}' "
+
+	data = frappe.db.sql(
         f"""
 		SELECT
 			cr.posting_date AS date,
@@ -697,12 +709,13 @@ def get_consumable_transactions(filters):
 		WHERE cr.docstatus = 1
 		AND cr.payment_type = 'Cash'
 		AND ci.invoiced = 0
-		{ipd_conditions}
+		AND ci.is_billable = 1
+		{conditions}
 	""",
         filters,
         as_dict=1,
     )
-    return data
+	return data
 
 
 def get_cash_lrpmt_transaction(filters):

--- a/hms_tz/hms_tz/report/itemized_bill_report/itemized_bill_report.py
+++ b/hms_tz/hms_tz/report/itemized_bill_report/itemized_bill_report.py
@@ -86,6 +86,10 @@ def execute(filters=None):
         if ipd_cons:
             data += ipd_cons
 
+        consumables = get_consumable_transactions(filters)
+        if consumables:
+            data += consumables
+
         data = sorted(data, key=lambda d: (d["category"], d["date"]))
 
         if not data:
@@ -148,6 +152,10 @@ def execute(filters=None):
         )
         if insurance_lrpmt_data:
             data += insurance_lrpmt_data
+
+        consumables = get_consumable_transactions(filters)
+        if consumables:
+            data += consumables
 
         data = sorted(data, key=lambda d: (d["category"], d["date"]))
 
@@ -214,6 +222,10 @@ def execute(filters=None):
         ipd_cons = get_ipd_consultancy_transactions(filters)
         if ipd_cons:
             data += ipd_cons
+
+        consumables = get_consumable_transactions(filters)
+        if consumables:
+            data += consumables
 
         data = sorted(data, key=lambda d: (d["category"], d["date"]))
         if not data:
@@ -582,6 +594,74 @@ def get_ipd_consultancy_transactions(filters):
     data = query.run(as_dict=True)
 
     return data
+
+
+def get_consumable_transactions(filters):
+    """Fetch billable consumable items from Consumable Record for the patient.
+    Works for both OPD and IPD, and for both Cash and Insurance patients.
+    Links through cr.appointment to Patient Appointment, and LEFT JOINs
+    Inpatient Record for admitted/discharge date metadata.
+    """
+    ci = DocType("Consumable Item")
+    cr = DocType("Consumable Record")
+    pa = DocType("Patient Appointment")
+    ipd_rec = DocType("Inpatient Record")
+
+    query = (
+        frappe.qb.from_(ci)
+        .inner_join(cr)
+        .on(ci.parent == cr.name)
+        .inner_join(pa)
+        .on(cr.appointment == pa.name)
+        .left_join(ipd_rec)
+        .on(pa.name == ipd_rec.patient_appointment)
+        .select(
+            cr.posting_date.as_("date"),
+            ValueWrapper("Consumables").as_("category"),
+            ci.item_name.as_("description"),
+            ci.qty_requested.as_("quantity"),
+            ci.rate.as_("rate"),
+            ci.amount.as_("amount"),
+            pa.patient.as_("patient"),
+            pa.patient_name.as_("patient_name"),
+            pa.appointment_type.as_("appointment_type"),
+            pa.insurance_company.as_("insurance_company"),
+            pa.coverage_plan_name.as_("coverage_plan_name"),
+            pa.authorization_number.as_("authorization_number"),
+            pa.coverage_plan_card_number.as_("coverage_plan_card_number"),
+            fn.Date(ipd_rec.admitted_datetime).as_("admitted_date"),
+            ipd_rec.discharge_date.as_("discharge_date"),
+        )
+        .where(
+            (cr.docstatus == 1)
+            & (ci.is_billable == 1)
+        )
+    )
+
+    # Apply filters
+    if filters.get("patient"):
+        query = query.where(cr.patient == filters.patient)
+
+    if filters.get("patient_appointment"):
+        query = query.where(cr.appointment == filters.patient_appointment)
+
+    if filters.get("from_date"):
+        query = query.where(cr.posting_date >= filters.from_date)
+
+    if filters.get("to_date"):
+        query = query.where(cr.posting_date <= filters.to_date)
+
+    # Apply patient type filter
+    if filters.get("patient_type") == "In-Patient":
+        query = query.where(
+            (cr.inpatient_record.isnotnull()) & (cr.inpatient_record != "")
+        )
+    elif filters.get("patient_type") == "Out-Patient":
+        query = query.where(
+            (cr.inpatient_record.isnull()) | (cr.inpatient_record == "")
+        )
+
+    return query.run(as_dict=True)
 
 
 def get_cash_lrpmt_transaction(filters):


### PR DESCRIPTION
- Add get_consumable_transactions to itemized bill report using frappe.qb, fetching billable, non-invoiced items for both Cash and Insurance patients
- Support OPD and IPD scenarios via LEFT JOIN on Inpatient Record and patient_type filtering on cr.inpatient_record
- Include consumables in all three code paths (no filter, Out-Patient, In-Patient)
- Filter by cr.posting_date for date range and cr.appointment for appointment linkage