### PR TITLE
feat: add shift tracking to Nurse Record for shift-based deduplication

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
@@ -26,6 +26,10 @@
   "nurse",
   "nurse_name",
   "amended_from",
+  "column_break_shift",
+  "nurse_shift",
+  "shift_start_time",
+  "shift_end_time",
   "section_break_r45y2",
   "payment_type",
   "insurance_subscription",
@@ -159,6 +163,24 @@
    "options": "Open\nIn Progress\nCompleted",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "column_break_shift",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "shift_type.start_time",
+   "fieldname": "shift_start_time",
+   "fieldtype": "Time",
+   "label": "Shift Start Time",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "shift_type.end_time",
+   "fieldname": "shift_end_time",
+   "fieldtype": "Time",
+   "label": "Shift End Time",
+   "read_only": 1
   },
   {
    "fieldname": "service_unit",
@@ -428,11 +450,21 @@
   {
    "fieldname": "section_break_r45y2",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "nurse_shift",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Nurse Shift",
+   "options": "Shift Type",
+   "reqd": 1,
+   "search_index": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-10 17:35:38.124259",
+ "modified": "2026-05-14 16:38:48.725657",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "Nurse Record",

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -146,7 +146,7 @@ class NursingSchedule(Document):
 
 
 def create_nurse_records_for_admitted_patients():
-    """Background job (every 4 hours): auto-create Nurse Records for admitted patients.
+    """Background job (every 1 hour): auto-create Nurse Records for admitted patients.
 
     Logic:
     1. Get all Nursing Schedule records for today that haven't yet generated
@@ -179,6 +179,9 @@ def create_nurse_records_for_admitted_patients():
             "assign_based_on",
             "room",
             "ward",
+            "shift_type",
+            "shift_start_time",
+            "shift_end_time",
         ],
     )
 
@@ -239,15 +242,15 @@ def create_nurse_records_for_admitted_patients():
             if not matched:
                 continue
 
-            #Check if a record already exists
+            # Check if a record already exists for this nurse + patient + shift
             existing = frappe.db.exists(
                 "Nurse Record",
                 {
                     "patient": ip.patient,
                     "nurse": schedule.nurse,
                     "posting_date": today,
+                    "shift_type": schedule.shift_type,
                     "docstatus": ["!=", 2],
-                    "nurse": schedule.nurse,
                 },
             )
             if existing:
@@ -270,6 +273,9 @@ def create_nurse_records_for_admitted_patients():
                 nr.posting_date = today
                 nr.company = ip.company
                 nr.inpatient_record = ip.name
+                nr.nurse_shift = schedule.shift_type
+                nr.shift_start_time = schedule.shift_start_time
+                nr.shift_end_time = schedule.shift_end_time
 
                 insurance_details = frappe.get_cached_value(
                     "Patient Appointment",


### PR DESCRIPTION
- Add nurse_shift (Link to Shift Type, mandatory), shift_start_time, and shift_end_time fields to Nurse Record DocType
- Fetch shift_start_time and shift_end_time from Shift Type via fetch_from
- Update auto-creation job to include shift_type in duplicate check, allowing the same nurse to have records for different shifts on the same day
- Set shift fields on auto-created Nurse Records from Nursing Schedule data