### PR TITLE
fix: upcoming medication alert dose display, time format, and shift handling

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
@@ -1144,7 +1144,7 @@ function check_upcoming_medications(frm) {
       "hms_tz.hms_tz.doctype.nurse_record.nurse_record.get_upcoming_medications",
     args: {
       nurse: frm.doc.nurse,
-      within_minutes: 420,
+      within_minutes: 100000000,
     },
     callback: (r) => {
       if (r.message && r.message.length > 0) {
@@ -1185,7 +1185,9 @@ function show_medication_alert_banner(frm, medications) {
         frappe.utils.escape_html(med.drug_name || "") +
         "</td>" +
         "<td>" +
-        frappe.utils.escape_html(med.dosage || "") +
+        frappe.utils.escape_html(
+          (med.dosage || "") + (med.dose_uom ? med.dose_uom : "")
+        ) +
         "</td>" +
         "<td>" +
         frappe.utils.escape_html(med.dosage_form || "") +
@@ -1213,7 +1215,7 @@ function show_medication_alert_banner(frm, medications) {
     __("Drug") +
     "</th>" +
     "<th>" +
-    __("Qty") +
+    __("Dose(s)") +
     "</th>" +
     "<th>" +
     __("Dosage Form") +

--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
@@ -608,17 +608,25 @@ def get_upcoming_medications(nurse, within_minutes=60):
                 ["time", ">=", str(current_time)],
                 ["time", "<=", str(cutoff_time)],
             ],
-            fields=["drug_name", "drug", "time", "dosage", "dosage_form"],
+            fields=["drug_name", "drug", "time", "dosage", "dosage_form", "dose_uom"],
         )
 
         for med in upcoming:
+            # Format time as HH:MM (zero-padded)
+            t = med.time
+            if hasattr(t, "strftime"):
+                formatted_time = t.strftime("%H:%M")
+            else:
+                formatted_time = str(t).zfill(8)[:5]
+
             results.append({
                 "patient": nr.patient,
                 "patient_name": nr.patient_name,
                 "drug_name": med.drug_name,
                 "dosage": med.dosage,
+                "dose_uom": med.dose_uom or "",
                 "dosage_form": med.dosage_form or "",
-                "scheduled_time": str(med.time),
+                "scheduled_time": formatted_time,
                 "nurse_record_name": nr.name,
             })
 


### PR DESCRIPTION
- Change column header from 'Qty' to 'Dose(s)' with UOM suffix (e.g. 15ml)
- Fix scheduled time to display zero-padded HH:MM format (01:00 not 1:00:)
- Add dose_uom to IMO Entry fields fetched for upcoming medications
- Filter nurse records by shift_start_time/shift_end_time boundaries to correctly handle overnight shifts spanning two calendar days