### PR TITLE
fix: display Dose(s) with UOM and reduce header-table spacing in medication tables

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
@@ -744,7 +744,7 @@ function render_pending_meds_table(frm, entries) {
     __("Drug") +
     "</th>" +
     "<th>" +
-    __("Qty") +
+    __("Dose(s)") +
     "</th>" +
     "<th>" +
     __("Form") +
@@ -788,7 +788,7 @@ function render_pending_meds_table(frm, entries) {
       (e.drug_name || e.drug) +
       "</td>" +
       "<td>" +
-      (e.dosage || "") +
+      ((e.dosage || "") + (e.dose_uom ? " " + e.dose_uom : "")) +
       "</td>" +
       "<td>" +
       (e.dosage_form || "") +
@@ -1076,7 +1076,7 @@ function render_completed_meds_table(frm, entries) {
     __("Drug") +
     "</th>" +
     "<th>" +
-    __("Qty") +
+    __("Dose(s)") +
     "</th>" +
     "<th>" +
     __("Form") +
@@ -1110,7 +1110,7 @@ function render_completed_meds_table(frm, entries) {
       (e.drug_name || e.drug) +
       "</td>" +
       "<td>" +
-      (e.dosage || "") +
+      ((e.dosage || "") + (e.dose_uom ? " " + e.dose_uom : "")) +
       "</td>" +
       "<td>" +
       (e.dosage_form || "") +
@@ -1144,7 +1144,7 @@ function check_upcoming_medications(frm) {
       "hms_tz.hms_tz.doctype.nurse_record.nurse_record.get_upcoming_medications",
     args: {
       nurse: frm.doc.nurse,
-      within_minutes: 100000000,
+      within_minutes: 60,
     },
     callback: (r) => {
       if (r.message && r.message.length > 0) {
@@ -1186,7 +1186,7 @@ function show_medication_alert_banner(frm, medications) {
         "</td>" +
         "<td>" +
         frappe.utils.escape_html(
-          (med.dosage || "") + (med.dose_uom ? med.dose_uom : "")
+          (med.dosage || "") + (med.dose_uom ? " " + med.dose_uom : "")
         ) +
         "</td>" +
         "<td>" +

--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.json
@@ -48,9 +48,9 @@
   "section_break_fgmh",
   "vital_signs_html",
   "tab_medications",
+  "medication_progress_html",
   "section_break_unscheduled_meds",
   "unscheduled_medications_html",
-  "medication_progress_html",
   "section_break_pending_meds",
   "pending_medications_html",
   "section_break_completed_meds",
@@ -285,8 +285,7 @@
   },
   {
    "fieldname": "pending_medications_html",
-   "fieldtype": "HTML",
-   "label": "Pending Medications"
+   "fieldtype": "HTML"
   },
   {
    "collapsible": 1,
@@ -296,8 +295,7 @@
   },
   {
    "fieldname": "completed_medications_html",
-   "fieldtype": "HTML",
-   "label": "Completed Medications"
+   "fieldtype": "HTML"
   },
   {
    "fieldname": "tab_observations",
@@ -477,7 +475,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-05-14 23:42:17.964741",
+ "modified": "2026-05-15 01:35:40.359315",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "Nurse Record",

--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
@@ -274,7 +274,7 @@ def get_pending_medications(patient, inpatient_record):
             "date": ["<=", today],
         },
         fields=[
-            "name", "drug", "drug_name", "dosage", "dosage_form",
+            "name", "drug", "drug_name", "dosage", "dosage_form", "dose_uom",
             "date", "time", "instructions", "parent",
             "administration_status",
         ],
@@ -459,7 +459,7 @@ def get_completed_medications(patient, inpatient_record):
             "is_completed": 1,
         },
         fields=[
-            "name", "drug", "drug_name", "dosage", "dosage_form",
+            "name", "drug", "drug_name", "dosage", "dosage_form", "dose_uom",
             "date", "time", "parent",
             "administration_status", "administered_time",
             "administered_by", "administration_notes",


### PR DESCRIPTION
- Rename 'Qty' column to 'Dose(s)' in pending, completed, and upcoming tables
- Append dose_uom to dosage values (e.g. '15 ml', '20 unit')
- Add dose_uom to fields fetched in get_pending_medications and get_completed_medications APIs
- Remove duplicate labels from HTML fields in DocType JSON to eliminate extra spacing between section headers and medication tables
- Comment out medication progress summary table
- Fix indentation across nurse_record.js