### PR TITLE
fix: add server-side BMI calculation and SpO2/RBG support for vital signs creation

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
@@ -189,8 +189,10 @@ def get_vital_signs(patient, appointment=None):
             "bp_systolic",
             "bp_diastolic",
             "bp",
+            "oxygen_saturation_spo2",
+            "rbg",
             "weight",
-            "height",
+            "height_in_cm",
             "bmi",
             "vital_signs_note",
         ],
@@ -225,8 +227,10 @@ def create_vital_signs(patient, nurse_record, **kwargs):
         "respiratory_rate",
         "bp_systolic",
         "bp_diastolic",
+        "oxygen_saturation_spo2",
+        "rbg",
         "weight",
-        "height",
+        "height_in_cm",
         "tongue",
         "abdomen",
         "reflexes",
@@ -235,6 +239,16 @@ def create_vital_signs(patient, nurse_record, **kwargs):
     for field in vital_fields:
         if kwargs.get(field):
             vs.set(field, kwargs[field])
+
+    # Convert height_in_cm to height (in meters) and calculate BMI
+    if vs.height_in_cm:
+        vs.height = flt(vs.height_in_cm) / 100.0
+        if flt(vs.weight) and vs.height:
+            vs.bmi = flt(flt(vs.weight) / (vs.height * vs.height), 2)
+
+    # Set BP display string
+    if vs.bp_systolic and vs.bp_diastolic:
+        vs.bp = f"{vs.bp_systolic}/{vs.bp_diastolic} mmHg"
 
     vs.insert(ignore_permissions=True)
     vs.submit()

--- a/hms_tz/nhif/api/clinical_procedure.py
+++ b/hms_tz/nhif/api/clinical_procedure.py
@@ -9,7 +9,7 @@ import json
 import frappe
 from frappe import _
 from frappe.query_builder import DocType
-from frappe.utils import get_fullname, nowdate
+from frappe.utils import flt, get_fullname, nowdate
 
 from hms_tz.hms_tz.doctype.hospital_revenue_entry.hospital_revenue_entry import (
     create_revenue_entry,
@@ -217,13 +217,24 @@ def create_vital_signs_from_cp(clinical_procedure: str, **kwargs) -> str:
     vital_fields = [
         "temperature", "pulse", "respiratory_rate",
         "bp_systolic", "bp_diastolic",
-        "weight", "height",
+        "oxygen_saturation_spo2", "rbg",
+        "weight", "height_in_cm",
         "tongue", "abdomen", "reflexes",
         "vital_signs_note",
     ]
     for field in vital_fields:
         if kwargs.get(field):
             vs.set(field, kwargs[field])
+
+    # Convert height_in_cm to height (in meters) and calculate BMI
+    if vs.height_in_cm:
+        vs.height = flt(vs.height_in_cm) / 100.0
+        if flt(vs.weight) and vs.height:
+            vs.bmi = flt(flt(vs.weight) / (vs.height * vs.height), 2)
+
+    # Set BP display string
+    if vs.bp_systolic and vs.bp_diastolic:
+        vs.bp = f"{vs.bp_systolic}/{vs.bp_diastolic} mmHg"
 
     vs.insert(ignore_permissions=True)
     vs.submit()


### PR DESCRIPTION
- Add oxygen_saturation_spo2 and rbg to vital_fields and get_vital_signs query
- Use height_in_cm instead of height for dialog-based vital sign creation
- Convert height_in_cm to height (meters) server-side for BMI formula
- Calculate BMI server-side since client-side JS does not run on API insert
- Set BP display string (systolic/diastolic mmHg) server-side
- Wrap weight in flt() to prevent TypeError when form sends string values