### PR TITLE
feat: add consumable item group filter to HMS TZ Setting

### DIFF
--- a/hms_tz/hms_tz/doctype/consumable_record/consumable_dialog.js
+++ b/hms_tz/hms_tz/doctype/consumable_record/consumable_dialog.js
@@ -33,6 +33,19 @@ hms_tz.open_consumable_dialog = function (opts) {
     return;
   }
 
+  // Fetch consumable item group setting before opening the dialog
+  frappe.db.get_value(
+    "HMS TZ Setting",
+    { company: opts.company },
+    "consumable_item_group",
+    (r) => {
+      const consumable_item_group = r && r.consumable_item_group;
+      _open_dialog(opts, consumable_item_group);
+    }
+  );
+};
+
+function _open_dialog(opts, consumable_item_group) {
   const is_insurance = opts.payment_type === "Insurance";
 
   const dialog = new frappe.ui.Dialog({
@@ -176,7 +189,11 @@ hms_tz.open_consumable_dialog = function (opts) {
         cannot_add_rows: false,
         in_place_edit: true,
         data: [],
-        fields: _get_item_table_fields(is_insurance, opts.company),
+        fields: _get_item_table_fields(
+          is_insurance,
+          opts.company,
+          consumable_item_group
+        ),
       },
     ],
 
@@ -198,9 +215,14 @@ hms_tz.open_consumable_dialog = function (opts) {
 
   dialog.show();
   return dialog;
-};
+}
 
-function _get_item_table_fields(is_insurance, company) {
+function _get_item_table_fields(is_insurance, company, consumable_item_group) {
+  const item_filters = { is_stock_item: 1, disabled: 0 };
+  if (consumable_item_group) {
+    item_filters.item_group = consumable_item_group;
+  }
+
   const fields = [
     {
       fieldname: "item_code",
@@ -211,7 +233,7 @@ function _get_item_table_fields(is_insurance, company) {
       reqd: 1,
       columns: 2,
       get_query: () => ({
-        filters: { is_stock_item: 1, disabled: 0 },
+        filters: item_filters,
       }),
     },
     {

--- a/hms_tz/hms_tz/doctype/hms_tz_setting/hms_tz_setting.json
+++ b/hms_tz/hms_tz/doctype/hms_tz_setting/hms_tz_setting.json
@@ -46,6 +46,8 @@
   "hms_tz_limit_exceed_action",
   "nursing_conf_section",
   "auto_create_shift_assignment_from_nursing_roster",
+  "column_break_jsba",
+  "consumable_item_group",
   "reporting_section",
   "start_date",
   "nhif_tab",
@@ -680,16 +682,27 @@
    "label": "Auto Create Shift Assignment from Nursing Roster"
   },
   {
+   "description": "If set, only items belonging to this Item Group (and its sub-groups) will be shown in consumable item dialogs across the system",
+   "fieldname": "consumable_item_group",
+   "fieldtype": "Link",
+   "label": "Consumable Item Group",
+   "options": "Item Group"
+  },
+  {
    "default": "0",
    "description": "If ticket, Inpatient Medication Order will be auto created during submission of delivery note for admitted patients",
    "fieldname": "auto_create_imo_from_delivery_note",
    "fieldtype": "Check",
    "label": "Auto Create IMO from Delivery Note"
+  },
+  {
+   "fieldname": "column_break_jsba",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-12 11:07:32.848024",
+ "modified": "2026-05-15 03:05:19.349908",
  "modified_by": "Administrator",
  "module": "Hms Tz",
  "name": "HMS TZ Setting",


### PR DESCRIPTION
- Add 'Consumable Item Group' Link field under Nursing Conf section
- Fetch configured item group from HMS TZ Setting per company before opening consumable dialog
- Apply item_group filter on item_code Link field in consumable items table
- Applies across all modules: Nurse Record, Clinical Procedure, Lab Test, Radiology, Therapy Session, Preoperative Assessment
- Backward compatible: shows all stock items if no group is configured