### PR TITLE
refactor: rename service_unit to room and service_unit_type to ward in Nurse Record

### DIFF
--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.js
@@ -56,7 +56,7 @@ function set_queries(frm) {
       },
     };
   });
-  frm.set_query("service_unit", () => {
+  frm.set_query("room", () => {
     return {
       filters: {
         disabled: 0,
@@ -66,7 +66,7 @@ function set_queries(frm) {
     };
   });
 
-  frm.set_query("service_unit_type", () => {
+  frm.set_query("ward", () => {
     return {
       filters: {
         disabled: 0,

--- a/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
+++ b/hms_tz/hms_tz/doctype/nurse_record/nurse_record.py
@@ -39,7 +39,7 @@ class NurseRecord(Document):
 
         self.set_missing_values()
         self.validate_no_duplicate()
-        self.validate_service_unit_fields()
+        self.validate_room_and_ward_fields()
         self.set_status_on_save()
         self.set_previous_notes()
 
@@ -111,19 +111,18 @@ class NurseRecord(Document):
                 ).format(self.patient, self.nurse, self.posting_date, existing)
             )
 
-    def validate_service_unit_fields(self):
+    def validate_room_and_ward_fields(self):
         """Validate service unit fields.
 
         Rules:
-        - If service_unit is set but service_unit_type is missing: OK
-        - If service_unit_type is set but service_unit is missing: OK
+        - If room is set but ward is missing: OK
+        - If ward is set but room is missing: OK
         - If BOTH are missing: throw validation error
         """
-        if not self.service_unit and not self.service_unit_type:
+        if not self.room and not self.ward:
             frappe.throw(
                 _(
-                    "Please set at least one of Service Unit or Service Unit"
-                    " Type."
+                    "Please set at least one of Room or Ward."
                 )
             )
 

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -156,8 +156,8 @@ def create_nurse_records_for_admitted_patients():
     3. For each admitted patient, get the last service unit from the
        inpatient_occupancies child table.
     4. Match nursing schedules by comparing:
-       - schedule.service_unit == last occupancy service_unit, OR
-       - schedule.service_unit_type == service_unit_type of the last
+       - schedule.room == last occupancy service_unit, OR
+       - schedule.ward == service_unit_type of the last
          occupancy's service unit
     5. Create a Nurse Record for each match if one doesn't already exist.
     6. Mark the Nursing Schedule's nurse_record_created checkbox.
@@ -294,12 +294,12 @@ def create_nurse_records_for_admitted_patients():
                     nr.insurance_coverage_plan = ""
                     nr.insurance_subscription = ""
 
-                nr.service_unit = (
+                nr.room = (
                     last_occupancy
                     if schedule.assign_based_on == "Room"
                     else None
                 )
-                nr.service_unit_type = (
+                nr.ward = (
                     last_su_type
                     if schedule.assign_based_on == "Ward"
                     else None


### PR DESCRIPTION
- Update custom field queries for room and ward in nurse_record.js
- Replace references to service_unit and service_unit_type with room and ward in nurse_record.py
- Rename validate_service_unit_fields to validate_room_and_ward_fields and update error messages
- Update automatic Nurse Record creation logic in nursing_schedule.py to use the new fieldnames (nr.room and nr.ward)