### PR TITLE
fix: fix typo in background job messages and handle null IsNonSpecific in medical code update

### DIFF
--- a/hms_tz/nhif/nhif_api/price_package.py
+++ b/hms_tz/nhif/nhif_api/price_package.py
@@ -56,7 +56,7 @@ def process_nhif_records(company):
         company=company,
         facility_code=facility_code,
     )
-    frappe.msgprint("Processing NHIF prices via backaground job", alert=True)
+    frappe.msgprint("Processing NHIF prices via background job", alert=True)
 
     enqueue(
         method=process_nhif_coverages,
@@ -66,7 +66,7 @@ def process_nhif_records(company):
         company=company,
         facility_code=facility_code,
     )
-    frappe.msgprint("Processing NHIF Coverages via backaground job", alert=True)
+    frappe.msgprint("Processing NHIF Coverages via background job", alert=True)
 
 
 @frappe.whitelist()
@@ -79,7 +79,7 @@ def enqueue_fetch_nhif_items(company):
         is_async=True,
         company=company,
     )
-    frappe.msgprint("Fetch NHIF Items via backaground job", alert=True)
+    frappe.msgprint("Fetch NHIF Items via background job", alert=True)
 
 
 def get_price_package(company):

--- a/hms_tz/nhif/nhif_api/reference.py
+++ b/hms_tz/nhif/nhif_api/reference.py
@@ -17,7 +17,7 @@ def enqueue_get_diseases(company):
         is_async=True,
         company=company,
     )
-    frappe.msgprint("Fetch Diseases via backaground job", alert=True)
+    frappe.msgprint("Fetch Diseases via background job", alert=True)
 
 
 @frappe.whitelist()
@@ -205,13 +205,16 @@ def update_medical_code(disease):
         has_changed = True
         mc_doc.definition = disease.get("DiseaseName")
 
-    if mc_doc.is_non_specific != disease.get("IsNonSpecific"):
+    if (
+        disease.get("IsNonSpecific") and
+        mc_doc.is_non_specific != disease.get("IsNonSpecific")
+    ):
         has_changed = True
         mc_doc.is_non_specific = disease.get("IsNonSpecific")
 
-    if mc_doc.disabled == 1:
-        has_changed = True
-        mc_doc.disabled = 0
+    # if mc_doc.disabled == 1:
+    #     has_changed = True
+    #     mc_doc.disabled = 0
 
     if has_changed:
         mc_doc.save(ignore_permissions=True)


### PR DESCRIPTION
- Fix backaground → background typo in msgprint alerts
- Add null check for IsNonSpecific before comparing with existing value
- Disable auto-enabling of disabled medical codes on sync