### PR TITLE
fix: validate service request return values & rename pre-approval button

### DIFF
--- a/hms_tz/hms_tz/doctype/healthcare_service_request/healthcare_service_request.py
+++ b/hms_tz/hms_tz/doctype/healthcare_service_request/healthcare_service_request.py
@@ -296,11 +296,15 @@ class HealthcareServiceRequest(Document):
 
             if service_type == "Lab Test Template":
                 lab_service = self.get_sorted_service(values)
+                if not lab_service:
+                    continue
                 encounter_child = frappe.get_cached_doc(lab_service.ref_doctype, lab_service.ref_docname)
                 create_individual_lab_test(encounter_doc, encounter_child, lab_service)
 
             elif service_type == "Radiology Examination Template":
                 radiology_service = self.get_sorted_service(values)
+                if not radiology_service:
+                    continue
                 encounter_child = frappe.get_cached_doc(
                     radiology_service.ref_doctype,
                     radiology_service.ref_docname,
@@ -309,6 +313,8 @@ class HealthcareServiceRequest(Document):
 
             elif service_type == "Clinical Procedure Template":
                 procedure_service = self.get_sorted_service(values)
+                if not procedure_service:
+                    continue
                 encounter_child = frappe.get_cached_doc(
                     procedure_service.ref_doctype,
                     procedure_service.ref_docname,
@@ -317,10 +323,14 @@ class HealthcareServiceRequest(Document):
 
             elif service_type == "Medication":
                 medication_service = self.get_sorted_service(values)
+                if not medication_service:
+                    continue
                 medications.append(medication_service)
 
             elif service_type == "Therapy Type":
                 therapy_service = self.get_sorted_service(values)
+                if not therapy_service:
+                    continue
 
                 therapy_map[therapy_service.ref_docname] = therapy_service
 
@@ -361,7 +371,12 @@ class HealthcareServiceRequest(Document):
             service = services[0]
 
         elif len(services) > 1:
-            services = sorted(services, key=sort_key)
+            # remove items with amount 0
+            filtered_services = [d for d in services if d.amount > 0]
+            if len(filtered_services) == 0:
+                return frappe._dict()
+            # sort the services by insurance company
+            services = sorted(filtered_services, key=sort_key)
             service = services[0]
 
         return service

--- a/hms_tz/nhif/api/patient_encounter.js
+++ b/hms_tz/nhif/api/patient_encounter.js
@@ -2459,7 +2459,7 @@ var confirm_poc_btn = (frm) => {
 var verify_services_btn = (frm) => {
   if (!frm.page.fields_dict.verify_services_btn) {
     frm.page.add_field({
-      label: "Verify Services",
+      label: "Get PreApproval",
       fieldname: "verify_services_btn",
       fieldtype: "Button",
       click: async () => {


### PR DESCRIPTION
- Prevent potential runtime errors (ValueError/AttributeError) during healthcare service document creation by validating the returned service from `get_sorted_service` before accessing its attributes or using it in cached doc retrieval.
- Filter out empty `frappe._dict()` objects returned by `get_sorted_service` when payment amounts filter down to 0.
- Rename the page action button from "Verify Services" to "Get PreApproval" in `patient_encounter.js` to match the Jubilee integration workflow.
- Clean up indentation and code formatting in `patient_encounter.js`.